### PR TITLE
Fix Java home setting for Java 11

### DIFF
--- a/project/JavacBootClasspathPlugin.scala
+++ b/project/JavacBootClasspathPlugin.scala
@@ -32,7 +32,7 @@ object JavacBootClasspathPlugin extends AutoPlugin {
   private def toolsJar: File = javaHomeDirectory / "lib" / "tools.jar"
   private def javaHomeDirectory: File = {
     val home = file(System.getProperty("java.home"))
-    if (Properties.isJavaAtLeast("8"))
+    if (Properties.isJavaAtLeast("8") && !Properties.isJavaAtLeast("11"))
       home.getParentFile
     else
       home


### PR DESCRIPTION
Previously, the build was using the incorrect Java home directory for
Java 11.