### PR TITLE
Avoid NPE when getting localized name

### DIFF
--- a/src/main/java/lsifjava/DocumentIndexer.java
+++ b/src/main/java/lsifjava/DocumentIndexer.java
@@ -9,6 +9,7 @@ import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.*;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 
@@ -511,13 +512,15 @@ public class DocumentIndexer {
     }
 
     private String getLocalizedName(CtTypeReference<?> type) {
-        if(type.getPackage().getQualifiedName().equals("java.lang")) {
-            return type.getSimpleName();
-        } else if(type.getPackage().getQualifiedName().startsWith(this.packageName)) {
-            return type.getSimpleName();
-        } else {
-            return type.getQualifiedName();
+        final CtPackageReference packageRef = type.getPackage();
+        if (packageRef != null) {
+            final String qualifiedName = packageRef.getQualifiedName();
+            if (qualifiedName.equals("java.lang") || qualifiedName.startsWith(this.packageName)) {
+                return type.getSimpleName();
+            }
         }
+
+        return type.getQualifiedName();
     }
 
     private String humanRange(Range r) {


### PR DESCRIPTION
The package reference is not guaranteed to be present.

```
Exception in thread "main" java.lang.NullPointerException
	at lsifjava.DocumentIndexer.getLocalizedName(DocumentIndexer.java:514)
	at lsifjava.DocumentIndexer.appendTypeParam(DocumentIndexer.java:505)
	at lsifjava.DocumentIndexer.mkClassDoc(DocumentIndexer.java:472)
	at lsifjava.DocumentIndexer.access$4(DocumentIndexer.java:446)
	at lsifjava.DocumentIndexer$DefinitionsVisitor.visitCtClass(DocumentIndexer.java:205)
	at spoon.support.reflect.declaration.CtClassImpl.accept(CtClassImpl.java:58)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
	at spoon.reflect.visitor.CtScanner.visitCtClass(CtScanner.java:335)
	at lsifjava.DocumentIndexer$DefinitionsVisitor.visitCtClass(DocumentIndexer.java:196)
	at spoon.support.reflect.declaration.CtClassImpl.accept(CtClassImpl.java:58)
	at lsifjava.DocumentIndexer.visitDefinitions(DocumentIndexer.java:55)
	at lsifjava.ProjectIndexer.index(ProjectIndexer.java:125)
	at lsifjava.Main.main(Main.java:19)
```