### PR TITLE
emit required toolInfo

### DIFF
--- a/src/main/java/ProjectIndexer.java
+++ b/src/main/java/ProjectIndexer.java
@@ -30,7 +30,8 @@ public class ProjectIndexer {
         emitter.emitVertex("metaData", Util.mapOf(
                 "version", "0.4.0",
                 "positionEncoding", "utf-16",
-                "projectRoot", String.format("file://%s", Paths.get(arguments.projectRoot).toAbsolutePath().toString())
+                "projectRoot", String.format("file://%s", Paths.get(arguments.projectRoot).toAbsolutePath().toString()),
+                "toolInfo", Util.mapOf("name", "lsif-java", "version", "0.1.0")
         ));
 
         String projectId = emitter.emitVertex("project", Util.mapOf(


### PR DESCRIPTION
Tried to upload a dump file that worked after I added tool name.

```
File: dump.lsif
Root: 
error: 500 Internal Server Error

{"message":"Could not find tool type in metadata vertex at the start of the dump."}
```

It'd be nice to introduce tests so that we can make sure our indexers are up to spec if stronger server validation is introduced.