### PR TITLE
Fix infinite loop

### DIFF
--- a/src/main/java/ProjectIndexer.java
+++ b/src/main/java/ProjectIndexer.java
@@ -58,7 +58,15 @@ public class ProjectIndexer {
         }
 
         for (DocumentIndexer indexer : indexers.values()) {
-            indexer.index();
+            indexer.preIndex();
+        }
+
+        for (DocumentIndexer indexer : indexers.values()) {
+            indexer.visitDefinitions();
+        }
+
+        for (DocumentIndexer indexer : indexers.values()) {
+            indexer.visitReferences();
         }
 
         for (DocumentIndexer indexer : indexers.values()) {


### PR DESCRIPTION
Prior to this change, we'd enter an infinite loop when files used symbols from each other.

After this change, all definitions are visited before references, eliminating the possibility of an infinite loop.