### PR TITLE
Improved gradle instructions to use dir instead of path/name

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,14 @@ allprojects {
             }
             publications {
                 sourcegraph(MavenPublication) {
-                    def projectDirStr = project.projectDir
+                    def projectDirStr = project.projectDir.toString()
                     def subprojectSet = project.subprojects
-                    def projectPath = project.path.replace(":", "/")/* .substring(1) */
-                    if (projectPath.startsWith("/")) {
-                        projectPath = projectPath.substring(1)
-                    }
                     def sourceSetsSet = []
                     if (project.hasProperty("sourceSets.main.java.srcDirs")) {
                         sourceSetsSet = project.sourceSets.main.java.srcDirs
                     }
 
-                    if (!(new File(projectDirStr.toString()+"/build.gradle").exists())) return
+                    if (!(new File(projectDirStr+"/build.gradle").exists())) return
 
                     def javaApplied = components.collect{it.getName()}.contains("java")
                     if (javaApplied) from components.java
@@ -139,11 +135,8 @@ allprojects {
                         if (subprojectSet.size() > 0) {
                             node.appendNode("modules").with {
                                 for(Project p : subprojectSet) {
-                                    if(new File(p.path.replace(":", "/./").substring(1)+"/build.gradle").exists()) {
-                                        def path = p.path.replace(":", "/").substring(1)
-                                        if (path.startsWith(projectPath) && projectPath != "") {
-                                            path = path.substring(projectPath.length()+1)
-                                        }
+                                    if(new File(p.projectDir.toString()+"/build.gradle").exists()) {
+                                        def path = p.projectDir.toString().substring(projectDirStr.size()+1)
                                         appendNode("module", path)
                                     }
                                 }


### PR DESCRIPTION
`project.path` seems to be the *wrong* field to use, as it seems to mirror the name (?), which does not have to reflect the filesystem tree structure. 

WIP need to test on more repos