### PR TITLE
Fixed project root absolute path ending in '.' when lsif-java called with -projectRoot .

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,7 +3,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException{
         System.out.println("Running JVM " + System.getProperty("java.version"));
         Arguments arguments = ArgumentParser.parse(args);
         PrintWriter writer = createWriter(arguments);

--- a/src/main/java/ProjectIndexer.java
+++ b/src/main/java/ProjectIndexer.java
@@ -26,11 +26,11 @@ public class ProjectIndexer {
         this.emitter = emitter;
     }
 
-    public void index() {
+    public void index() throws IOException {
         emitter.emitVertex("metaData", Util.mapOf(
                 "version", "0.4.0",
                 "positionEncoding", "utf-16",
-                "projectRoot", String.format("file://%s", Paths.get(arguments.projectRoot).toAbsolutePath().toString()),
+                "projectRoot", String.format("file://%s", Paths.get(arguments.projectRoot).toFile().getCanonicalPath()),
                 "toolInfo", Util.mapOf("name", "lsif-java", "version", "0.1.0")
         ));
 


### PR DESCRIPTION
Must please the almighty sourcegraph/lsif-validate :pray: 