### PR TITLE
JDK 9+ Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
       - run: sbt test
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
       - run: sbt checkAll

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ These are the main components of the project.
 | `./sbt`                                                            | terminal | Start interactive sbt shell with Java 8. Takes a while to load on the first run.    |
 | `unit/test`                                                        | sbt      | Run fast unit tests.                                                                |
 | `~unit/test`                                                       | sbt      | Start watch mode to run tests on file save, good for local edit-and-test workflows. |
-| `snapshot/testOnly tests.MinimizedSnapshotSuite`                   | sbt      | Runs fast snapshot tests. Indexes a small set of files under `tests/minimized`.     |
-| `snapshot/testOnly tests.MinimizedSnapshotSuite -- *InnerClasses*` | sbt      | Runs only individual tests cases matching the name "InnerClasses".                  |
-| `snapshot/testOnly tests.LibrarySnapshotSuite`                     | sbt      | Runs slow snapshot tests. Indexes a corpus of external Java libraries.              |
-| `snapshot/test`                                                    | sbt      | Runs all snapshot tests.                                                            |
-| `snapshot/run`                                                     | sbt      | Update snapshot tests. Use this command after you have fixed a bug.                 |
+| `snapshots/testOnly tests.MinimizedSnapshotSuite`                   | sbt      | Runs fast snapshot tests. Indexes a small set of files under `tests/minimized`.     |
+| `snapshots/testOnly tests.MinimizedSnapshotSuite -- *InnerClasses*` | sbt      | Runs only individual tests cases matching the name "InnerClasses".                  |
+| `snapshots/testOnly tests.LibrarySnapshotSuite`                     | sbt      | Runs slow snapshot tests. Indexes a corpus of external Java libraries.              |
+| `snapshots/test`                                                    | sbt      | Runs all snapshot tests.                                                            |
+| `snapshots/run`                                                     | sbt      | Update snapshot tests. Use this command after you have fixed a bug.                 |
 | `fixAll`                                                           | sbt      | Run Scalafmt, Scalafix and Javafmt on all sources. Run this before opening a PR.    |
 
 ### Import the project into IntelliJ

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -4,12 +4,12 @@ import com.sun.source.tree.*;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Position;
-import com.sourcegraph.semanticdb_javac.Semanticdb;
 import com.sourcegraph.semanticdb_javac.Semanticdb.SymbolOccurrence.Role;
 
 import javax.lang.model.util.Elements;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -98,14 +98,27 @@ public abstract class BaseEpoxyAdapter
   private final SpanSizeLookup spanSizeLookup = new SpanSizeLookup() {
 //              ^^^^^^^^^^^^^^ reference _root_/
 //                             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#spanSizeLookup.
+//                                              ^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 19:3
+//                                                  ^^^^^^^^^^^^^^ reference _root_/
 //                                                  ^^^^^^^^^^^^^^ reference _root_/
 
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public int getSpanSize(int position) {
+//             ^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#spanSizeLookup.``#getSpanSize().
+//                             ^^^^^^^^ definition local0
       try {
         return getModelForPosition(position)
+//             ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
+//                                 ^^^^^^^^ reference local0
             .spanSize(spanCount, position, getItemCount());
+//           ^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#spanSize().
+//                    ^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#spanCount.
+//                               ^^^^^^^^ reference local0
+//                                         ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getItemCount().
       } catch (IndexOutOfBoundsException e) {
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                                       ^ definition local1
         // There seems to be a GridLayoutManager bug where when the user is in accessibility mode
         // it incorrectly uses an outdated view position
         // when calling this method. This crashes when a view is animating out, when it is
@@ -114,6 +127,8 @@ public abstract class BaseEpoxyAdapter
         // library fixes this
         // TODO: (eli_hart 8/23/16) Figure out if this has been fixed in new support library
         onExceptionSwallowed(e);
+//      ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onExceptionSwallowed().
+//                           ^ reference local1
         return 1;
       }
     }
@@ -137,7 +152,7 @@ public abstract class BaseEpoxyAdapter
   protected void onExceptionSwallowed(RuntimeException exception) {
 //               ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onExceptionSwallowed().
 //                                    ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
-//                                                     ^^^^^^^^^ definition local0
+//                                                     ^^^^^^^^^ definition local2
 
   }
 
@@ -167,27 +182,27 @@ public abstract class BaseEpoxyAdapter
    ^^^^^^^^ reference java/lang/Override#
   public long getItemId(int position) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getItemId().
-//                          ^^^^^^^^ definition local1
+//                          ^^^^^^^^ definition local3
     // This does not call getModelForPosition so that we don't use the id of the empty model when
     // hidden,
     // so that the id stays constant when gone vs shown
     return getCurrentModels().get(position).id();
 //         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                            ^^^ reference java/util/List#get().
-//                                ^^^^^^^^ reference local1
-//                                          ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                ^^^^^^^^ reference local3
+//                                          ^^ reference com/airbnb/epoxy/EpoxyModel#id().
   }
 
   @Override
    ^^^^^^^^ reference java/lang/Override#
   public int getItemViewType(int position) {
 //           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getItemViewType().
-//                               ^^^^^^^^ definition local2
+//                               ^^^^^^^^ definition local4
     return viewTypeManager.getViewTypeAndRememberModel(getModelForPosition(position));
 //         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewTypeManager.
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#getViewTypeAndRememberModel().
 //                                                     ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
-//                                                                         ^^^^^^^^ reference local2
+//                                                                         ^^^^^^^^ reference local4
   }
 
   @Override
@@ -196,27 +211,27 @@ public abstract class BaseEpoxyAdapter
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                       ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onCreateViewHolder().
 //                                          ^^^^^^^^^ reference _root_/
-//                                                    ^^^^^^ definition local3
-//                                                                ^^^^^^^^ definition local4
+//                                                    ^^^^^^ definition local5
+//                                                                ^^^^^^^^ definition local6
     EpoxyModel<?> model = viewTypeManager.getModelForViewType(this, viewType);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^ definition local5
+//                ^^^^^ definition local7
 //                        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewTypeManager.
 //                                        ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#getModelForViewType().
 //                                                            ^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#this.
-//                                                                  ^^^^^^^^ reference local4
+//                                                                  ^^^^^^^^ reference local6
     View view = model.buildView(parent);
 //  ^^^^ reference _root_/
-//       ^^^^ definition local6
-//              ^^^^^ reference local5
+//       ^^^^ definition local8
+//              ^^^^^ reference local7
 //                    ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#buildView().
-//                              ^^^^^^ reference local3
+//                              ^^^^^^ reference local5
     return new EpoxyViewHolder(parent, view, model.shouldSaveViewState());
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#`<init>`().
 //             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                             ^^^^^^ reference local3
-//                                     ^^^^ reference local6
-//                                           ^^^^^ reference local5
+//                             ^^^^^^ reference local5
+//                                     ^^^^ reference local8
+//                                           ^^^^^ reference local7
 //                                                 ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#shouldSaveViewState().
   }
 
@@ -225,12 +240,12 @@ public abstract class BaseEpoxyAdapter
   public void onBindViewHolder(EpoxyViewHolder holder, int position) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onBindViewHolder().
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                             ^^^^^^ definition local7
-//                                                         ^^^^^^^^ definition local8
+//                                             ^^^^^^ definition local9
+//                                                         ^^^^^^^^ definition local10
     onBindViewHolder(holder, position, Collections.emptyList());
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onBindViewHolder(+1).
-//                   ^^^^^^ reference local7
-//                           ^^^^^^^^ reference local8
+//                   ^^^^^^ reference local9
+//                           ^^^^^^^^ reference local10
 //                                     ^^^^^^^^^^^ reference java/util/Collections#
 //                                                 ^^^^^^^^^ reference java/util/Collections#emptyList().
   }
@@ -240,41 +255,41 @@ public abstract class BaseEpoxyAdapter
   public void onBindViewHolder(EpoxyViewHolder holder, int position, List<Object> payloads) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onBindViewHolder(+1).
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                             ^^^^^^ definition local9
-//                                                         ^^^^^^^^ definition local10
+//                                             ^^^^^^ definition local11
+//                                                         ^^^^^^^^ definition local12
 //                                                                   ^^^^ reference java/util/List#
 //                                                                        ^^^^^^ reference java/lang/Object#
-//                                                                                ^^^^^^^^ definition local11
+//                                                                                ^^^^^^^^ definition local13
     EpoxyModel<?> modelToShow = getModelForPosition(position);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^^^^^^^ definition local12
+//                ^^^^^^^^^^^ definition local14
 //                              ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
-//                                                  ^^^^^^^^ reference local10
+//                                                  ^^^^^^^^ reference local12
 
     EpoxyModel<?> previouslyBoundModel = null;
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^^^^^^^^^^^^^^^^ definition local13
+//                ^^^^^^^^^^^^^^^^^^^^ definition local15
     if (diffPayloadsEnabled()) {
 //      ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#diffPayloadsEnabled().
       previouslyBoundModel = DiffPayload.getModelFromPayload(payloads, getItemId(position));
-//    ^^^^^^^^^^^^^^^^^^^^ reference local13
+//    ^^^^^^^^^^^^^^^^^^^^ reference local15
 //                           ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#
 //                                       ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#getModelFromPayload().
-//                                                           ^^^^^^^^ reference local11
+//                                                           ^^^^^^^^ reference local13
 //                                                                     ^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getItemId().
-//                                                                               ^^^^^^^^ reference local10
+//                                                                               ^^^^^^^^ reference local12
     }
 
     holder.bind(modelToShow, previouslyBoundModel, payloads, position);
-//  ^^^^^^ reference local9
+//  ^^^^^^ reference local11
 //         ^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#bind().
-//              ^^^^^^^^^^^ reference local12
-//                           ^^^^^^^^^^^^^^^^^^^^ reference local13
-//                                                 ^^^^^^^^ reference local11
-//                                                           ^^^^^^^^ reference local10
+//              ^^^^^^^^^^^ reference local14
+//                           ^^^^^^^^^^^^^^^^^^^^ reference local15
+//                                                 ^^^^^^^^ reference local13
+//                                                           ^^^^^^^^ reference local12
 
     if (payloads.isEmpty()) {
-//      ^^^^^^^^ reference local11
+//      ^^^^^^^^ reference local13
 //               ^^^^^^^ reference java/util/List#isEmpty().
       // We only apply saved state to the view on initial bind, not on model updates.
       // Since view state should be independent of model props, we should not need to apply state
@@ -282,29 +297,29 @@ public abstract class BaseEpoxyAdapter
       viewHolderState.restore(holder);
 //    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
 //                    ^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#restore().
-//                            ^^^^^^ reference local9
+//                            ^^^^^^ reference local11
     }
 
     boundViewHolders.put(holder);
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders.
 //                   ^^^ reference com/airbnb/epoxy/BoundViewHolders#put().
-//                       ^^^^^^ reference local9
+//                       ^^^^^^ reference local11
 
     if (diffPayloadsEnabled()) {
 //      ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#diffPayloadsEnabled().
       onModelBound(holder, modelToShow, position, previouslyBoundModel);
 //    ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+1).
-//                 ^^^^^^ reference local9
-//                         ^^^^^^^^^^^ reference local12
-//                                      ^^^^^^^^ reference local10
-//                                                ^^^^^^^^^^^^^^^^^^^^ reference local13
+//                 ^^^^^^ reference local11
+//                         ^^^^^^^^^^^ reference local14
+//                                      ^^^^^^^^ reference local12
+//                                                ^^^^^^^^^^^^^^^^^^^^ reference local15
     } else {
       onModelBound(holder, modelToShow, position, payloads);
 //    ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound().
-//                 ^^^^^^ reference local9
-//                         ^^^^^^^^^^^ reference local12
-//                                      ^^^^^^^^ reference local10
-//                                                ^^^^^^^^ reference local11
+//                 ^^^^^^ reference local11
+//                         ^^^^^^^^^^^ reference local14
+//                                      ^^^^^^^^ reference local12
+//                                                ^^^^^^^^ reference local13
     }
   }
 
@@ -320,38 +335,38 @@ public abstract class BaseEpoxyAdapter
   protected void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position,
 //               ^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound().
 //                            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                            ^^^^^^ definition local14
+//                                            ^^^^^^ definition local16
 //                                                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                                  ^^^^^ definition local15
-//                                                                             ^^^^^^^^ definition local16
+//                                                                  ^^^^^ definition local17
+//                                                                             ^^^^^^^^ definition local18
       @Nullable List<Object> payloads) {
 //     ^^^^^^^^ reference androidx/annotation/Nullable#
 //              ^^^^ reference java/util/List#
 //                   ^^^^^^ reference java/lang/Object#
-//                           ^^^^^^^^ definition local17
+//                           ^^^^^^^^ definition local19
     onModelBound(holder, model, position);
 //  ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+2).
-//               ^^^^^^ reference local14
-//                       ^^^^^ reference local15
-//                              ^^^^^^^^ reference local16
+//               ^^^^^^ reference local16
+//                       ^^^^^ reference local17
+//                              ^^^^^^^^ reference local18
   }
 
   void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position,
 //     ^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+1).
 //                  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                  ^^^^^^ definition local18
+//                                  ^^^^^^ definition local20
 //                                          ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                        ^^^^^ definition local19
-//                                                                   ^^^^^^^^ definition local20
+//                                                        ^^^^^ definition local21
+//                                                                   ^^^^^^^^ definition local22
       @Nullable EpoxyModel<?> previouslyBoundModel) {
 //     ^^^^^^^^ reference androidx/annotation/Nullable#
 //              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                            ^^^^^^^^^^^^^^^^^^^^ definition local21
+//                            ^^^^^^^^^^^^^^^^^^^^ definition local23
     onModelBound(holder, model, position);
 //  ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+2).
-//               ^^^^^^ reference local18
-//                       ^^^^^ reference local19
-//                              ^^^^^^^^ reference local20
+//               ^^^^^^ reference local20
+//                       ^^^^^ reference local21
+//                              ^^^^^^^^ reference local22
   }
 
   /**
@@ -361,10 +376,10 @@ public abstract class BaseEpoxyAdapter
   protected void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position) {
 //               ^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+2).
 //                            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                            ^^^^^^ definition local22
+//                                            ^^^^^^ definition local24
 //                                                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                                  ^^^^^ definition local23
-//                                                                             ^^^^^^^^ definition local24
+//                                                                  ^^^^^ definition local25
+//                                                                             ^^^^^^^^ definition local26
 
   }
 
@@ -383,11 +398,11 @@ public abstract class BaseEpoxyAdapter
   EpoxyModel<?> getModelForPosition(int position) {
   ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
-//                                      ^^^^^^^^ definition local25
+//                                      ^^^^^^^^ definition local27
     return getCurrentModels().get(position);
 //         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                            ^^^ reference java/util/List#get().
-//                                ^^^^^^^^ reference local25
+//                                ^^^^^^^^ reference local27
   }
 
   @Override
@@ -395,28 +410,28 @@ public abstract class BaseEpoxyAdapter
   public void onViewRecycled(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewRecycled().
 //                           ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                           ^^^^^^ definition local26
+//                                           ^^^^^^ definition local28
     viewHolderState.save(holder);
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
 //                  ^^^^ reference com/airbnb/epoxy/ViewHolderState#save(+1).
-//                       ^^^^^^ reference local26
+//                       ^^^^^^ reference local28
     boundViewHolders.remove(holder);
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders.
 //                   ^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#remove().
-//                          ^^^^^^ reference local26
+//                          ^^^^^^ reference local28
 
     EpoxyModel<?> model = holder.getModel();
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^ definition local27
-//                        ^^^^^^ reference local26
+//                ^^^^^ definition local29
+//                        ^^^^^^ reference local28
 //                               ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
     holder.unbind();
-//  ^^^^^^ reference local26
+//  ^^^^^^ reference local28
 //         ^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#unbind().
     onModelUnbound(holder, model);
 //  ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onModelUnbound().
-//                 ^^^^^^ reference local26
-//                         ^^^^^ reference local27
+//                 ^^^^^^ reference local28
+//                         ^^^^^ reference local29
   }
 
   @CallSuper
@@ -427,7 +442,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onDetachedFromRecyclerView().
 //                                        ^^^^^^^ reference androidx/annotation/NonNull#
 //                                                ^^^^^^^^^^^^ reference _root_/
-//                                                             ^^^^^^^^^^^^ definition local28
+//                                                             ^^^^^^^^^^^^ definition local30
     // The last model is saved for optimization, but holding onto it can leak anything saved inside
     // the model (like a click listener that references a Fragment). This is only needed during
     // the viewholder creation phase, so it is safe to clear now.
@@ -443,9 +458,9 @@ public abstract class BaseEpoxyAdapter
   protected void onModelUnbound(EpoxyViewHolder holder, EpoxyModel<?> model) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onModelUnbound().
 //                              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                              ^^^^^^ definition local29
+//                                              ^^^^^^ definition local31
 //                                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                                    ^^^^^ definition local30
+//                                                                    ^^^^^ definition local32
 
   }
 
@@ -456,14 +471,14 @@ public abstract class BaseEpoxyAdapter
   public boolean onFailedToRecycleView(EpoxyViewHolder holder) {
 //               ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onFailedToRecycleView().
 //                                     ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                                     ^^^^^^ definition local31
+//                                                     ^^^^^^ definition local33
     //noinspection unchecked,rawtypes
     return ((EpoxyModel) holder.getModel()).onFailedToRecycleView(holder.objectToBind());
 //           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                       ^^^^^^ reference local31
+//                       ^^^^^^ reference local33
 //                              ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
 //                                          ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#onFailedToRecycleView().
-//                                                                ^^^^^^ reference local31
+//                                                                ^^^^^^ reference local33
 //                                                                       ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#objectToBind().
   }
 
@@ -474,14 +489,14 @@ public abstract class BaseEpoxyAdapter
   public void onViewAttachedToWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewAttachedToWindow().
 //                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                                   ^^^^^^ definition local32
+//                                                   ^^^^^^ definition local34
     //noinspection unchecked,rawtypes
     ((EpoxyModel) holder.getModel()).onViewAttachedToWindow(holder.objectToBind());
 //    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^^ reference local32
+//                ^^^^^^ reference local34
 //                       ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
 //                                   ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#onViewAttachedToWindow().
-//                                                          ^^^^^^ reference local32
+//                                                          ^^^^^^ reference local34
 //                                                                 ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#objectToBind().
   }
 
@@ -492,32 +507,32 @@ public abstract class BaseEpoxyAdapter
   public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewDetachedFromWindow().
 //                                     ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                                     ^^^^^^ definition local33
+//                                                     ^^^^^^ definition local35
     //noinspection unchecked,rawtypes
     ((EpoxyModel) holder.getModel()).onViewDetachedFromWindow(holder.objectToBind());
 //    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^^ reference local33
+//                ^^^^^^ reference local35
 //                       ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
 //                                   ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#onViewDetachedFromWindow().
-//                                                            ^^^^^^ reference local33
+//                                                            ^^^^^^ reference local35
 //                                                                   ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#objectToBind().
   }
 
   public void onSaveInstanceState(Bundle outState) {
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onSaveInstanceState().
 //                                ^^^^^^ reference _root_/
-//                                       ^^^^^^^^ definition local34
+//                                       ^^^^^^^^ definition local36
     // Save the state of currently bound views first so they are included. Views that were
     // scrolled off and unbound will already have had
     // their state saved.
     for (EpoxyViewHolder holder : boundViewHolders) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                       ^^^^^^ definition local35
+//                       ^^^^^^ definition local37
 //                                ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders.
       viewHolderState.save(holder);
 //    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
 //                    ^^^^ reference com/airbnb/epoxy/ViewHolderState#save(+1).
-//                         ^^^^^^ reference local35
+//                         ^^^^^^ reference local37
     }
 
     if (viewHolderState.size() > 0 && !hasStableIds()) {
@@ -530,7 +545,7 @@ public abstract class BaseEpoxyAdapter
     }
 
     outState.putParcelable(SAVED_STATE_ARG_VIEW_HOLDERS, viewHolderState);
-//  ^^^^^^^^ reference local34
+//  ^^^^^^^^ reference local36
 //           ^^^^^^^^^^^^^ reference putParcelable#
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#SAVED_STATE_ARG_VIEW_HOLDERS.
 //                                                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
@@ -540,7 +555,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onRestoreInstanceState().
 //                                    ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                             ^^^^^^ reference _root_/
-//                                                    ^^^^^^^ definition local36
+//                                                    ^^^^^^^ definition local38
     // To simplify things we enforce that state is restored before views are bound, otherwise it
     // is more difficult to update view state once they are bound
     if (boundViewHolders.size() > 0) {
@@ -554,10 +569,10 @@ public abstract class BaseEpoxyAdapter
     }
 
     if (inState != null) {
-//      ^^^^^^^ reference local36
+//      ^^^^^^^ reference local38
       viewHolderState = inState.getParcelable(SAVED_STATE_ARG_VIEW_HOLDERS);
 //    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
-//                      ^^^^^^^ reference local36
+//                      ^^^^^^^ reference local38
 //                              ^^^^^^^^^^^^^ reference getParcelable#
 //                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#SAVED_STATE_ARG_VIEW_HOLDERS.
       if (viewHolderState == null) {
@@ -580,23 +595,23 @@ public abstract class BaseEpoxyAdapter
   protected int getModelPosition(EpoxyModel<?> model) {
 //              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getModelPosition().
 //                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                             ^^^^^ definition local37
+//                                             ^^^^^ definition local39
     int size = getCurrentModels().size();
-//      ^^^^ definition local38
+//      ^^^^ definition local40
 //             ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                ^^^^ reference java/util/List#size().
     for (int i = 0; i < size; i++) {
-//           ^ definition local39
-//                  ^ reference local39
-//                      ^^^^ reference local38
-//                            ^ reference local39
+//           ^ definition local41
+//                  ^ reference local41
+//                      ^^^^ reference local40
+//                            ^ reference local41
       if (model == getCurrentModels().get(i)) {
-//        ^^^^^ reference local37
+//        ^^^^^ reference local39
 //                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                    ^^^ reference java/util/List#get().
-//                                        ^ reference local39
+//                                        ^ reference local41
         return i;
-//             ^ reference local39
+//             ^ reference local41
       }
     }
 
@@ -625,11 +640,11 @@ public abstract class BaseEpoxyAdapter
    */
   public void setSpanCount(int spanCount) {
 //            ^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#setSpanCount().
-//                             ^^^^^^^^^ definition local40
+//                             ^^^^^^^^^ definition local42
     this.spanCount = spanCount;
 //  ^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#this.
 //       ^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#spanCount.
-//                   ^^^^^^^^^ reference local40
+//                   ^^^^^^^^^ reference local42
   }
 
   public int getSpanCount() {
@@ -659,7 +674,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#setupStickyHeaderView().
 //                                   ^^^^^^^ reference org/jetbrains/annotations/NotNull#
 //                                           ^^^^ reference _root_/
-//                                                ^^^^^^^^^^^^ definition local41
+//                                                ^^^^^^^^^^^^ definition local43
     // no-op
   }
 
@@ -676,7 +691,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference org/jetbrains/annotations/NotNull#
 //                                              ^^^^ reference _root_/
-//                                                   ^^^^^^^^^^^^ definition local42
+//                                                   ^^^^^^^^^^^^ definition local44
     // no-op
   }
 
@@ -691,7 +706,7 @@ public abstract class BaseEpoxyAdapter
    ^^^^^^^^ reference java/lang/Override#
   public boolean isStickyHeader(int position) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#isStickyHeader().
-//                                  ^^^^^^^^ definition local43
+//                                  ^^^^^^^^ definition local45
     return false;
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
@@ -100,7 +100,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
 //         ^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#holders.
 //                 ^^^ reference androidx/collection/LongSparseArray#get().
 //                     ^^^^^ reference local3
-//                           ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                           ^^ reference com/airbnb/epoxy/EpoxyModel#id().
   }
 
   private class HolderIterator implements Iterator<EpoxyViewHolder> {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -134,6 +134,7 @@ public class Carousel extends EpoxyRecyclerView {
 //                                        ^^^^^^^ reference _root_/
 //                                                ^^^^^^^ definition local0
           return new LinearSnapHelper();
+//               ^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //                   ^^^^^^^^^^^^^^^^ reference _root_/
         }
       };

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -95,95 +95,253 @@ class DiffHelper {
 //              ^^^^^^^^^^^^ reference RecyclerView/
 //                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
 //                                               ^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.
+//                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 91:3
+//                                                              ^^^^^^^^^^^^ reference RecyclerView/
 //                                                              ^^^^^^^^^^^^ reference RecyclerView/
 //                                                                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
+//                                                                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public void onChanged() {
+//              ^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.``#onChanged().
       throw new UnsupportedOperationException(
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1). 1:99
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
           "Diffing is enabled. You should use notifyModelsChanged instead of notifyDataSetChanged");
     }
 
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeChanged(int positionStart, int itemCount) {
+//              ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.``#onItemRangeChanged().
+//                                     ^^^^^^^^^^^^^ definition local2
+//                                                        ^^^^^^^^^ definition local3
       for (int i = positionStart; i < positionStart + itemCount; i++) {
+//             ^ definition local4
+//                 ^^^^^^^^^^^^^ reference local2
+//                                ^ reference local4
+//                                    ^^^^^^^^^^^^^ reference local2
+//                                                    ^^^^^^^^^ reference local3
+//                                                               ^ reference local4
         currentStateList.get(i).hashCode = adapter.getCurrentModels().get(i).hashCode();
+//      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                       ^^^ reference java/util/ArrayList#get().
+//                           ^ reference local4
+//                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#hashCode.
+//                                         ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
+//                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
+//                                                                    ^^^ reference java/util/List#get().
+//                                                                        ^ reference local4
+//                                                                           ^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hashCode().
       }
     }
 
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeInserted(int positionStart, int itemCount) {
+//              ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.``#onItemRangeInserted().
+//                                      ^^^^^^^^^^^^^ definition local5
+//                                                         ^^^^^^^^^ definition local6
       if (itemCount == 0) {
+//        ^^^^^^^^^ reference local6
         // no-op
         return;
       }
 
       if (itemCount == 1 || positionStart == currentStateList.size()) {
+//        ^^^^^^^^^ reference local6
+//                          ^^^^^^^^^^^^^ reference local5
+//                                           ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                                                            ^^^^ reference java/util/ArrayList#size().
         for (int i = positionStart; i < positionStart + itemCount; i++) {
+//               ^ definition local7
+//                   ^^^^^^^^^^^^^ reference local5
+//                                  ^ reference local7
+//                                      ^^^^^^^^^^^^^ reference local5
+//                                                      ^^^^^^^^^ reference local6
+//                                                                 ^ reference local7
           currentStateList.add(i, createStateForPosition(i));
+//        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                         ^^^ reference java/util/ArrayList#add(+2).
+//                             ^ reference local7
+//                                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#createStateForPosition().
+//                                                       ^ reference local7
         }
       } else {
         // Add in a batch since multiple insertions to the middle of the list are slow
         List<ModelState> newModels = new ArrayList<>(itemCount);
+//      ^^^^ reference java/util/List#
+//           ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//                       ^^^^^^^^^ definition local8
+//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
+//                                       ^^^^^^^^^ reference java/util/ArrayList#
+//                                                   ^^^^^^^^^ reference local6
         for (int i = positionStart; i < positionStart + itemCount; i++) {
+//               ^ definition local9
+//                   ^^^^^^^^^^^^^ reference local5
+//                                  ^ reference local9
+//                                      ^^^^^^^^^^^^^ reference local5
+//                                                      ^^^^^^^^^ reference local6
+//                                                                 ^ reference local9
           newModels.add(createStateForPosition(i));
+//        ^^^^^^^^^ reference local8
+//                  ^^^ reference java/util/List#add().
+//                      ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#createStateForPosition().
+//                                             ^ reference local9
         }
 
         currentStateList.addAll(positionStart, newModels);
+//      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                       ^^^^^^ reference java/util/ArrayList#addAll(+1).
+//                              ^^^^^^^^^^^^^ reference local5
+//                                             ^^^^^^^^^ reference local8
       }
 
       // Update positions of affected items
       int size = currentStateList.size();
+//        ^^^^ definition local10
+//               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                                ^^^^ reference java/util/ArrayList#size().
       for (int i = positionStart + itemCount; i < size; i++) {
+//             ^ definition local11
+//                 ^^^^^^^^^^^^^ reference local5
+//                                 ^^^^^^^^^ reference local6
+//                                            ^ reference local11
+//                                                ^^^^ reference local10
+//                                                      ^ reference local11
         currentStateList.get(i).position += itemCount;
+//      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                       ^^^ reference java/util/ArrayList#get().
+//                           ^ reference local11
+//                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
+//                                          ^^^^^^^^^ reference local6
       }
     }
 
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeRemoved(int positionStart, int itemCount) {
+//              ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.``#onItemRangeRemoved().
+//                                     ^^^^^^^^^^^^^ definition local12
+//                                                        ^^^^^^^^^ definition local13
       if (itemCount == 0) {
+//        ^^^^^^^^^ reference local13
         // no-op
         return;
       }
 
       List<ModelState> modelsToRemove =
+//    ^^^^ reference java/util/List#
+//         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//                     ^^^^^^^^^^^^^^ definition local14
           currentStateList.subList(positionStart, positionStart + itemCount);
+//        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                         ^^^^^^^ reference java/util/ArrayList#subList().
+//                                 ^^^^^^^^^^^^^ reference local12
+//                                                ^^^^^^^^^^^^^ reference local12
+//                                                                ^^^^^^^^^ reference local13
       for (ModelState model : modelsToRemove) {
+//         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//                    ^^^^^ definition local15
+//                            ^^^^^^^^^^^^^^ reference local14
         currentStateMap.remove(model.id);
+//      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
+//                      ^^^^^^ reference java/util/Map#remove().
+//                             ^^^^^ reference local15
+//                                   ^^ reference com/airbnb/epoxy/ModelState#id.
       }
       modelsToRemove.clear();
+//    ^^^^^^^^^^^^^^ reference local14
+//                   ^^^^^ reference java/util/List#clear().
 
       // Update positions of affected items
       int size = currentStateList.size();
+//        ^^^^ definition local16
+//               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                                ^^^^ reference java/util/ArrayList#size().
       for (int i = positionStart; i < size; i++) {
+//             ^ definition local17
+//                 ^^^^^^^^^^^^^ reference local12
+//                                ^ reference local17
+//                                    ^^^^ reference local16
+//                                          ^ reference local17
         currentStateList.get(i).position -= itemCount;
+//      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                       ^^^ reference java/util/ArrayList#get().
+//                           ^ reference local17
+//                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
+//                                          ^^^^^^^^^ reference local13
       }
     }
 
     @Override
+//   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+//              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer.``#onItemRangeMoved().
+//                                   ^^^^^^^^^^^^ definition local18
+//                                                     ^^^^^^^^^^ definition local19
+//                                                                     ^^^^^^^^^ definition local20
       if (fromPosition == toPosition) {
+//        ^^^^^^^^^^^^ reference local18
+//                        ^^^^^^^^^^ reference local19
         // no-op
         return;
       }
 
       if (itemCount != 1) {
+//        ^^^^^^^^^ reference local20
         throw new IllegalArgumentException("Moving more than 1 item at a time is not "
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1). 1:63
+//                ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
             + "supported. Number of items moved: " + itemCount);
+//                                                   ^^^^^^^^^ reference local20
       }
 
       ModelState model = currentStateList.remove(fromPosition);
+//    ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//               ^^^^^ definition local21
+//                       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                                        ^^^^^^ reference java/util/ArrayList#remove().
+//                                               ^^^^^^^^^^^^ reference local18
       model.position = toPosition;
+//    ^^^^^ reference local21
+//          ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
+//                     ^^^^^^^^^^ reference local19
       currentStateList.add(toPosition, model);
+//    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                     ^^^ reference java/util/ArrayList#add(+2).
+//                         ^^^^^^^^^^ reference local19
+//                                     ^^^^^ reference local21
 
       if (fromPosition < toPosition) {
+//        ^^^^^^^^^^^^ reference local18
+//                       ^^^^^^^^^^ reference local19
         // shift the affected items left
         for (int i = fromPosition; i < toPosition; i++) {
+//               ^ definition local22
+//                   ^^^^^^^^^^^^ reference local18
+//                                 ^ reference local22
+//                                     ^^^^^^^^^^ reference local19
+//                                                 ^ reference local22
           currentStateList.get(i).position--;
+//        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                         ^^^ reference java/util/ArrayList#get().
+//                             ^ reference local22
+//                                ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
         }
       } else {
         // shift the affected items right
         for (int i = toPosition + 1; i <= fromPosition; i++) {
+//               ^ definition local23
+//                   ^^^^^^^^^^ reference local19
+//                                   ^ reference local23
+//                                        ^^^^^^^^^^^^ reference local18
+//                                                      ^ reference local23
           currentStateList.get(i).position++;
+//        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
+//                         ^^^ reference java/util/ArrayList#get().
+//                             ^ reference local23
+//                                ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
         }
       }
     }
@@ -197,13 +355,13 @@ class DiffHelper {
 //     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#notifyModelChanges().
     UpdateOpHelper updateOpHelper = new UpdateOpHelper();
 //  ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                 ^^^^^^^^^^^^^^ definition local2
+//                 ^^^^^^^^^^^^^^ definition local24
 //                                  ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#`<init>`().
 //                                      ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
 
     buildDiff(updateOpHelper);
 //  ^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#buildDiff().
-//            ^^^^^^^^^^^^^^ reference local2
+//            ^^^^^^^^^^^^^^ reference local24
 
     // Send out the proper notify calls for the diff. We remove our
     // observer first so that we don't react to our own notify calls
@@ -213,7 +371,7 @@ class DiffHelper {
 //                                        ^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#observer.
     notifyChanges(updateOpHelper);
 //  ^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#notifyChanges().
-//                ^^^^^^^^^^^^^^ reference local2
+//                ^^^^^^^^^^^^^^ reference local24
     adapter.registerAdapterDataObserver(observer);
 //  ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#registerAdapterDataObserver#
@@ -223,14 +381,14 @@ class DiffHelper {
   private void notifyChanges(UpdateOpHelper opHelper) {
 //             ^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#notifyChanges().
 //                           ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                          ^^^^^^^^ definition local3
+//                                          ^^^^^^^^ definition local25
     for (UpdateOp op : opHelper.opList) {
 //       ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
-//                ^^ definition local4
-//                     ^^^^^^^^ reference local3
+//                ^^ definition local26
+//                     ^^^^^^^^ reference local25
 //                              ^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#opList.
       switch (op.type) {
-//            ^^ reference local4
+//            ^^ reference local26
 //               ^^^^ reference com/airbnb/epoxy/UpdateOp#type.
         case UpdateOp.ADD:
 //           ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
@@ -238,9 +396,9 @@ class DiffHelper {
           adapter.notifyItemRangeInserted(op.positionStart, op.itemCount);
 //        ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#notifyItemRangeInserted#
-//                                        ^^ reference local4
+//                                        ^^ reference local26
 //                                           ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
-//                                                          ^^ reference local4
+//                                                          ^^ reference local26
 //                                                             ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
           break;
         case UpdateOp.MOVE:
@@ -249,9 +407,9 @@ class DiffHelper {
           adapter.notifyItemMoved(op.positionStart, op.itemCount);
 //        ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#notifyItemMoved#
-//                                ^^ reference local4
+//                                ^^ reference local26
 //                                   ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
-//                                                  ^^ reference local4
+//                                                  ^^ reference local26
 //                                                     ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
           break;
         case UpdateOp.REMOVE:
@@ -260,9 +418,9 @@ class DiffHelper {
           adapter.notifyItemRangeRemoved(op.positionStart, op.itemCount);
 //        ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#notifyItemRangeRemoved#
-//                                       ^^ reference local4
+//                                       ^^ reference local26
 //                                          ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
-//                                                         ^^ reference local4
+//                                                         ^^ reference local26
 //                                                            ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
           break;
         case UpdateOp.UPDATE:
@@ -270,27 +428,27 @@ class DiffHelper {
 //                    ^^^^^^ reference com/airbnb/epoxy/UpdateOp#UPDATE.
           if (immutableModels && op.payloads != null) {
 //            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#immutableModels.
-//                               ^^ reference local4
+//                               ^^ reference local26
 //                                  ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
             adapter.notifyItemRangeChanged(op.positionStart, op.itemCount,
 //          ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                  ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#notifyItemRangeChanged#
-//                                         ^^ reference local4
+//                                         ^^ reference local26
 //                                            ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
-//                                                           ^^ reference local4
+//                                                           ^^ reference local26
 //                                                              ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
                 new DiffPayload(op.payloads));
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`().
 //                  ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#
-//                              ^^ reference local4
+//                              ^^ reference local26
 //                                 ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
           } else {
             adapter.notifyItemRangeChanged(op.positionStart, op.itemCount);
 //          ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                  ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#notifyItemRangeChanged#
-//                                         ^^ reference local4
+//                                         ^^ reference local26
 //                                            ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
-//                                                           ^^ reference local4
+//                                                           ^^ reference local26
 //                                                              ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
           }
           break;
@@ -298,7 +456,7 @@ class DiffHelper {
           throw new IllegalArgumentException("Unknown type: " + op.type);
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
-//                                                              ^^ reference local4
+//                                                              ^^ reference local26
 //                                                                 ^^^^ reference com/airbnb/epoxy/UpdateOp#type.
       }
     }
@@ -312,7 +470,7 @@ class DiffHelper {
 //        ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
 //                       ^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#buildDiff().
 //                                 ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                                ^^^^^^^^^^^^^^ definition local5
+//                                                ^^^^^^^^^^^^^^ definition local27
     prepareStateForDiff();
 //  ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#prepareStateForDiff().
 
@@ -323,37 +481,37 @@ class DiffHelper {
     // the change, this way subsequent operations will use the correct, updated positions.
     collectRemovals(updateOpHelper);
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#collectRemovals().
-//                  ^^^^^^^^^^^^^^ reference local5
+//                  ^^^^^^^^^^^^^^ reference local27
 
     // Only need to check for insertions if new list is bigger
     boolean hasInsertions =
-//          ^^^^^^^^^^^^^ definition local6
+//          ^^^^^^^^^^^^^ definition local28
         oldStateList.size() - updateOpHelper.getNumRemovals() != currentStateList.size();
 //      ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
-//                   ^^^^ reference java/util/ArrayList#size(+1).
-//                            ^^^^^^^^^^^^^^ reference local5
+//                   ^^^^ reference java/util/ArrayList#size().
+//                            ^^^^^^^^^^^^^^ reference local27
 //                                           ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#getNumRemovals().
 //                                                               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
-//                                                                                ^^^^ reference java/util/ArrayList#size(+1).
+//                                                                                ^^^^ reference java/util/ArrayList#size().
     if (hasInsertions) {
-//      ^^^^^^^^^^^^^ reference local6
+//      ^^^^^^^^^^^^^ reference local28
       collectInsertions(updateOpHelper);
 //    ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#collectInsertions().
-//                      ^^^^^^^^^^^^^^ reference local5
+//                      ^^^^^^^^^^^^^^ reference local27
     }
 
     collectMoves(updateOpHelper);
 //  ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#collectMoves().
-//               ^^^^^^^^^^^^^^ reference local5
+//               ^^^^^^^^^^^^^^ reference local27
     collectChanges(updateOpHelper);
 //  ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#collectChanges().
-//                 ^^^^^^^^^^^^^^ reference local5
+//                 ^^^^^^^^^^^^^^ reference local27
 
     resetOldState();
 //  ^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#resetOldState().
 
     return updateOpHelper;
-//         ^^^^^^^^^^^^^^ reference local5
+//         ^^^^^^^^^^^^^^ reference local27
   }
 
   private void resetOldState() {
@@ -382,119 +540,119 @@ class DiffHelper {
     ArrayList<ModelState> tempList = oldStateList;
 //  ^^^^^^^^^ reference java/util/ArrayList#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                        ^^^^^^^^ definition local7
+//                        ^^^^^^^^ definition local29
 //                                   ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
     oldStateList = currentStateList;
 //  ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
 //                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
     currentStateList = tempList;
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
-//                     ^^^^^^^^ reference local7
+//                     ^^^^^^^^ reference local29
 
     Map<Long, ModelState> tempMap = oldStateMap;
 //  ^^^ reference java/util/Map#
 //      ^^^^ reference java/lang/Long#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                        ^^^^^^^ definition local8
+//                        ^^^^^^^ definition local30
 //                                  ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateMap.
     oldStateMap = currentStateMap;
 //  ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateMap.
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
     currentStateMap = tempMap;
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
-//                    ^^^^^^^ reference local8
+//                    ^^^^^^^ reference local30
 
     // Remove all pairings in the old states so we can tell which of them were removed. The items
     // that still exist in the new list will be paired when we build the current list state below
     for (ModelState modelState : oldStateList) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                  ^^^^^^^^^^ definition local9
+//                  ^^^^^^^^^^ definition local31
 //                               ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
       modelState.pair = null;
-//    ^^^^^^^^^^ reference local9
+//    ^^^^^^^^^^ reference local31
 //               ^^^^ reference com/airbnb/epoxy/ModelState#pair.
     }
 
     int modelCount = adapter.getCurrentModels().size();
-//      ^^^^^^^^^^ definition local10
+//      ^^^^^^^^^^ definition local32
 //                   ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                           ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                              ^^^^ reference java/util/List#size().
     currentStateList.ensureCapacity(modelCount);
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                   ^^^^^^^^^^^^^^ reference java/util/ArrayList#ensureCapacity().
-//                                  ^^^^^^^^^^ reference local10
+//                                  ^^^^^^^^^^ reference local32
 
     for (int i = 0; i < modelCount; i++) {
-//           ^ definition local11
-//                  ^ reference local11
-//                      ^^^^^^^^^^ reference local10
-//                                  ^ reference local11
+//           ^ definition local33
+//                  ^ reference local33
+//                      ^^^^^^^^^^ reference local32
+//                                  ^ reference local33
       currentStateList.add(createStateForPosition(i));
 //    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
-//                     ^^^ reference java/util/ArrayList#add().
+//                     ^^^ reference java/util/ArrayList#add(+1).
 //                         ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#createStateForPosition().
-//                                                ^ reference local11
+//                                                ^ reference local33
     }
   }
 
   private ModelState createStateForPosition(int position) {
 //        ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                   ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#createStateForPosition().
-//                                              ^^^^^^^^ definition local12
+//                                              ^^^^^^^^ definition local34
     EpoxyModel<?> model = adapter.getCurrentModels().get(position);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                ^^^^^ definition local13
+//                ^^^^^ definition local35
 //                        ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                                ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                                   ^^^ reference java/util/List#get().
-//                                                       ^^^^^^^^ reference local12
+//                                                       ^^^^^^^^ reference local34
     model.addedToAdapter = true;
-//  ^^^^^ reference local13
+//  ^^^^^ reference local35
 //        ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#addedToAdapter.
     ModelState state = ModelState.build(model, position, immutableModels);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//             ^^^^^ definition local14
+//             ^^^^^ definition local36
 //                     ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                                ^^^^^ reference com/airbnb/epoxy/ModelState#build().
-//                                      ^^^^^ reference local13
-//                                             ^^^^^^^^ reference local12
+//                                      ^^^^^ reference local35
+//                                             ^^^^^^^^ reference local34
 //                                                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#immutableModels.
 
     ModelState previousValue = currentStateMap.put(state.id, state);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//             ^^^^^^^^^^^^^ definition local15
+//             ^^^^^^^^^^^^^ definition local37
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
 //                                             ^^^ reference java/util/Map#put().
-//                                                 ^^^^^ reference local14
+//                                                 ^^^^^ reference local36
 //                                                       ^^ reference com/airbnb/epoxy/ModelState#id.
-//                                                           ^^^^^ reference local14
+//                                                           ^^^^^ reference local36
     if (previousValue != null) {
-//      ^^^^^^^^^^^^^ reference local15
+//      ^^^^^^^^^^^^^ reference local37
       int previousPosition = previousValue.position;
-//        ^^^^^^^^^^^^^^^^ definition local16
-//                           ^^^^^^^^^^^^^ reference local15
+//        ^^^^^^^^^^^^^^^^ definition local38
+//                           ^^^^^^^^^^^^^ reference local37
 //                                         ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
       EpoxyModel<?> previousModel = adapter.getCurrentModels().get(previousPosition);
 //    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                  ^^^^^^^^^^^^^ definition local17
+//                  ^^^^^^^^^^^^^ definition local39
 //                                  ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                                          ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                                             ^^^ reference java/util/List#get().
-//                                                                 ^^^^^^^^^^^^^^^^ reference local16
+//                                                                 ^^^^^^^^^^^^^^^^ reference local38
       throw new IllegalStateException("Two models have the same ID. ID's must be unique!"
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:76
 //              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
           + " Model at position " + position + ": " + model
-//                                  ^^^^^^^^ reference local12
-//                                                    ^^^^^ reference local13
+//                                  ^^^^^^^^ reference local34
+//                                                    ^^^^^ reference local35
           + " Model at position " + previousPosition + ": " + previousModel);
-//                                  ^^^^^^^^^^^^^^^^ reference local16
-//                                                            ^^^^^^^^^^^^^ reference local17
+//                                  ^^^^^^^^^^^^^^^^ reference local38
+//                                                            ^^^^^^^^^^^^^ reference local39
     }
 
     return state;
-//         ^^^^^ reference local14
+//         ^^^^^ reference local36
   }
 
   /**
@@ -505,44 +663,44 @@ class DiffHelper {
   private void collectRemovals(UpdateOpHelper helper) {
 //             ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#collectRemovals().
 //                             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                            ^^^^^^ definition local18
+//                                            ^^^^^^ definition local40
     for (ModelState state : oldStateList) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                  ^^^^^ definition local19
+//                  ^^^^^ definition local41
 //                          ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
       // Update the position of the item to take into account previous removals,
       // so that future operations will reference the correct position
       state.position -= helper.getNumRemovals();
-//    ^^^^^ reference local19
+//    ^^^^^ reference local41
 //          ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                      ^^^^^^ reference local18
+//                      ^^^^^^ reference local40
 //                             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#getNumRemovals().
 
       // This is our first time going through the list, so we
       // look up the item with the matching id in the new
       // list and hold a reference to it so that we can access it quickly in the future
       state.pair = currentStateMap.get(state.id);
-//    ^^^^^ reference local19
+//    ^^^^^ reference local41
 //          ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                 ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
 //                                 ^^^ reference java/util/Map#get().
-//                                     ^^^^^ reference local19
+//                                     ^^^^^ reference local41
 //                                           ^^ reference com/airbnb/epoxy/ModelState#id.
       if (state.pair != null) {
-//        ^^^^^ reference local19
+//        ^^^^^ reference local41
 //              ^^^^ reference com/airbnb/epoxy/ModelState#pair.
         state.pair.pair = state;
-//      ^^^^^ reference local19
+//      ^^^^^ reference local41
 //            ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                 ^^^^ reference com/airbnb/epoxy/ModelState#pair.
-//                        ^^^^^ reference local19
+//                        ^^^^^ reference local41
         continue;
       }
 
       helper.remove(state.position);
-//    ^^^^^^ reference local18
+//    ^^^^^^ reference local40
 //           ^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#remove().
-//                  ^^^^^ reference local19
+//                  ^^^^^ reference local41
 //                        ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
     }
   }
@@ -555,42 +713,42 @@ class DiffHelper {
   private void collectInsertions(UpdateOpHelper helper) {
 //             ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#collectInsertions().
 //                               ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                              ^^^^^^ definition local20
+//                                              ^^^^^^ definition local42
     Iterator<ModelState> oldItemIterator = oldStateList.iterator();
 //  ^^^^^^^^ reference java/util/Iterator#
 //           ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                       ^^^^^^^^^^^^^^^ definition local21
+//                       ^^^^^^^^^^^^^^^ definition local43
 //                                         ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
 //                                                      ^^^^^^^^ reference java/util/ArrayList#iterator().
 
     for (ModelState itemToInsert : currentStateList) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                  ^^^^^^^^^^^^ definition local22
+//                  ^^^^^^^^^^^^ definition local44
 //                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
       if (itemToInsert.pair != null) {
-//        ^^^^^^^^^^^^ reference local22
+//        ^^^^^^^^^^^^ reference local44
 //                     ^^^^ reference com/airbnb/epoxy/ModelState#pair.
         // Update the position of the next item in the old list to take any insertions into account
         ModelState nextOldItem = getNextItemWithPair(oldItemIterator);
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                 ^^^^^^^^^^^ definition local23
+//                 ^^^^^^^^^^^ definition local45
 //                               ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#getNextItemWithPair().
-//                                                   ^^^^^^^^^^^^^^^ reference local21
+//                                                   ^^^^^^^^^^^^^^^ reference local43
         if (nextOldItem != null) {
-//          ^^^^^^^^^^^ reference local23
+//          ^^^^^^^^^^^ reference local45
           nextOldItem.position += helper.getNumInsertions();
-//        ^^^^^^^^^^^ reference local23
+//        ^^^^^^^^^^^ reference local45
 //                    ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                ^^^^^^ reference local20
+//                                ^^^^^^ reference local42
 //                                       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#getNumInsertions().
         }
         continue;
       }
 
       helper.add(itemToInsert.position);
-//    ^^^^^^ reference local20
+//    ^^^^^^ reference local42
 //           ^^^ reference com/airbnb/epoxy/UpdateOpHelper#add().
-//               ^^^^^^^^^^^^ reference local22
+//               ^^^^^^^^^^^^ reference local44
 //                            ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
     }
   }
@@ -601,67 +759,67 @@ class DiffHelper {
   private void collectChanges(UpdateOpHelper helper) {
 //             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#collectChanges().
 //                            ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                           ^^^^^^ definition local24
+//                                           ^^^^^^ definition local46
     for (ModelState newItem : currentStateList) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                  ^^^^^^^ definition local25
+//                  ^^^^^^^ definition local47
 //                            ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
       ModelState previousItem = newItem.pair;
 //    ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//               ^^^^^^^^^^^^ definition local26
-//                              ^^^^^^^ reference local25
+//               ^^^^^^^^^^^^ definition local48
+//                              ^^^^^^^ reference local47
 //                                      ^^^^ reference com/airbnb/epoxy/ModelState#pair.
       if (previousItem == null) {
-//        ^^^^^^^^^^^^ reference local26
+//        ^^^^^^^^^^^^ reference local48
         continue;
       }
 
       // We use equals when we know the models are immutable and available, otherwise we have to
       // rely on the stored hashCode
       boolean modelChanged;
-//            ^^^^^^^^^^^^ definition local27
+//            ^^^^^^^^^^^^ definition local49
       if (immutableModels) {
 //        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#immutableModels.
         // Make sure that the old model hasn't changed, otherwise comparing it with the new one
         // won't be accurate.
         if (previousItem.model.isDebugValidationEnabled()) {
-//          ^^^^^^^^^^^^ reference local26
+//          ^^^^^^^^^^^^ reference local48
 //                       ^^^^^ reference com/airbnb/epoxy/ModelState#model.
 //                             ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#isDebugValidationEnabled().
           previousItem.model
-//        ^^^^^^^^^^^^ reference local26
+//        ^^^^^^^^^^^^ reference local48
 //                     ^^^^^ reference com/airbnb/epoxy/ModelState#model.
               .validateStateHasNotChangedSinceAdded("Model was changed before it could be diffed.",
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#validateStateHasNotChangedSinceAdded().
                   previousItem.position);
-//                ^^^^^^^^^^^^ reference local26
+//                ^^^^^^^^^^^^ reference local48
 //                             ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
         }
 
         modelChanged = !previousItem.model.equals(newItem.model);
-//      ^^^^^^^^^^^^ reference local27
-//                      ^^^^^^^^^^^^ reference local26
+//      ^^^^^^^^^^^^ reference local49
+//                      ^^^^^^^^^^^^ reference local48
 //                                   ^^^^^ reference com/airbnb/epoxy/ModelState#model.
 //                                         ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#equals().
-//                                                ^^^^^^^ reference local25
+//                                                ^^^^^^^ reference local47
 //                                                        ^^^^^ reference com/airbnb/epoxy/ModelState#model.
       } else {
         modelChanged = previousItem.hashCode != newItem.hashCode;
-//      ^^^^^^^^^^^^ reference local27
-//                     ^^^^^^^^^^^^ reference local26
+//      ^^^^^^^^^^^^ reference local49
+//                     ^^^^^^^^^^^^ reference local48
 //                                  ^^^^^^^^ reference com/airbnb/epoxy/ModelState#hashCode.
-//                                              ^^^^^^^ reference local25
+//                                              ^^^^^^^ reference local47
 //                                                      ^^^^^^^^ reference com/airbnb/epoxy/ModelState#hashCode.
       }
 
       if (modelChanged) {
-//        ^^^^^^^^^^^^ reference local27
+//        ^^^^^^^^^^^^ reference local49
         helper.update(newItem.position, previousItem.model);
-//      ^^^^^^ reference local24
+//      ^^^^^^ reference local46
 //             ^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#update(+1).
-//                    ^^^^^^^ reference local25
+//                    ^^^^^^^ reference local47
 //                            ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                      ^^^^^^^^^^^^ reference local26
+//                                      ^^^^^^^^^^^^ reference local48
 //                                                   ^^^^^ reference com/airbnb/epoxy/ModelState#model.
       }
     }
@@ -673,31 +831,31 @@ class DiffHelper {
   private void collectMoves(UpdateOpHelper helper) {
 //             ^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#collectMoves().
 //                          ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
-//                                         ^^^^^^ definition local28
+//                                         ^^^^^^ definition local50
     // This walks through both the new and old list simultaneous and checks for position changes.
     Iterator<ModelState> oldItemIterator = oldStateList.iterator();
 //  ^^^^^^^^ reference java/util/Iterator#
 //           ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                       ^^^^^^^^^^^^^^^ definition local29
+//                       ^^^^^^^^^^^^^^^ definition local51
 //                                         ^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#oldStateList.
 //                                                      ^^^^^^^^ reference java/util/ArrayList#iterator().
     ModelState nextOldItem = null;
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//             ^^^^^^^^^^^ definition local30
+//             ^^^^^^^^^^^ definition local52
 
     for (ModelState newItem : currentStateList) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                  ^^^^^^^ definition local31
+//                  ^^^^^^^ definition local53
 //                            ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
       if (newItem.pair == null) {
-//        ^^^^^^^ reference local31
+//        ^^^^^^^ reference local53
 //                ^^^^ reference com/airbnb/epoxy/ModelState#pair.
         // This item was inserted. However, insertions are done at the item's final position, and
         // aren't smart about inserting at a different position to take future moves into account.
         // As the old state list is updated to reflect moves, it needs to also consider insertions
         // affected by those moves in order for the final change set to be correct
         if (helper.moves.isEmpty()) {
-//          ^^^^^^ reference local28
+//          ^^^^^^ reference local50
 //                 ^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#moves.
 //                       ^^^^^^^ reference java/util/List#isEmpty().
           // There have been no moves, so the item is still at it's correct position
@@ -708,7 +866,7 @@ class DiffHelper {
           // (for optimization purposes), but we can create a pair for this item to
           // track its position in the old list and move it back to its final position if necessary
           newItem.pairWithSelf();
-//        ^^^^^^^ reference local31
+//        ^^^^^^^ reference local53
 //                ^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#pairWithSelf().
         }
       }
@@ -724,129 +882,129 @@ class DiffHelper {
       // already iterated through are guaranteed to have their pair
       // be already in the right spot, which won't be affected by future MOVEs.
       if (nextOldItem == null) {
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
         nextOldItem = getNextItemWithPair(oldItemIterator);
-//      ^^^^^^^^^^^ reference local30
+//      ^^^^^^^^^^^ reference local52
 //                    ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#getNextItemWithPair().
-//                                        ^^^^^^^^^^^^^^^ reference local29
+//                                        ^^^^^^^^^^^^^^^ reference local51
 
         // We've already iterated through all old items and moved each
         // item once. However, subsequent moves may have shifted an item out of
         // its correct space once it was already moved. We finish
         // iterating through all the new items to ensure everything is still correct
         if (nextOldItem == null) {
-//          ^^^^^^^^^^^ reference local30
+//          ^^^^^^^^^^^ reference local52
           nextOldItem = newItem.pair;
-//        ^^^^^^^^^^^ reference local30
-//                      ^^^^^^^ reference local31
+//        ^^^^^^^^^^^ reference local52
+//                      ^^^^^^^ reference local53
 //                              ^^^^ reference com/airbnb/epoxy/ModelState#pair.
         }
       }
 
       while (nextOldItem != null) {
-//           ^^^^^^^^^^^ reference local30
+//           ^^^^^^^^^^^ reference local52
         // Make sure the positions are updated to the latest
         // move operations before we calculate the next move
         updateItemPosition(newItem.pair, helper.moves);
 //      ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#updateItemPosition().
-//                         ^^^^^^^ reference local31
+//                         ^^^^^^^ reference local53
 //                                 ^^^^ reference com/airbnb/epoxy/ModelState#pair.
-//                                       ^^^^^^ reference local28
+//                                       ^^^^^^ reference local50
 //                                              ^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#moves.
         updateItemPosition(nextOldItem, helper.moves);
 //      ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#updateItemPosition().
-//                         ^^^^^^^^^^^ reference local30
-//                                      ^^^^^^ reference local28
+//                         ^^^^^^^^^^^ reference local52
+//                                      ^^^^^^ reference local50
 //                                             ^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#moves.
 
         // The item is the same and its already in the correct place
         if (newItem.id == nextOldItem.id && newItem.position == nextOldItem.position) {
-//          ^^^^^^^ reference local31
+//          ^^^^^^^ reference local53
 //                  ^^ reference com/airbnb/epoxy/ModelState#id.
-//                        ^^^^^^^^^^^ reference local30
+//                        ^^^^^^^^^^^ reference local52
 //                                    ^^ reference com/airbnb/epoxy/ModelState#id.
-//                                          ^^^^^^^ reference local31
+//                                          ^^^^^^^ reference local53
 //                                                  ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                                              ^^^^^^^^^^^ reference local30
+//                                                              ^^^^^^^^^^^ reference local52
 //                                                                          ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
           nextOldItem = null;
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
           break;
         }
 
         int newItemDistance = newItem.pair.position - newItem.position;
-//          ^^^^^^^^^^^^^^^ definition local32
-//                            ^^^^^^^ reference local31
+//          ^^^^^^^^^^^^^^^ definition local54
+//                            ^^^^^^^ reference local53
 //                                    ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                                         ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                                    ^^^^^^^ reference local31
+//                                                    ^^^^^^^ reference local53
 //                                                            ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
         int oldItemDistance = nextOldItem.pair.position - nextOldItem.position;
-//          ^^^^^^^^^^^^^^^ definition local33
-//                            ^^^^^^^^^^^ reference local30
+//          ^^^^^^^^^^^^^^^ definition local55
+//                            ^^^^^^^^^^^ reference local52
 //                                        ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                                             ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                                        ^^^^^^^^^^^ reference local30
+//                                                        ^^^^^^^^^^^ reference local52
 //                                                                    ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
 
         // Both items are already in the correct position
         if (newItemDistance == 0 && oldItemDistance == 0) {
-//          ^^^^^^^^^^^^^^^ reference local32
-//                                  ^^^^^^^^^^^^^^^ reference local33
+//          ^^^^^^^^^^^^^^^ reference local54
+//                                  ^^^^^^^^^^^^^^^ reference local55
           nextOldItem = null;
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
           break;
         }
 
         if (oldItemDistance > newItemDistance) {
-//          ^^^^^^^^^^^^^^^ reference local33
-//                            ^^^^^^^^^^^^^^^ reference local32
+//          ^^^^^^^^^^^^^^^ reference local55
+//                            ^^^^^^^^^^^^^^^ reference local54
           helper.move(nextOldItem.position, nextOldItem.pair.position);
-//        ^^^^^^ reference local28
+//        ^^^^^^ reference local50
 //               ^^^^ reference com/airbnb/epoxy/UpdateOpHelper#move().
-//                    ^^^^^^^^^^^ reference local30
+//                    ^^^^^^^^^^^ reference local52
 //                                ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                          ^^^^^^^^^^^ reference local30
+//                                          ^^^^^^^^^^^ reference local52
 //                                                      ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                                                           ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
 
           nextOldItem.position = nextOldItem.pair.position;
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
 //                    ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                               ^^^^^^^^^^^ reference local30
+//                               ^^^^^^^^^^^ reference local52
 //                                           ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                                                ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
           nextOldItem.lastMoveOp = helper.getNumMoves();
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#lastMoveOp.
-//                                 ^^^^^^ reference local28
+//                                 ^^^^^^ reference local50
 //                                        ^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#getNumMoves().
 
           nextOldItem = getNextItemWithPair(oldItemIterator);
-//        ^^^^^^^^^^^ reference local30
+//        ^^^^^^^^^^^ reference local52
 //                      ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#getNextItemWithPair().
-//                                          ^^^^^^^^^^^^^^^ reference local29
+//                                          ^^^^^^^^^^^^^^^ reference local51
         } else {
           helper.move(newItem.pair.position, newItem.position);
-//        ^^^^^^ reference local28
+//        ^^^^^^ reference local50
 //               ^^^^ reference com/airbnb/epoxy/UpdateOpHelper#move().
-//                    ^^^^^^^ reference local31
+//                    ^^^^^^^ reference local53
 //                            ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                                 ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                           ^^^^^^^ reference local31
+//                                           ^^^^^^^ reference local53
 //                                                   ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
 
           newItem.pair.position = newItem.position;
-//        ^^^^^^^ reference local31
+//        ^^^^^^^ reference local53
 //                ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                     ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                ^^^^^^^ reference local31
+//                                ^^^^^^^ reference local53
 //                                        ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
           newItem.pair.lastMoveOp = helper.getNumMoves();
-//        ^^^^^^^ reference local31
+//        ^^^^^^^ reference local53
 //                ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //                     ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#lastMoveOp.
-//                                  ^^^^^^ reference local28
+//                                  ^^^^^^ reference local50
 //                                         ^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#getNumMoves().
           break;
         }
@@ -862,64 +1020,64 @@ class DiffHelper {
   private void updateItemPosition(ModelState item, List<UpdateOp> moveOps) {
 //             ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#updateItemPosition().
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                                           ^^^^ definition local34
+//                                           ^^^^ definition local56
 //                                                 ^^^^ reference java/util/List#
 //                                                      ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
-//                                                                ^^^^^^^ definition local35
+//                                                                ^^^^^^^ definition local57
     int size = moveOps.size();
-//      ^^^^ definition local36
-//             ^^^^^^^ reference local35
+//      ^^^^ definition local58
+//             ^^^^^^^ reference local57
 //                     ^^^^ reference java/util/List#size().
 
     for (int i = item.lastMoveOp; i < size; i++) {
-//           ^ definition local37
-//               ^^^^ reference local34
+//           ^ definition local59
+//               ^^^^ reference local56
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#lastMoveOp.
-//                                ^ reference local37
-//                                    ^^^^ reference local36
-//                                          ^ reference local37
+//                                ^ reference local59
+//                                    ^^^^ reference local58
+//                                          ^ reference local59
       UpdateOp moveOp = moveOps.get(i);
 //    ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
-//             ^^^^^^ definition local38
-//                      ^^^^^^^ reference local35
+//             ^^^^^^ definition local60
+//                      ^^^^^^^ reference local57
 //                              ^^^ reference java/util/List#get().
-//                                  ^ reference local37
+//                                  ^ reference local59
       int fromPosition = moveOp.positionStart;
-//        ^^^^^^^^^^^^ definition local39
-//                       ^^^^^^ reference local38
+//        ^^^^^^^^^^^^ definition local61
+//                       ^^^^^^ reference local60
 //                              ^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#positionStart.
       int toPosition = moveOp.itemCount;
-//        ^^^^^^^^^^ definition local40
-//                     ^^^^^^ reference local38
+//        ^^^^^^^^^^ definition local62
+//                     ^^^^^^ reference local60
 //                            ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
 
       if (item.position > fromPosition && item.position <= toPosition) {
-//        ^^^^ reference local34
+//        ^^^^ reference local56
 //             ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                        ^^^^^^^^^^^^ reference local39
-//                                        ^^^^ reference local34
+//                        ^^^^^^^^^^^^ reference local61
+//                                        ^^^^ reference local56
 //                                             ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                                         ^^^^^^^^^^ reference local40
+//                                                         ^^^^^^^^^^ reference local62
         item.position--;
-//      ^^^^ reference local34
+//      ^^^^ reference local56
 //           ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
       } else if (item.position < fromPosition && item.position >= toPosition) {
-//               ^^^^ reference local34
+//               ^^^^ reference local56
 //                    ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                               ^^^^^^^^^^^^ reference local39
-//                                               ^^^^ reference local34
+//                               ^^^^^^^^^^^^ reference local61
+//                                               ^^^^ reference local56
 //                                                    ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                                                ^^^^^^^^^^ reference local40
+//                                                                ^^^^^^^^^^ reference local62
         item.position++;
-//      ^^^^ reference local34
+//      ^^^^ reference local56
 //           ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
       }
     }
 
     item.lastMoveOp = size;
-//  ^^^^ reference local34
+//  ^^^^ reference local56
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#lastMoveOp.
-//                    ^^^^ reference local36
+//                    ^^^^ reference local58
   }
 
   /**
@@ -932,29 +1090,29 @@ class DiffHelper {
 //                   ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#getNextItemWithPair().
 //                                       ^^^^^^^^ reference java/util/Iterator#
 //                                                ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                                                            ^^^^^^^^ definition local41
+//                                                            ^^^^^^^^ definition local63
     ModelState nextItem = null;
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//             ^^^^^^^^ definition local42
+//             ^^^^^^^^ definition local64
     while (nextItem == null && iterator.hasNext()) {
-//         ^^^^^^^^ reference local42
-//                             ^^^^^^^^ reference local41
+//         ^^^^^^^^ reference local64
+//                             ^^^^^^^^ reference local63
 //                                      ^^^^^^^ reference java/util/Iterator#hasNext().
       nextItem = iterator.next();
-//    ^^^^^^^^ reference local42
-//               ^^^^^^^^ reference local41
+//    ^^^^^^^^ reference local64
+//               ^^^^^^^^ reference local63
 //                        ^^^^ reference java/util/Iterator#next().
 
       if (nextItem.pair == null) {
-//        ^^^^^^^^ reference local42
+//        ^^^^^^^^ reference local64
 //                 ^^^^ reference com/airbnb/epoxy/ModelState#pair.
         // Skip this one and go on to the next
         nextItem = null;
-//      ^^^^^^^^ reference local42
+//      ^^^^^^^^ reference local64
       }
     }
 
     return nextItem;
-//         ^^^^^^^^ reference local42
+//         ^^^^^^^^ reference local64
   }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
@@ -81,7 +81,7 @@ public class DiffPayload {
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#modelsById.
 //                 ^^^ reference androidx/collection/LongSparseArray#put().
 //                     ^^^^^ reference local2
-//                           ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                           ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                                 ^^^^^ reference local2
       }
     }
@@ -134,7 +134,7 @@ public class DiffPayload {
         if (diffPayload.singleModel.id() == modelId) {
 //          ^^^^^^^^^^^ reference local7
 //                      ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#singleModel.
-//                                  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                  ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                                          ^^^^^^^ reference local5
           return diffPayload.singleModel;
 //               ^^^^^^^^^^^ reference local7

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
@@ -191,6 +191,7 @@ public class DiffResult {
 //                               ^^^^^^^ definition local9
     dispatchTo(new AdapterListUpdateCallback(adapter));
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#dispatchTo().
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^ reference _root_/
 //                                           ^^^^^^^ reference local9
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -107,6 +107,7 @@ public final class EpoxyAsyncUtil {
     if (!async) {
 //       ^^^^^ reference local1
       return new Handler(looper);
+//           ^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //               ^^^^^^^ reference _root_/
 //                       ^^^^^^ reference local0
     }
@@ -148,6 +149,7 @@ public final class EpoxyAsyncUtil {
     }
 
     return new Handler(looper);
+//         ^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //             ^^^^^^^ reference _root_/
 //                     ^^^^^^ reference local0
   }
@@ -163,6 +165,7 @@ public final class EpoxyAsyncUtil {
     HandlerThread handlerThread = new HandlerThread(threadName);
 //  ^^^^^^^^^^^^^ reference _root_/
 //                ^^^^^^^^^^^^^ definition local4
+//                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //                                    ^^^^^^^^^^^^^ reference _root_/
 //                                                  ^^^^^^^^^^ reference local3
     handlerThread.start();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -605,7 +605,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     int size = modelsBeingBuilt.size();
 //      ^^^^ definition local8
 //             ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                              ^^^^ reference java/util/ArrayList#size(+1).
+//                              ^^^^ reference java/util/ArrayList#size().
     for (int i = 0; i < size; i++) {
 //           ^ definition local9
 //                  ^ reference local9
@@ -636,7 +636,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     int size = modelsBeingBuilt.size();
 //      ^^^^ definition local12
 //             ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                              ^^^^ reference java/util/ArrayList#size(+1).
+//                              ^^^^ reference java/util/ArrayList#size().
     for (int i = 0; i < size; i++) {
 //           ^ definition local13
 //                  ^ reference local13
@@ -816,7 +816,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //  ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#assertIsBuildingModels().
     return modelsBeingBuilt.size();
 //         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                          ^^^^ reference java/util/ArrayList#size(+1).
+//                          ^^^^ reference java/util/ArrayList#size().
   }
 
   private void assertIsBuildingModels() {
@@ -867,7 +867,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
 //                   ^^^^^^^^^^^^^^ reference java/util/ArrayList#ensureCapacity().
 //                                  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                                                   ^^^^ reference java/util/ArrayList#size(+1).
+//                                                   ^^^^ reference java/util/ArrayList#size().
 //                                                            ^^^^^^^^^^^ reference local24
 //                                                                        ^^^^^^ reference length.
 
@@ -895,7 +895,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
 //                   ^^^^^^^^^^^^^^ reference java/util/ArrayList#ensureCapacity().
 //                                  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                                                   ^^^^ reference java/util/ArrayList#size(+1).
+//                                                   ^^^^ reference java/util/ArrayList#size().
 //                                                            ^^^^^^^^^^^ reference local26
 //                                                                        ^^^^ reference java/util/List#size().
 
@@ -922,7 +922,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 
     if (modelToAdd.hasDefaultId()) {
 //      ^^^^^^^^^^ reference local28
-//                 ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hasDefaultId(+1).
+//                 ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hasDefaultId().
       throw new IllegalEpoxyUsage(
 //          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 2:68
 //              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
@@ -1056,7 +1056,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //         ^^^^^^^^ reference local32
 //                  ^^^ reference java/util/Set#add().
 //                      ^^^^^ reference local34
-//                            ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                            ^^ reference com/airbnb/epoxy/EpoxyModel#id().
         int indexOfDuplicate = modelIterator.previousIndex();
 //          ^^^^^^^^^^^^^^^^ definition local35
 //                             ^^^^^^^^^^^^^ reference local33
@@ -1128,9 +1128,9 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                                     ^ reference local41
       if (model.id() == duplicateModel.id()) {
 //        ^^^^^ reference local42
-//              ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//              ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                      ^^^^^^^^^^^^^^ reference local39
-//                                     ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                     ^^ reference com/airbnb/epoxy/EpoxyModel#id().
         return i;
 //             ^ reference local41
       }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -432,7 +432,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                             ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
       if (model.id() == id) {
 //        ^^^^^ reference local23
-//              ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//              ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                      ^^ reference local22
         return model;
 //             ^^^^^ reference local23
@@ -466,9 +466,9 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                                 ^ reference local26
       if (model.id() == targetModel.id()) {
 //        ^^^^^ reference local27
-//              ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//              ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                      ^^^^^^^^^^^ reference local24
-//                                  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                  ^^ reference com/airbnb/epoxy/EpoxyModel#id().
         return i;
 //             ^ reference local26
       }
@@ -505,7 +505,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 
     updatedList.add(toPosition, updatedList.remove(fromPosition));
 //  ^^^^^^^^^^^ reference local30
-//              ^^^ reference java/util/ArrayList#add(+1).
+//              ^^^ reference java/util/ArrayList#add(+2).
 //                  ^^^^^^^^^^ reference local29
 //                              ^^^^^^^^^^^ reference local30
 //                                          ^^^^^^ reference java/util/ArrayList#remove().
@@ -581,21 +581,53 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                 ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#ITEM_CALLBACK.
       new ItemCallback<EpoxyModel<?>>() {
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 15:7
+//        ^^^^^^^^^^^^ reference _root_/
 //        ^^^^^^^^^^^^ reference _root_/
 //                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
         @Override
+//       ^^^^^^^^ reference java/lang/Override#
         public boolean areItemsTheSame(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
+//                     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#ITEM_CALLBACK.``#areItemsTheSame().
+//                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                   ^^^^^^^ definition local35
+//                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                                          ^^^^^^^ definition local36
           return oldItem.id() == newItem.id();
+//               ^^^^^^^ reference local35
+//                       ^^ reference com/airbnb/epoxy/EpoxyModel#id().
+//                               ^^^^^^^ reference local36
+//                                       ^^ reference com/airbnb/epoxy/EpoxyModel#id().
         }
 
         @Override
+//       ^^^^^^^^ reference java/lang/Override#
         public boolean areContentsTheSame(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
+//                     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#ITEM_CALLBACK.``#areContentsTheSame().
+//                                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                      ^^^^^^^ definition local37
+//                                                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                                             ^^^^^^^ definition local38
           return oldItem.equals(newItem);
+//               ^^^^^^^ reference local37
+//                       ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#equals().
+//                              ^^^^^^^ reference local38
         }
 
         @Override
+//       ^^^^^^^^ reference java/lang/Override#
         public Object getChangePayload(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
+//             ^^^^^^ reference java/lang/Object#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#ITEM_CALLBACK.``#getChangePayload().
+//                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                   ^^^^^^^ definition local39
+//                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//                                                                          ^^^^^^^ definition local40
           return new DiffPayload(oldItem);
+//               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`(+1).
+//                   ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#
+//                               ^^^^^^^ reference local39
         }
       };
 
@@ -607,11 +639,11 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    ^^^^^^^^ reference java/lang/Override#
   public boolean isStickyHeader(int position) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#isStickyHeader().
-//                                  ^^^^^^^^ definition local35
+//                                  ^^^^^^^^ definition local41
     return epoxyController.isStickyHeader(position);
 //         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#epoxyController.
 //                         ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isStickyHeader().
-//                                        ^^^^^^^^ reference local35
+//                                        ^^^^^^^^ reference local41
   }
 
   /**
@@ -624,11 +656,11 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //            ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#setupStickyHeaderView().
 //                                   ^^^^^^^ reference org/jetbrains/annotations/NotNull#
 //                                           ^^^^ reference _root_/
-//                                                ^^^^^^^^^^^^ definition local36
+//                                                ^^^^^^^^^^^^ definition local42
     epoxyController.setupStickyHeaderView(stickyHeader);
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#epoxyController.
 //                  ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#setupStickyHeaderView().
-//                                        ^^^^^^^^^^^^ reference local36
+//                                        ^^^^^^^^^^^^ reference local42
   }
 
   /**
@@ -641,10 +673,10 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference org/jetbrains/annotations/NotNull#
 //                                              ^^^^ reference _root_/
-//                                                   ^^^^^^^^^^^^ definition local37
+//                                                   ^^^^^^^^^^^^ definition local43
     epoxyController.teardownStickyHeaderView(stickyHeader);
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#epoxyController.
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#teardownStickyHeaderView().
-//                                           ^^^^^^^^^^^^ reference local37
+//                                           ^^^^^^^^^^^^ reference local43
   }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
@@ -294,7 +294,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
 //                                            ^^^^^^^^^ reference local22
       isInFirstRow = isInFirstRow(position, spanSizeLookup, spanCount);
 //    ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow.
-//                   ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow(+1).
+//                   ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow().
 //                                ^^^^^^^^ reference local16
 //                                          ^^^^^^^^^^^^^^ reference local20
 //                                                          ^^^^^^^^^ reference local22
@@ -302,7 +302,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
 //    ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow.
           !isInFirstRow && isInLastRow(position, itemCount, spanSizeLookup, spanCount);
 //         ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow.
-//                         ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow(+1).
+//                         ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow().
 //                                     ^^^^^^^^ reference local16
 //                                               ^^^^^^^^^ reference local18
 //                                                          ^^^^^^^^^^^^^^ reference local20
@@ -411,7 +411,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
   }
 
   private static boolean isInFirstRow(int position, SpanSizeLookup spanSizeLookup, int spanCount) {
-//                       ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow(+1).
+//                       ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInFirstRow().
 //                                        ^^^^^^^^ definition local28
 //                                                  ^^^^^^^^^^^^^^ reference _root_/
 //                                                                 ^^^^^^^^^^^^^^ definition local29
@@ -439,7 +439,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
   }
 
   private static boolean isInLastRow(int position, int itemCount, SpanSizeLookup spanSizeLookup,
-//                       ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow(+1).
+//                       ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow().
 //                                       ^^^^^^^^ definition local33
 //                                                     ^^^^^^^^^ definition local34
 //                                                                ^^^^^^^^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -130,7 +130,7 @@ public abstract class EpoxyModel<T> {
 //          ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#`<init>`().
 //                          ^^ definition local0
     id(id);
-//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //     ^^ reference local0
   }
 
@@ -144,7 +144,7 @@ public abstract class EpoxyModel<T> {
   }
 
   boolean hasDefaultId() {
-//        ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#hasDefaultId(+1).
+//        ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#hasDefaultId().
     return hasDefaultId;
 //         ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hasDefaultId.
   }
@@ -323,7 +323,7 @@ public abstract class EpoxyModel<T> {
   }
 
   public long id() {
-//            ^^ definition com/airbnb/epoxy/EpoxyModel#id(+1).
+//            ^^ definition com/airbnb/epoxy/EpoxyModel#id().
     return id;
 //         ^^ reference com/airbnb/epoxy/EpoxyModel#id.
   }
@@ -336,7 +336,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(long id) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+2).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+1).
 //                             ^^ definition local15
     if ((addedToAdapter || firstControllerAddedTo != null) && id != this.id) {
 //       ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#addedToAdapter.
@@ -369,7 +369,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(@Nullable Number... ids) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+3).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+2).
 //                         ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                  ^^^^^^ reference java/lang/Number#
 //                                            ^^^ definition local16
@@ -392,7 +392,7 @@ public abstract class EpoxyModel<T> {
       }
     }
     return id(result);
-//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //            ^^^^^^ reference local17
   }
 
@@ -405,7 +405,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(long id1, long id2) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+4).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+3).
 //                             ^^^ definition local19
 //                                       ^^^ definition local20
     long result = hashLong64Bit(id1);
@@ -418,7 +418,7 @@ public abstract class EpoxyModel<T> {
 //                         ^^^^^^^^^^^^^ reference com/airbnb/epoxy/IdUtils#hashLong64Bit().
 //                                       ^^^ reference local20
     return id(result);
-//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //            ^^^^^^ reference local21
   }
 
@@ -437,12 +437,12 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(@Nullable CharSequence key) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+5).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+4).
 //                         ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                  ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                               ^^^ definition local22
     id(hashString64Bit(key));
-//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //     ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IdUtils#hashString64Bit().
 //                     ^^^ reference local22
     return this;
@@ -457,7 +457,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(@Nullable CharSequence key, @Nullable CharSequence... otherKeys) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+6).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+5).
 //                         ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                  ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                               ^^^ definition local23
@@ -482,7 +482,7 @@ public abstract class EpoxyModel<T> {
       }
     }
     return id(result);
-//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//         ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //            ^^^^^^ reference local25
   }
 
@@ -501,7 +501,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> id(@Nullable CharSequence key, long id) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+7).
+//                     ^^ definition com/airbnb/epoxy/EpoxyModel#id(+6).
 //                         ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                  ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                               ^^^ definition local27
@@ -516,7 +516,7 @@ public abstract class EpoxyModel<T> {
 //                         ^^^^^^^^^^^^^ reference com/airbnb/epoxy/IdUtils#hashLong64Bit().
 //                                       ^^ reference local28
     id(result);
-//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //     ^^^^^^ reference local29
     return this;
 //         ^^^^ reference com/airbnb/epoxy/EpoxyModel#this.
@@ -543,7 +543,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> layout(@LayoutRes int layoutRes) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#layout(+1).
+//                     ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#layout().
 //                             ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                           ^^^^^^^^^ definition local30
     onMutation();
@@ -925,7 +925,7 @@ public abstract class EpoxyModel<T> {
   public EpoxyModel<T> spanSizeOverride(@Nullable SpanSizeOverrideCallback spanSizeCallback) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
-//                     ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#spanSizeOverride(+1).
+//                     ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#spanSizeOverride().
 //                                       ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                                ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#SpanSizeOverrideCallback#
 //                                                                         ^^^^^^^^^^^^^^^^ definition local49

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -178,13 +178,13 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //       ^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#models.
 //                ^^^^^^ reference local5
     layout(layoutRes);
-//  ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#layout(+1).
+//  ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#layout().
 //         ^^^^^^^^^ reference local4
     id(models.get(0).id());
-//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+2).
+//  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
 //     ^^^^^^ reference local5
 //            ^^^ reference java/util/List#get().
-//                   ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                   ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 
     boolean saveState = false;
 //          ^^^^^^^^^ definition local6
@@ -229,7 +229,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
     this();
 //  ^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+3).
     layout(layoutRes);
-//  ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#layout(+1).
+//  ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#layout().
 //         ^^^^^^^^^ reference local8
   }
 
@@ -393,9 +393,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                                                               ^^^^^^^^^^ reference local24
           if (previousModel.id() == model.id()) {
 //            ^^^^^^^^^^^^^ reference local25
-//                          ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                          ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                                  ^^^^^ reference local22
-//                                        ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                        ^^ reference com/airbnb/epoxy/EpoxyModel#id().
             viewHolder.bind(model, previousModel, Collections.emptyList(), modelIndex);
 //          ^^^^^^^^^^ reference local23
 //                     ^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#bind().
@@ -602,7 +602,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModelGroup shouldSaveViewState(boolean shouldSaveViewState) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#
-//                       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+1).
+//                       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState().
 //                                                   ^^^^^^^^^^^^^^^^^^^ definition local47
     onMutation();
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#onMutation().
@@ -617,7 +617,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   @Override
    ^^^^^^^^ reference java/lang/Override#
   public boolean shouldSaveViewState() {
-//               ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+2).
+//               ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+1).
     // By default state is saved if any of the models have saved state enabled.
     // Override this if you need custom behavior.
     if (shouldSaveViewState != null) {
@@ -656,6 +656,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                                                          ^^^^^^^^^^ reference _root_/
 //                                                                     ^^^^^^ definition local50
     return new ModelGroupHolder(parent);
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //             ^^^^^^^^^^^^^^^^ reference _root_/
 //                              ^^^^^^ reference local50
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -406,6 +406,7 @@ public abstract class EpoxyTouchHelper {
 //    ^^^^^^^^^^^^^^^ reference _root_/
 //                    ^^^^^^^^^^^^^^^ definition local18
           new ItemTouchHelper(new EpoxyModelTouchCallback<U>(controller, targetModelClass) {
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`# 37:12
 //            ^^^^^^^^^^^^^^^ reference _root_/
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#andCallbacks().``#`<init>`(). 37:11
 //                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#
@@ -883,6 +884,7 @@ public abstract class EpoxyTouchHelper {
 //    ^^^^^^^^^^^^^^^ reference _root_/
 //                    ^^^^^^^^^^^^^^^ definition local64
           new ItemTouchHelper(new EpoxyModelTouchCallback<U>(null, targetModelClass) {
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`# 42:12
 //            ^^^^^^^^^^^^^^^ reference _root_/
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#andCallbacks().``#`<init>`(). 42:11
 //                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
@@ -161,9 +161,9 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 
     if (previousModel.id() != element.id()) {
 //      ^^^^^^^^^^^^^ reference local12
-//                    ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                    ^^ reference com/airbnb/epoxy/EpoxyModel#id().
 //                            ^^^^^^^ reference local11
-//                                    ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                                    ^^ reference com/airbnb/epoxy/EpoxyModel#id().
       notifyRemoval(index, 1);
 //    ^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notifyRemoval().
 //                  ^^^^^ reference local10
@@ -184,10 +184,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                 ^^^^^^^^^^ definition local13
     notifyInsertion(size(), 1);
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notifyInsertion().
-//                  ^^^^ reference java/util/ArrayList#size(+1).
+//                  ^^^^ reference java/util/ArrayList#size().
     return super.add(epoxyModel);
 //         ^^^^^ reference com/airbnb/epoxy/ModelList#super.
-//               ^^^ reference java/util/ArrayList#add().
+//               ^^^ reference java/util/ArrayList#add(+1).
 //                   ^^^^^^^^^^ reference local13
   }
 
@@ -203,7 +203,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                  ^^^^^ reference local14
     super.add(index, element);
 //  ^^^^^ reference com/airbnb/epoxy/ModelList#super.
-//        ^^^ reference java/util/ArrayList#add(+1).
+//        ^^^ reference java/util/ArrayList#add(+2).
 //            ^^^^^ reference local14
 //                   ^^^^^^^ reference local15
   }
@@ -217,7 +217,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                                          ^ definition local16
     notifyInsertion(size(), c.size());
 //  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notifyInsertion().
-//                  ^^^^ reference java/util/ArrayList#size(+1).
+//                  ^^^^ reference java/util/ArrayList#size().
 //                          ^ reference local16
 //                            ^^^^ reference java/util/Collection#size().
     return super.addAll(c);
@@ -295,7 +295,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //       ^^^^^^^ reference java/util/ArrayList#isEmpty().
       notifyRemoval(0, size());
 //    ^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notifyRemoval().
-//                     ^^^^ reference java/util/ArrayList#size(+1).
+//                     ^^^^ reference java/util/ArrayList#size().
       super.clear();
 //    ^^^^^ reference com/airbnb/epoxy/ModelList#super.
 //          ^^^^^ reference java/util/ArrayList#clear().
@@ -430,7 +430,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                 ^^^^^^^ definition com/airbnb/epoxy/ModelList#Itr#hasNext().
       return cursor != size();
 //           ^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#cursor.
-//                     ^^^^ reference java/util/ArrayList#size(+1).
+//                     ^^^^ reference java/util/ArrayList#size().
     }
 
     @SuppressWarnings("unchecked")
@@ -674,7 +674,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
     if (start >= 0 && end <= size()) {
 //      ^^^^^ reference local40
 //                    ^^^ reference local41
-//                           ^^^^ reference java/util/ArrayList#size(+1).
+//                           ^^^^ reference java/util/ArrayList#size().
       if (start <= end) {
 //        ^^^^^ reference local40
 //                 ^^^ reference local41
@@ -1195,7 +1195,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public int size() {
-//             ^^^^ definition com/airbnb/epoxy/ModelList#SubList#size(+1).
+//             ^^^^ definition com/airbnb/epoxy/ModelList#SubList#size().
       if (modCount == fullList.modCount) {
 //        ^^^^^^^^ reference java/util/AbstractList#modCount.
 //                    ^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#fullList.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
@@ -57,7 +57,7 @@ class ModelState {
 //  ^^^^^ reference local3
 //        ^^ reference com/airbnb/epoxy/ModelState#id.
 //             ^^^^^ reference local0
-//                   ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
+//                   ^^ reference com/airbnb/epoxy/EpoxyModel#id().
     state.position = position;
 //  ^^^^^ reference local3
 //        ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
@@ -151,7 +151,7 @@ public class QuantityStringResAttribute {
     // Probably incorrect - comparing Object[] arrays with Arrays.equals
     return Arrays.equals(formatArgs, that.formatArgs);
 //         ^^^^^^ reference java/util/Arrays#
-//                ^^^^^^ reference java/util/Arrays#equals(+8).
+//                ^^^^^^ reference java/util/Arrays#equals(+16).
 //                       ^^^^^^^^^^ reference com/airbnb/epoxy/QuantityStringResAttribute#formatArgs.
 //                                   ^^^^ reference local7
 //                                        ^^^^^^^^^^ reference com/airbnb/epoxy/QuantityStringResAttribute#formatArgs.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
@@ -302,7 +302,7 @@ public class StringAttributeData {
 
     return Arrays.equals(formatArgs, that.formatArgs);
 //         ^^^^^^ reference java/util/Arrays#
-//                ^^^^^^ reference java/util/Arrays#equals(+8).
+//                ^^^^^^ reference java/util/Arrays#equals(+16).
 //                       ^^^^^^^^^^ reference com/airbnb/epoxy/StringAttributeData#formatArgs.
 //                                   ^^^^ reference local11
 //                                        ^^^^^^^^^^ reference com/airbnb/epoxy/StringAttributeData#formatArgs.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -161,7 +161,7 @@ class UpdateOp {
 //                   ^^^^^^^^^ reference java/util/ArrayList#
     } else if (payloads.size() == 1) {
 //             ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
-//                      ^^^^ reference java/util/ArrayList#size(+1).
+//                      ^^^^ reference java/util/ArrayList#size().
       // There are multiple payloads, but we don't know how big the batch will end up being.
       // To prevent resizing the list many times we bump it to a medium size
       payloads.ensureCapacity(10);
@@ -171,7 +171,7 @@ class UpdateOp {
 
     payloads.add(payload);
 //  ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
-//           ^^^ reference java/util/ArrayList#add().
+//           ^^^ reference java/util/ArrayList#add(+1).
 //               ^^^^^^^ reference local8
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -118,34 +118,73 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                    ^^^^^^^ reference _root_/
 //                            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                                             ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#CREATOR.
+//                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 18:3
 //                                                           ^^^^^^^ reference _root_/
+//                                                           ^^^^^^^ reference _root_/
+//                                                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                                                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 
     public ViewHolderState[] newArray(int size) {
+//         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                           ^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#CREATOR.``#newArray().
+//                                        ^^^^ definition local5
       return new ViewHolderState[size];
+//               ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                               ^^^^ reference local5
     }
 
     public ViewHolderState createFromParcel(Parcel source) {
+//         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                         ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#CREATOR.``#createFromParcel().
+//                                          ^^^^^^ reference _root_/
+//                                                 ^^^^^^ definition local6
       int size = source.readInt();
+//        ^^^^ definition local7
+//               ^^^^^^ reference local6
+//                      ^^^^^^^ reference readInt#
       ViewHolderState state = new ViewHolderState(size);
+//    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                    ^^^^^ definition local8
+//                            ^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#`<init>`(+1).
+//                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                                                ^^^^ reference local7
 
       for (int i = 0; i < size; i++) {
+//             ^ definition local9
+//                    ^ reference local9
+//                        ^^^^ reference local7
+//                              ^ reference local9
         long key = source.readLong();
+//           ^^^ definition local10
+//                 ^^^^^^ reference local6
+//                        ^^^^^^^^ reference readLong#
         ViewState value = source.readParcelable(ViewState.class.getClassLoader());
+//      ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                ^^^^^ definition local11
+//                        ^^^^^^ reference local6
+//                               ^^^^^^^^^^^^^^ reference readParcelable#
+//                                              ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                                                        ^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#class.
+//                                                              ^^^^^^^^^^^^^^ reference java/lang/Class#getClassLoader().
         state.put(key, value);
+//      ^^^^^ reference local8
+//            ^^^ reference androidx/collection/LongSparseArray#put().
+//                ^^^ reference local10
+//                     ^^^^^ reference local11
       }
 
       return state;
+//           ^^^^^ reference local8
     }
   };
 
   public boolean hasStateForHolder(EpoxyViewHolder holder) {
 //               ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#hasStateForHolder().
 //                                 ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                                 ^^^^^^ definition local5
+//                                                 ^^^^^^ definition local12
     return get(holder.getItemId()) != null;
 //         ^^^ reference androidx/collection/LongSparseArray#get().
-//             ^^^^^^ reference local5
+//             ^^^^^^ reference local12
 //                    ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getItemId#
   }
 
@@ -153,14 +192,14 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //            ^^^^ definition com/airbnb/epoxy/ViewHolderState#save().
 //                 ^^^^^^^^^^ reference java/util/Collection#
 //                            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                             ^^^^^^^ definition local6
+//                                             ^^^^^^^ definition local13
     for (EpoxyViewHolder holder : holders) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                       ^^^^^^ definition local7
-//                                ^^^^^^^ reference local6
+//                       ^^^^^^ definition local14
+//                                ^^^^^^^ reference local13
       save(holder);
 //    ^^^^ reference com/airbnb/epoxy/ViewHolderState#save(+1).
-//         ^^^^^^ reference local7
+//         ^^^^^^ reference local14
     }
   }
 
@@ -168,9 +207,9 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
   public void save(EpoxyViewHolder holder) {
 //            ^^^^ definition com/airbnb/epoxy/ViewHolderState#save(+1).
 //                 ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                 ^^^^^^ definition local8
+//                                 ^^^^^^ definition local15
     if (!holder.getModel().shouldSaveViewState()) {
-//       ^^^^^^ reference local8
+//       ^^^^^^ reference local15
 //              ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
 //                         ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#shouldSaveViewState().
       return;
@@ -181,28 +220,28 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
     // should have identical ids for all its views, and will just overwrite the previous state.
     ViewState state = get(holder.getItemId());
 //  ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
-//            ^^^^^ definition local9
+//            ^^^^^ definition local16
 //                    ^^^ reference androidx/collection/LongSparseArray#get().
-//                        ^^^^^^ reference local8
+//                        ^^^^^^ reference local15
 //                               ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getItemId#
     if (state == null) {
-//      ^^^^^ reference local9
+//      ^^^^^ reference local16
       state = new ViewState();
-//    ^^^^^ reference local9
+//    ^^^^^ reference local16
 //            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`().
 //                ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
     }
 
     state.save(holder.itemView);
-//  ^^^^^ reference local9
+//  ^^^^^ reference local16
 //        ^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#save().
-//             ^^^^^^ reference local8
+//             ^^^^^^ reference local15
 //                    ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#itemView#
     put(holder.getItemId(), state);
 //  ^^^ reference androidx/collection/LongSparseArray#put().
-//      ^^^^^^ reference local8
+//      ^^^^^^ reference local15
 //             ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getItemId#
-//                          ^^^^^ reference local9
+//                          ^^^^^ reference local16
   }
 
   /**
@@ -212,9 +251,9 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
   public void restore(EpoxyViewHolder holder) {
 //            ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#restore().
 //                    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
-//                                    ^^^^^^ definition local10
+//                                    ^^^^^^ definition local17
     if (!holder.getModel().shouldSaveViewState()) {
-//       ^^^^^^ reference local10
+//       ^^^^^^ reference local17
 //              ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getModel().
 //                         ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#shouldSaveViewState().
       return;
@@ -222,22 +261,22 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 
     ViewState state = get(holder.getItemId());
 //  ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
-//            ^^^^^ definition local11
+//            ^^^^^ definition local18
 //                    ^^^ reference androidx/collection/LongSparseArray#get().
-//                        ^^^^^^ reference local10
+//                        ^^^^^^ reference local17
 //                               ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#getItemId#
     if (state != null) {
-//      ^^^^^ reference local11
+//      ^^^^^ reference local18
       state.restore(holder.itemView);
-//    ^^^^^ reference local11
+//    ^^^^^ reference local18
 //          ^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#restore().
-//                  ^^^^^^ reference local10
+//                  ^^^^^^ reference local17
 //                         ^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#itemView#
     } else {
       // The first time a model is bound it won't have previous state. We need to make sure
       // the view is reset to its initial state to clear any changes from previously bound models
       holder.restoreInitialViewState();
-//    ^^^^^^ reference local10
+//    ^^^^^^ reference local17
 //           ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#restoreInitialViewState().
     }
   }
@@ -258,68 +297,68 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 
     private ViewState(int size, int[] keys, Parcelable[] values) {
 //          ^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1).
-//                        ^^^^ definition local12
-//                                    ^^^^ definition local13
+//                        ^^^^ definition local19
+//                                    ^^^^ definition local20
 //                                          ^^^^^^^^^^ reference _root_/
-//                                                       ^^^^^^ definition local14
+//                                                       ^^^^^^ definition local21
       super(size);
-//          ^^^^ reference local12
+//          ^^^^ reference local19
       for (int i = 0; i < size; ++i) {
-//             ^ definition local15
-//                    ^ reference local15
-//                        ^^^^ reference local12
-//                                ^ reference local15
+//             ^ definition local22
+//                    ^ reference local22
+//                        ^^^^ reference local19
+//                                ^ reference local22
         put(keys[i], values[i]);
 //      ^^^ reference androidx/collection/LongSparseArray#put().
-//          ^^^^ reference local13
-//               ^ reference local15
-//                   ^^^^^^ reference local14
-//                          ^ reference local15
+//          ^^^^ reference local20
+//               ^ reference local22
+//                   ^^^^^^ reference local21
+//                          ^ reference local22
       }
     }
 
     public void save(View view) {
 //              ^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#save().
 //                   ^^^^ reference _root_/
-//                        ^^^^ definition local16
+//                        ^^^^ definition local23
       int originalId = view.getId();
-//        ^^^^^^^^^^ definition local17
-//                     ^^^^ reference local16
+//        ^^^^^^^^^^ definition local24
+//                     ^^^^ reference local23
 //                          ^^^^^ reference getId#
       setIdIfNoneExists(view);
 //    ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#setIdIfNoneExists().
-//                      ^^^^ reference local16
+//                      ^^^^ reference local23
 
       view.saveHierarchyState(this);
-//    ^^^^ reference local16
+//    ^^^^ reference local23
 //         ^^^^^^^^^^^^^^^^^^ reference saveHierarchyState#
 //                            ^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#this.
       view.setId(originalId);
-//    ^^^^ reference local16
+//    ^^^^ reference local23
 //         ^^^^^ reference setId#
-//               ^^^^^^^^^^ reference local17
+//               ^^^^^^^^^^ reference local24
     }
 
     public void restore(View view) {
 //              ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#restore().
 //                      ^^^^ reference _root_/
-//                           ^^^^ definition local18
+//                           ^^^^ definition local25
       int originalId = view.getId();
-//        ^^^^^^^^^^ definition local19
-//                     ^^^^ reference local18
+//        ^^^^^^^^^^ definition local26
+//                     ^^^^ reference local25
 //                          ^^^^^ reference getId#
       setIdIfNoneExists(view);
 //    ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#setIdIfNoneExists().
-//                      ^^^^ reference local18
+//                      ^^^^ reference local25
 
       view.restoreHierarchyState(this);
-//    ^^^^ reference local18
+//    ^^^^ reference local25
 //         ^^^^^^^^^^^^^^^^^^^^^ reference restoreHierarchyState#
 //                               ^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#this.
       view.setId(originalId);
-//    ^^^^ reference local18
+//    ^^^^ reference local25
 //         ^^^^^ reference setId#
-//               ^^^^^^^^^^ reference local19
+//               ^^^^^^^^^^ reference local26
     }
 
     /**
@@ -331,14 +370,14 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
     private void setIdIfNoneExists(View view) {
 //               ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#setIdIfNoneExists().
 //                                 ^^^^ reference _root_/
-//                                      ^^^^ definition local20
+//                                      ^^^^ definition local27
       if (view.getId() == View.NO_ID) {
-//        ^^^^ reference local20
+//        ^^^^ reference local27
 //             ^^^^^ reference getId#
 //                        ^^^^ reference _root_/
 //                             ^^^^^ reference NO_ID#
         view.setId(R.id.view_model_state_saving_id);
-//      ^^^^ reference local20
+//      ^^^^ reference local27
 //           ^^^^^ reference setId#
 //                 ^ reference R/
 //                   ^^ reference R/id#
@@ -358,48 +397,48 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
     public void writeToParcel(Parcel parcel, int flags) {
 //              ^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#writeToParcel().
 //                            ^^^^^^ reference _root_/
-//                                   ^^^^^^ definition local21
-//                                               ^^^^^ definition local22
+//                                   ^^^^^^ definition local28
+//                                               ^^^^^ definition local29
       int size = size();
-//        ^^^^ definition local23
+//        ^^^^ definition local30
 //               ^^^^ reference androidx/collection/LongSparseArray#size().
       int[] keys = new int[size];
-//          ^^^^ definition local24
-//                         ^^^^ reference local23
+//          ^^^^ definition local31
+//                         ^^^^ reference local30
       Parcelable[] values = new Parcelable[size];
 //    ^^^^^^^^^^ reference _root_/
-//                 ^^^^^^ definition local25
+//                 ^^^^^^ definition local32
 //                              ^^^^^^^^^^ reference _root_/
-//                                         ^^^^ reference local23
+//                                         ^^^^ reference local30
       for (int i = 0; i < size; ++i) {
-//             ^ definition local26
-//                    ^ reference local26
-//                        ^^^^ reference local23
-//                                ^ reference local26
+//             ^ definition local33
+//                    ^ reference local33
+//                        ^^^^ reference local30
+//                                ^ reference local33
         keys[i] = keyAt(i);
-//      ^^^^ reference local24
-//           ^ reference local26
+//      ^^^^ reference local31
+//           ^ reference local33
 //                ^^^^^ reference androidx/collection/LongSparseArray#keyAt().
-//                      ^ reference local26
+//                      ^ reference local33
         values[i] = valueAt(i);
-//      ^^^^^^ reference local25
-//             ^ reference local26
+//      ^^^^^^ reference local32
+//             ^ reference local33
 //                  ^^^^^^^ reference androidx/collection/LongSparseArray#valueAt().
-//                          ^ reference local26
+//                          ^ reference local33
       }
       parcel.writeInt(size);
-//    ^^^^^^ reference local21
+//    ^^^^^^ reference local28
 //           ^^^^^^^^ reference writeInt#
-//                    ^^^^ reference local23
+//                    ^^^^ reference local30
       parcel.writeIntArray(keys);
-//    ^^^^^^ reference local21
+//    ^^^^^^ reference local28
 //           ^^^^^^^^^^^^^ reference writeIntArray#
-//                         ^^^^ reference local24
+//                         ^^^^ reference local31
       parcel.writeParcelableArray(values, flags);
-//    ^^^^^^ reference local21
+//    ^^^^^^ reference local28
 //           ^^^^^^^^^^^^^^^^^^^^ reference writeParcelableArray#
-//                                ^^^^^^ reference local25
-//                                        ^^^^^ reference local22
+//                                ^^^^^^ reference local32
+//                                        ^^^^^ reference local29
     }
 
     public static final Creator<ViewState> CREATOR =
@@ -407,26 +446,68 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                              ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                         ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR.
         new Parcelable.ClassLoaderCreator<ViewState>() {
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 19:9
+//          ^^^^^^^^^^ reference Parcelable/
 //          ^^^^^^^^^^ reference Parcelable/
 //                     ^^^^^^^^^^^^^^^^^^ reference Parcelable/ClassLoaderCreator#
+//                     ^^^^^^^^^^^^^^^^^^ reference Parcelable/ClassLoaderCreator#
+//                                        ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                        ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
           @Override
+//         ^^^^^^^^ reference java/lang/Override#
           public ViewState createFromParcel(Parcel source, ClassLoader loader) {
+//               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                         ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR.``#createFromParcel().
+//                                          ^^^^^^ reference _root_/
+//                                                 ^^^^^^ definition local34
+//                                                         ^^^^^^^^^^^ reference java/lang/ClassLoader#
+//                                                                     ^^^^^^ definition local35
             int size = source.readInt();
+//              ^^^^ definition local36
+//                     ^^^^^^ reference local34
+//                            ^^^^^^^ reference readInt#
             int[] keys = new int[size];
+//                ^^^^ definition local37
+//                               ^^^^ reference local36
             source.readIntArray(keys);
+//          ^^^^^^ reference local34
+//                 ^^^^^^^^^^^^ reference readIntArray#
+//                              ^^^^ reference local37
             Parcelable[] values = source.readParcelableArray(loader);
+//          ^^^^^^^^^^ reference _root_/
+//                       ^^^^^^ definition local38
+//                                ^^^^^^ reference local34
+//                                       ^^^^^^^^^^^^^^^^^^^ reference readParcelableArray#
+//                                                           ^^^^^^ reference local35
             return new ViewState(size, keys, values);
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1).
+//                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                               ^^^^ reference local36
+//                                     ^^^^ reference local37
+//                                           ^^^^^^ reference local38
           }
 
           @Override
+//         ^^^^^^^^ reference java/lang/Override#
           public ViewState createFromParcel(Parcel source) {
+//               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                         ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR.``#createFromParcel(+1).
+//                                          ^^^^^^ reference _root_/
+//                                                 ^^^^^^ definition local39
             return createFromParcel(source, null);
+//                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR.``#createFromParcel().
+//                                  ^^^^^^ reference local39
           }
 
           @Override
+//         ^^^^^^^^ reference java/lang/Override#
           public ViewState[] newArray(int size) {
+//               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                           ^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR.``#newArray().
+//                                        ^^^^ definition local40
             return new ViewState[size];
+//                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                               ^^^^ reference local40
           }
         };
   }

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -1,4 +1,5 @@
 package minimized;
+^^^^^ reference minimized/Enums#
 
 import java.util.Arrays;
 //     ^^^^ reference java/
@@ -41,7 +42,6 @@ public enum Enums {
 //                             ^^^^^^ reference minimized/Enums#values().
 //                                       ^^^ reference java/util/stream/Stream#map().
 //                                           ^ definition local2
-//                                            ^^^^^ reference minimized/Enums#
 //                                                ^ reference local2
 //                                                  ^^^^^ reference minimized/Enums#value.
 //                                                         ^^^ reference java/util/stream/Stream#map().


### PR DESCRIPTION
Previously, the semanticdb-javac compiler plugin only supported Java 8. The plugin failed when compiling with Java 9+ due to our use of 'unsupported' APIs that changed from JDK 9.

This PR adds support for all JDKs from 9 onwards in addition to the previously supported JDK 8 by 
1) Using APIs that have been stable (thus far) and 
2) Removing usages of (as tested thus far) redundant and unstable APIs.

Notes:
- With JDK9+ anonymous classes and everything enclosed within don't get skipped. We should see why this happens in JDK8
- There was 1 erroneous reference that moved to 0:0, why? https://github.com/sourcegraph/lsif-java/pull/91#discussion_r583017177

Closes #90 