### PR TITLE
Build meta from gradle init script

### DIFF
--- a/src/main/kotlin/lsifjava/BuildToolInterface.kt
+++ b/src/main/kotlin/lsifjava/BuildToolInterface.kt
@@ -4,13 +4,14 @@ import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
 interface BuildToolInterface {
-    fun getClasspaths(): List<Classpath>
-    fun getSourceDirectories(): List<List<Path>>
-    fun javaSourceVersions(): List<String?>
+    val classpaths: List<Classpath>
+    val sourceDirectories: List<List<Path>>
+    val javaSourceVersions: List<String?>
 }
 
 // TODO(nsc) exclusions? lazy eval?
@@ -36,28 +37,53 @@ class GradleInterface(private val projectDir: CanonicalPath): AutoCloseable, Bui
     }
 
     // is this even *correct*? Is the order the same?
-    override fun getClasspaths(): List<Classpath> {
-        val eclipseClasspaths = getClasspathsFromEclipse()
-        return ideaModel.children.mapIndexed { i, it ->
-            Classpath(it.dependencies
-                .filterIsInstance<IdeaSingleEntryLibraryDependency>()
-                .map { it.file.canonicalPath }
-                .toSet()
-            ) + eclipseClasspaths[i]
-        }
+    override val classpaths: List<Classpath> get() {
+        val initScriptClasspath = kotlin.runCatching { getClasspathFromInitScript() }.getOrDefault(Classpath(setOf()))
+
+        val eclipseClasspaths = kotlin.runCatching { eclipseClasspath() }.getOrDefault(listOf())
+
+        val ideaClasspath = kotlin.runCatching { ideaClasspath() }.getOrDefault(listOf())
+
+        return ideaClasspath.mapIndexed {i, it -> it + eclipseClasspaths[i] + initScriptClasspath }
     }
 
+    private fun ideaClasspath() = ideaModel.children.map { it ->
+        Classpath(it.dependencies
+            .filterIsInstance<IdeaSingleEntryLibraryDependency>()
+            .map { it.file.canonicalPath }
+            .toSet()
+        )
+    }
 
-    private fun getClasspathsFromEclipse() = eclipseClasspath(eclipseModel)
-
-    private fun eclipseClasspath(project: EclipseProject): List<Classpath> {
+    private fun eclipseClasspath(project: EclipseProject = eclipseModel): List<Classpath> {
         val classPaths = arrayListOf<Classpath>()
         classPaths += Classpath(project.classpath.map { it.file.canonicalPath }.toSet())
         project.children.forEach { eclipseClasspath(it).toCollection(classPaths) }
         return classPaths
     }
 
-    override fun getSourceDirectories(): List<List<Path>> {
+    private fun getClasspathFromInitScript(): Classpath {
+        val config = File.createTempFile("lsifjava", ".gradle")
+        config.deleteOnExit()
+
+        config.bufferedWriter().use { configWriter ->
+            ClassLoader.getSystemResourceAsStream(initScriptName)!!.bufferedReader().use { configReader ->
+                configReader.copyTo(configWriter)
+            }
+        }
+
+        // Unix only for now. To be revisited
+        val (stdout, stderr) = execAndReadStdoutAndStderr("./gradlew -I ${config.absolutePath} lsifjavaAllGradleDeps", projectDir.path)
+
+        val artifacts = artifactPattern.findAll(stdout)
+            .mapNotNull { it.groups[1] }
+            .map { Paths.get(it.value).toFile().canonicalPath }
+            .toSet()
+            
+        return Classpath(artifacts)
+    }
+
+    override val sourceDirectories: List<List<Path>> get() {
         return ideaModel.children.flatMap { module ->
             module.contentRoots.map { root ->
                 root.sourceDirectories.map { Paths.get(it.directory.canonicalPath) } +
@@ -84,7 +110,7 @@ class GradleInterface(private val projectDir: CanonicalPath): AutoCloseable, Bui
         return sourceDirs
     }
     
-    override fun javaSourceVersions() = javaSourceVersion(eclipseModel)
+    override val javaSourceVersions: List<String?> get() = javaSourceVersion(eclipseModel)
 
     // get rid of String?, use parent version or else fallback
     private fun javaSourceVersion(project: EclipseProject): List<String?> {
@@ -95,12 +121,4 @@ class GradleInterface(private val projectDir: CanonicalPath): AutoCloseable, Bui
     }
 
     override fun close() = projectConnection.close()
-}
-
-inline class Classpath(private val classpaths: Set<String>) {
-    operator fun plus(other: Set<String>) = Classpath(classpaths.union(other))
-    
-    operator fun plus(other: Classpath) = Classpath(classpaths.union(other.classpaths))
-
-    override fun toString() = classpaths.joinToString(":")
 }

--- a/src/main/kotlin/lsifjava/BuildToolInterface.kt
+++ b/src/main/kotlin/lsifjava/BuildToolInterface.kt
@@ -15,17 +15,23 @@ interface BuildToolInterface {
 
 // TODO(nsc) exclusions? lazy eval?
 class GradleInterface(private val projectDir: CanonicalPath): AutoCloseable, BuildToolInterface {
-    private val projectConnection by lazy {
+    private val initScriptName = "projectClasspathFinder.gradle"
+
+    private val artifactPattern by lazy(LazyThreadSafetyMode.NONE) {
+        "lsifjava (.+)(?:\r?\n)".toRegex()
+    }
+
+    private val projectConnection by lazy(LazyThreadSafetyMode.NONE) {
         GradleConnector.newConnector()
             .forProjectDirectory(projectDir.path.toFile())
             .connect()
     }
 
-    private val eclipseModel by lazy {
+    private val eclipseModel by lazy(LazyThreadSafetyMode.NONE) {
         projectConnection.getModel(EclipseProject::class.java)
     }
     
-    private val ideaModel by lazy {
+    private val ideaModel by lazy(LazyThreadSafetyMode.NONE) {
         projectConnection.getModel(IdeaProject::class.java)
     }
 

--- a/src/main/kotlin/lsifjava/UtilTypes.kt
+++ b/src/main/kotlin/lsifjava/UtilTypes.kt
@@ -1,5 +1,9 @@
 package lsifjava
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.io.ByteArrayOutputStream
 import java.io.Writer
 import java.nio.file.Path
 
@@ -12,4 +16,34 @@ object NoopWriter: Writer() {
     override fun close() = Unit
     override fun flush() = Unit
     override fun write(p0: CharArray, p1: Int, p2: Int) = Unit
+}
+
+inline class Classpath(private val classpaths: Set<String>) {
+    operator fun plus(other: Set<String>) = Classpath(classpaths.union(other))
+
+    operator fun plus(other: Classpath) = Classpath(classpaths.union(other.classpaths))
+    
+    fun size() = classpaths.size
+    
+    override fun toString() = classpaths.joinToString(":")
+}
+
+fun List<Classpath>.merge() = this.reduce { acc, classpath -> acc + classpath }
+
+fun execAndReadStdoutAndStderr(shellCommand: String, directory: Path): Pair<String, String> {
+    val process = Runtime.getRuntime().exec(shellCommand, null, directory.toFile())
+    val output = ByteArrayOutputStream().writer()
+    val errors = ByteArrayOutputStream().writer()
+
+    runBlocking(Dispatchers.IO) {
+        launch {
+            process.inputStream.bufferedReader().use { it.copyTo(output) }
+        }
+
+        launch {
+            process.errorStream.bufferedReader().use { it.copyTo(errors) }
+        }
+    }
+
+    return Pair(output.toString(), errors.toString())
 }

--- a/src/main/kotlin/lsifjava/UtilTypes.kt
+++ b/src/main/kotlin/lsifjava/UtilTypes.kt
@@ -28,7 +28,13 @@ inline class Classpath(private val classpaths: Set<String>) {
     override fun toString() = classpaths.joinToString(":")
 }
 
-fun List<Classpath>.merge() = this.reduce { acc, classpath -> acc + classpath }
+fun List<Classpath>.merge() = when(this.isEmpty()) {
+    false -> this.reduce { acc, classpath -> acc + classpath }
+    else -> {
+        println("no classpaths were inferred, symbol resolution for external dependencies may fail.")
+        Classpath(setOf())
+    }
+}
 
 fun execAndReadStdoutAndStderr(shellCommand: String, directory: Path): Pair<String, String> {
     val process = Runtime.getRuntime().exec(shellCommand, null, directory.toFile())

--- a/src/main/resources/projectClasspathFinder.gradle
+++ b/src/main/resources/projectClasspathFinder.gradle
@@ -1,0 +1,44 @@
+allprojects { project ->
+    task lsifjavaAllGradleDeps {
+        doLast {
+            if (project.hasProperty('android')) {
+                project.android.getBootClasspath().each {
+                    println "lsifjava $it"
+                }
+                if (project.android.hasProperty('applicationVariants')) {
+                    project.android.applicationVariants.all { variant ->
+                        try {
+                            variant.getCompileClasspath().each {
+                                println "lsifjava $it"
+                            }
+                        } catch(ignored){}
+                    }
+                }
+            } else {
+                // Print the list of all dependencies jar files.
+                project.configurations.findAll {
+                    it.metaClass.respondsTo(it, "isCanBeResolved") ? it.isCanBeResolved() : false
+                }.each {
+                    it.resolve().each {
+                        def inspected = it.inspect()
+
+                        if (inspected.endsWith("jar")) {
+                            if (!inspected.contains("zip!")) {
+                                println "lsifjava $it"
+                            }
+                        } else if (inspected.endsWith("aar")) {
+                            // If the dependency is an AAR file we try to determine the location
+                            // of the classes.jar file in the exploded aar folder.
+                            def splitted = inspected.split("/")
+                            def namespace = splitted[-5]
+                            def name = splitted[-4]
+                            def version = splitted[-3]
+                            def explodedPath = "$project.buildDir/intermediates/exploded-aar/$namespace/$name/$version/jars/classes.jar"
+                            println "lsifjava $explodedPath"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Init script is derived from https://github.com/fwcd/kotlin-language-server/blob/master/server/src/main/resources/projectClassPathFinder.gradle

~~Will consider https://github.com/sourcegraph/lsif-java/issues/70 closeable after merging this, further improvements can be made on an as-needed basis~~
Going to attempt similar to the following also https://kythe.io/examples/#extracting-gradle-based-repositories

From second commit:
Another best-effort attempt at deriving some build meta (classpaths) from gradle.
Has great results in some Android repos tested (airbnb/epoxy for one)
This approach could be used further for getting more comprehensive meta for other config but thus far source dir and java version inference has been good enough