### PR TITLE
Upgrade spoon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compile 'com.github.javaparser:javaparser-symbol-solver-core:3.14.16'
-    compile 'fr.inria.gforge.spoon:spoon-core:7.5.0'
+    compile 'fr.inria.gforge.spoon:spoon-core:8.1.0-beta-17'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'commons-cli:commons-cli:1.4'
 }


### PR DESCRIPTION
Resolves #17. There's no harm in using the beta since no one relies heavily on this indexer yet.