### PR TITLE
Use https repo for maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ application {
 repositories {
     mavenLocal()
     maven {
-        url = 'http://repo.maven.apache.org/maven2'
+        url = 'https://repo.maven.apache.org/maven2'
     }
 }
 


### PR DESCRIPTION
Newer versions of maven will fail hard otherwise:

```
...
   > Could not resolve commons-cli:commons-cli:1.4.
     Required by:
         project :
      > Could not resolve commons-cli:commons-cli:1.4.
         > Could not get resource 'http://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.pom'.
            > Could not GET 'http://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.pom'. Received status code 501 from server: HTTPS Required
```

Verified working on mvn 3.6.3 with this change.