### PR TITLE
Switch to Spoon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+spoon.classpath-app.tmp

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
         </dependency>
 
         <dependency>
+            <groupId>fr.inria.gforge.spoon</groupId>
+            <artifactId>spoon-core</artifactId>
+            <version>7.5.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>

--- a/src/main/java/DocumentIndexer.java
+++ b/src/main/java/DocumentIndexer.java
@@ -1,29 +1,12 @@
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
-import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
-import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-import com.github.javaparser.resolution.declarations.ResolvedClassDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
-import com.github.javaparser.resolution.types.ResolvedType;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.*;
-import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import spoon.reflect.code.*;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.position.NoSourcePosition;
+import spoon.reflect.declaration.*;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtScanner;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,6 +17,7 @@ public class DocumentIndexer {
     private String projectRoot;
     private boolean noContents;
     private String pathname;
+    private CtElement spoonElement;
     private String projectId;
     private Emitter emitter;
     private Map<String, DocumentIndexer> indexers;
@@ -46,6 +30,7 @@ public class DocumentIndexer {
             String projectRoot,
             boolean noContents,
             String pathname,
+            CtElement spoonElement,
             String projectId,
             Emitter emitter,
             Map<String, DocumentIndexer> indexers
@@ -53,6 +38,7 @@ public class DocumentIndexer {
         this.projectRoot = projectRoot;
         this.noContents = noContents;
         this.pathname = pathname;
+        this.spoonElement = spoonElement;
         this.projectId = projectId;
         this.emitter = emitter;
         this.indexers = indexers;
@@ -72,10 +58,6 @@ public class DocumentIndexer {
     }
 
     private void doIndex() {
-        JavaSymbolSolver symbolSolver = getSymbolSolver();
-        StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
-        CompilationUnit cu = parse();
-
         Map<String, Object> args = Map.of(
                 "languageId", "java",
                 "uri", String.format("file://%s", Paths.get(pathname).toAbsolutePath().toString())
@@ -91,7 +73,7 @@ public class DocumentIndexer {
         }
 
         this.documentId = emitter.emitVertex("document", args);
-        cu.accept(new LSIFVisitor(symbolSolver), null);
+        this.spoonElement.accept(new LSIFVisitor());
     }
 
     public void postIndex() {
@@ -101,25 +83,6 @@ public class DocumentIndexer {
 
         emitter.emitEdge("contains", Map.of("outV", projectId, "inVs", new String[]{documentId}));
         emitter.emitEdge("contains", Map.of("outV", documentId, "inVs", rangeIds.stream().sorted().toArray()));
-    }
-
-    private JavaSymbolSolver getSymbolSolver() {
-        return new JavaSymbolSolver(getTypeSolver());
-    }
-
-    private TypeSolver getTypeSolver() {
-        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-        typeSolver.add(new JavaParserTypeSolver(projectRoot));
-        typeSolver.add(new ReflectionTypeSolver());
-        return typeSolver;
-    }
-
-    private CompilationUnit parse() {
-        try {
-            return StaticJavaParser.parse(new File(pathname));
-        } catch (FileNotFoundException ex) {
-            throw new RuntimeException(String.format("Failed to parse %s", pathname));
-        }
     }
 
     private void linkUses(DefinitionMeta meta, String documentId) {
@@ -143,55 +106,100 @@ public class DocumentIndexer {
         }
     }
 
-    private class LSIFVisitor extends VoidVisitorAdapter<Void> {
-        private JavaSymbolSolver symbolSolver;
-
-        public LSIFVisitor(JavaSymbolSolver symbolSolver) {
-            this.symbolSolver = symbolSolver;
-        }
-
+    private class LSIFVisitor extends CtScanner {
         // TODO - field access
         // TODO - types to classes
         // TODO - enums
         // TODO - inner classes?
 
         @Override
-        public void visit(final MethodCallExpr n, final Void arg) {
-            super.visit(n, arg);
-            emitUse(n);
+        public <T> void visitCtParameter(CtParameter<T> a) {
+            emitDefinition(mkRange(a.getPosition()), mkDoc(a.getType(), a.getDocComment()));
         }
 
         @Override
-        public void visit(final VariableDeclarationExpr n, final Void arg) {
-            super.visit(n, arg);
-            emitDefinition(n);
+        public <T> void visitCtVariableRead(CtVariableRead<T> a) {
+            emitUse(mkRange(a.getPosition()), mkRange(a.getVariable().getDeclaration().getPosition()), a.getVariable().getDeclaration().getDocComment(), a.getVariable().getDeclaration().getPosition().getFile().getPath());
         }
 
         @Override
-        public void visit(final MethodDeclaration n, final Void arg) {
-            super.visit(n, arg);
-            emitDefinition(n);
+        public <T> void visitCtMethod(CtMethod<T> a) {
+            super.visitCtMethod(a);
+            emitDefinition(nameRange(a), mkDoc(a.getType(), a.getDocComment()));
         }
 
         @Override
-        public void visit(final NameExpr n, final Void arg) {
-            super.visit(n, arg);
-            emitUse(n);
-        }
-
-        @Override
-        public void visit(final Parameter n, final Void arg) {
-            super.visit(n, arg);
-            emitDefinition(n);
-        }
-
-        private void emitDefinition(Node n) {
-            Optional<Range> rangeContainer = getRange(n);
-            if (!rangeContainer.isPresent()) {
-                throw new RuntimeException("Unexpected range-less AST node: " + n.toString());
+        public <T> void visitCtInvocation(CtInvocation<T> a) {
+            super.visitCtInvocation(a);
+            if (a.getPosition() instanceof NoSourcePosition) {
+                return;
             }
+            if (a.getExecutable() == null || a.getExecutable().getDeclaration() == null) {
+                return;
+            }
+            Range useRange = identifierRange(a, a.getExecutable().getSimpleName());
+            emitUse(
+                    useRange,
+                    nameRange(a.getExecutable().getDeclaration()),
+                    a.getExecutable().getDeclaration().getDocComment(),
+                    a.getExecutable().getDeclaration().getPosition().getFile().getPath()
+            );
+        }
 
-            Range range = rangeContainer.get();
+        @Override
+        public <T> void visitCtField(CtField<T> a) {
+            super.visitCtField(a);
+            emitDefinition(nameRange(a), mkDoc(a.getType(), a.getDocComment()));
+        }
+
+        @Override
+        public <T> void visitCtFieldRead(CtFieldRead<T> a) {
+            super.visitCtFieldRead(a);
+            if (a.getPosition() instanceof NoSourcePosition) {
+                System.out.println("Skipping CtFieldRead (NoSourcePosition) " + a);
+                return;
+            }
+            Range useRange = identifierRange(a, a.getVariable().getSimpleName());
+            CtField decl = a.getVariable().getDeclaration();
+            if (decl == null) {
+                System.out.println("Skipping CtFieldRead (null declaration) " + a);
+                return;
+            }
+            emitUse(
+                    useRange,
+                    nameRange(decl),
+                    decl.getDocComment(),
+                    decl.getPosition().getFile().getPath()
+            );
+        }
+
+        @Override
+        public <T> void visitCtClass(CtClass<T> a) {
+            super.visitCtClass(a);
+            emitDefinition(nameRange(a), a.getDocComment());
+        }
+
+        @Override
+        public <T> void visitCtTypeReference(CtTypeReference<T> a) {
+            super.visitCtTypeReference(a);
+            if (a.getPosition() instanceof NoSourcePosition) {
+                System.out.println("Skipping CtTypeReference (NoSourcePosition) " + a);
+                return;
+            }
+            CtType decl = a.getDeclaration();
+            if (decl == null) {
+                System.out.println("Skipping CtFieldRead (null declaration) " + a);
+                return;
+            }
+            emitUse(
+                    mkRange(a.getPosition()),
+                    nameRange(decl),
+                    decl.getDocComment(),
+                    decl.getPosition().getFile().getPath()
+            );
+        }
+
+        private void emitDefinition(Range range, String doc) {
             if (definitions.containsKey(range)) {
                 return;
             }
@@ -199,8 +207,8 @@ public class DocumentIndexer {
             String hoverId = emitter.emitVertex("hoverResult", Map.of(
                     "result", Map.of(
                             "contents", Map.of(
-                                    "language", "java",
-                                    "value", n.toString()
+                                    "kind", "markdown",
+                                    "value", doc
                             )
                     )
             ));
@@ -214,68 +222,23 @@ public class DocumentIndexer {
             definitions.put(range, new DefinitionMeta(rangeId, resultSetId)); // + contents?
         }
 
-        private void emitUse(Node n) {
-            ResolvedDeclaration definition;
-            try {
-                definition = symbolSolver.resolveDeclaration(n, ResolvedDeclaration.class);
-            } catch (RuntimeException ex) {
-                // ignore
-                return;
-            }
+        private void emitUse(Range use, Range def, String doc, String defPath) {
+            DocumentIndexer indexer = indexers.get(defPath);
 
-            Node definitionNode = getNode(definition);
-            if (definitionNode == null) {
-                return;
-            }
-
-            Optional<String> definitionPathContainer = definitionNode.findCompilationUnit()
-                    .flatMap(cu -> cu.getStorage())
-                    .map(s -> s.getPath().toString());
-
-            if (definitionPathContainer.isPresent() && definitionPathContainer.get().equals(pathname)) {
-                emitDefinition(definitionNode);
+            if (defPath.equals(pathname)) {
+                emitDefinition(def, doc);
             } else {
-                indexers.get(definitionPathContainer.get()).index();
+                indexer.index();
             }
 
-            emitUse(n, definitionNode, definitionPathContainer.orElse(pathname));
-        }
+            System.out.println(pathname + ":" + humanRange(use) + " -> " + defPath + ":" + humanRange(def));
 
-        private Node getNode(ResolvedDeclaration def) {
-            return
-                    JavaParserClassDeclaration.class.isInstance(def) ? JavaParserClassDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserConstructorDeclaration.class.isInstance(def) ? JavaParserConstructorDeclaration.class.cast(def).getWrappedNode()
-//                    : JavaParserEnumConstantDeclaration.class.isInstance(def) ? JavaParserEnumConstantDeclaration.class.cast(def).getWrappedNode()
-//                    : JavaParserEnumDeclaration.class.isInstance(def) ? JavaParserEnumDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserFieldDeclaration.class.isInstance(def) ? JavaParserFieldDeclaration.class.cast(def).getWrappedNode()
-//                    : JavaParserInterfaceDeclaration.class.isInstance(def) ? JavaParserInterfaceDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserMethodDeclaration.class.isInstance(def) ? JavaParserMethodDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserParameterDeclaration.class.isInstance(def) ? JavaParserParameterDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserSymbolDeclaration.class.isInstance(def) ? JavaParserSymbolDeclaration.class.cast(def).getWrappedNode()
-//                    : JavaParserTypeVariableDeclaration.class.isInstance(def) ? JavaParserTypeVariableDeclaration.class.cast(def).getWrappedNode()
-                            : JavaParserVariableDeclaration.class.isInstance(def) ? JavaParserVariableDeclaration.class.cast(def).getWrappedNode()
-                            : null;
-        }
-
-        private void emitUse(Node n, Node definition, String definitionPath) {
-            DocumentIndexer indexer = indexers.get(definitionPath);
-
-            Optional<Range> rangeContainer = getRange(n);
-            Optional<Range> definitionRangeContainer = getRange(definition);
-
-            if (!rangeContainer.isPresent()) {
-                throw new RuntimeException("Unexpected range-less AST node: " + n.toString());
+            DefinitionMeta meta = indexer.definitions.get(def);
+            if (meta == null) {
+                throw new RuntimeException("BUG definition doesn't exist, usePath " + pathname + ", use " + humanRange(use) + ", defPath " + defPath + ", def " + humanRange(def));
             }
 
-            if (!definitionRangeContainer.isPresent()) {
-                throw new RuntimeException("Unexpected range-less AST node: " + definition.toString());
-            }
-
-            Range range = rangeContainer.get();
-            Range definitionRange = definitionRangeContainer.get();
-            DefinitionMeta meta = indexer.definitions.get(definitionRange);
-
-            String rangeId = emitter.emitVertex("range", createRange(range));
+            String rangeId = emitter.emitVertex("range", createRange(use));
             emitter.emitEdge("next", Map.of("outV", rangeId, "inV", meta.resultSetId));
 
             if (meta.definitionResultId == null) {
@@ -297,27 +260,39 @@ public class DocumentIndexer {
             meta.referenceRangeIds.put(documentId, set);
         }
 
-        private Optional<Range> getRange(Node decl) {
-            if (decl.getClass().isAssignableFrom(VariableDeclarationExpr.class)) {
-                // Unwrap variable declarations
-                decl = ((VariableDeclarationExpr) decl).getVariables().get(0); // TODO - how to support multiple?
-            }
-
-            if (decl.getClass().isAssignableFrom(FieldDeclaration.class)) {
-                // Unwrap variable declarations
-                decl = ((FieldDeclaration) decl).getVariables().get(0); // TODO - how to support multiple?
-            }
-
-            try {
-                // Extract only the name portion of the AST node
-                return ((NodeWithSimpleName) decl).getName().getRange();
-            } catch (ClassCastException ex) {
-                // ignore
-            }
-
-            return decl.getRange();
+        private Range nameRange(CtNamedElement a) {
+            return nameRange(a.getPosition(), a.getSimpleName());
         }
 
+        private Range nameRange(SourcePosition a, String name) {
+            return Range.range(
+                    a.getLine(),
+                    a.getColumn(),
+                    a.getLine(),
+                    a.getColumn() + name.length()
+            );
+        }
+
+        private Range nameRange(Range a, String name) {
+            return Range.range(
+                    a.begin.line,
+                    a.begin.column,
+                    a.end.line,
+                    a.end.column + name.length()
+            );
+        }
+
+        private String mkDoc(CtTypeReference t, String docComment) {
+            return "```java\n" + t + "\n```" + (docComment.equals("") ? "" : "\n---\n" + docComment);
+        }
+
+        private String humanRange(Range r) {
+            return r.begin.line + ":" + r.begin.column + "-" + r.end.line + ":" + r.end.column;
+        }
+
+        private Range mkRange(SourcePosition pos) {
+            return Range.range(pos.getLine(), pos.getColumn(), pos.getEndLine(), pos.getEndColumn());
+        }
 
         private Map<String, Object> createRange(Range range) {
             return Map.of("start", createPosition(range.begin), "end", createPosition(range.end));
@@ -325,6 +300,16 @@ public class DocumentIndexer {
 
         private Map<String, Object> createPosition(Position position) {
             return Map.of("line", position.line - 1, "character", position.column - 1);
+        }
+
+        private Range identifierRange(CtTargetedExpression a, String b) {
+            // Ugh, we only want the range for the identifier, not the whole expression.
+            // This will probably break on fields/methods that are spread across lines.
+            // +1 for `.`, +1 because (I'm guessing) end is inclusive
+            SourcePosition p = a.getTarget().getPosition();
+            return p instanceof NoSourcePosition ?
+                    mkRange(a.getPosition()) :
+                    Range.range(p.getEndLine(), p.getEndColumn() + 1 + 1, p.getEndLine(), p.getEndColumn() + 1 + 1 + b.length());
         }
     }
 }

--- a/src/main/java/ProjectIndexer.java
+++ b/src/main/java/ProjectIndexer.java
@@ -1,5 +1,7 @@
 import spoon.MavenLauncher;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtIterator;
 
@@ -37,8 +39,8 @@ public class ProjectIndexer {
         MavenLauncher spoon = new MavenLauncher(arguments.projectRoot, MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
         spoon.buildModel();
         Map<String, CtElement> typeByFile = new HashMap();
-        for (CtElement el : spoon.getModel().getRootPackage().getTypes()) {
-            System.out.println(el.getPosition().getFile().getPath());
+        for (CtElement el : spoon.getModel().getAllTypes()) {
+            System.out.println("Found " + el.getPosition().getFile().getPath());
             typeByFile.put(el.getPosition().getFile().getPath(), el);
         }
 


### PR DESCRIPTION
Why switch from JavaParser to Spoon?

- Cross-file defs/refs currently don't work, and my attempt to make it work using JavaParser was unsuccessful https://github.com/sourcegraph/lsif-java/pull/1
- https://github.com/microsoft/lsif-java seems to be 10+x slower than JavaParser (I don't know why)
- Spoon is very popular and I wanted another data point in this design space (speed, features, etc.)
- Spoon seems to be comparable to JavaParser in speed

[Spoon](https://github.com/INRIA/spoon) is another Java source code parser/analysis library. My personal observations have been that compared to JavaParser, Spoon:

- Has nicer docs for getting started http://spoon.gforge.inria.fr/index.html
- Has a sane API
- Has built-in Maven support
- Is built on Eclipse JDT

I think cross-repo can be done using Spoon because Spoon tries to provide "weak" references to symbols outside of the current project http://spoon.gforge.inria.fr/references.html and I've seen `Unknown file` when trying to get the definition of something like `String`. We could attach a moniker right there.

![image](https://user-images.githubusercontent.com/1387653/67544721-c9feab00-f6b3-11e9-8151-18828cf4da1a.png)

TODO

- [x] Clean up the code a bit (it's in a raw WIP state right now)