### PR TITLE
adds snapshot command to lsif-java cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ out/
 *.hnir
 test-report.json
 dump.lsif
+
+./generated

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ lazy val cli = project
   .settings(
     moduleName := "lsif-java",
     mainClass.in(Compile) := Some("com.sourcegraph.lsif_java.LsifJava"),
+    baseDirectory.in(run) := baseDirectory.in(ThisBuild).value,
     buildInfoKeys :=
       Seq[BuildInfoKey](
         version,
@@ -164,6 +165,7 @@ lazy val cli = project
     nativeImageOutput := target.in(NativeImage).value / "lsif-java"
   )
   .enablePlugins(NativeImagePlugin, BuildInfoPlugin)
+  .dependsOn(plugin)
 
 def minimizedSourceDirectory =
   file("tests/minimized/src/main/java").getAbsoluteFile

--- a/cli/src/main/scala/com/sourcegraph/lsif_java/LsifJava.scala
+++ b/cli/src/main/scala/com/sourcegraph/lsif_java/LsifJava.scala
@@ -16,7 +16,8 @@ object LsifJava {
       CommandParser[HelpCommand],
       CommandParser[VersionCommand],
       CommandParser[IndexCommand],
-      CommandParser[IndexSemanticdbCommand]
+      CommandParser[IndexSemanticdbCommand],
+      CommandParser[SnapshotCommand]
     )
   )
   def main(args: Array[String]): Unit = {

--- a/cli/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
+++ b/cli/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
@@ -1,4 +1,4 @@
-package tests
+package com.sourcegraph.lsif_java
 
 import scala.jdk.CollectionConverters._
 
@@ -56,7 +56,7 @@ object SemanticdbPrinters {
       )
       .append(
         if (r.getStartCharacter == 1)
-          "^" * (width-1)
+          "^" * (width - 1)
         else
           "^" * width
       )

--- a/cli/src/main/scala/com/sourcegraph/lsif_java/SnapshotCommand.scala
+++ b/cli/src/main/scala/com/sourcegraph/lsif_java/SnapshotCommand.scala
@@ -1,0 +1,97 @@
+package com.sourcegraph.lsif_java
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
+import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocuments
+import moped.annotations.CommandName
+import moped.annotations.Description
+import moped.annotations.ExampleUsage
+import moped.annotations.Inline
+import moped.annotations.PositionalArguments
+import moped.annotations.Usage
+import moped.cli.Application
+import moped.cli.Command
+import moped.cli.CommandParser
+
+@Description(
+  "Generates annotated snapshots for each SemanticDB file in the given target roots."
+)
+@Usage("lsif-java snapshot [OPTIONS ...] [POSITIONAL ARGUMENTS ...]")
+@ExampleUsage(
+  "lsif-java snapshot --output=generated/ my/targetroo1 my/targetroot2"
+)
+@CommandName("snapshot")
+case class SnapshotCommand(
+    @PositionalArguments
+    @Description(
+      "List of directories containing SemanticDB files"
+    ) targetroot: List[Path] = Nil,
+    @Description("Output directory for the annotated snapshots") output: Path =
+      Paths.get("generated"),
+    @Inline() app: Application = Application.default
+) extends Command {
+  def sourceroot: Path = app.env.workingDirectory
+
+  override def run(): Int = {
+    val semanticdbPattern = FileSystems
+      .getDefault
+      .getPathMatcher("glob:**.semanticdb")
+    Files.walkFileTree(output, new DeleteVisitor())
+    Files.createDirectories(output)
+    val semanticdbFiles = ListBuffer.empty[TextDocument]
+
+    targetroot.foreach { root =>
+      Files.walkFileTree(
+        root,
+        new SimpleFileVisitor[Path] {
+          override def visitFile(
+              file: Path,
+              attrs: BasicFileAttributes
+          ): FileVisitResult = {
+            if (semanticdbPattern.matches(file)) {
+              val docs = TextDocuments.parseFrom(Files.readAllBytes(file))
+              docs
+                .getDocumentsList
+                .asScala
+                .foreach { doc =>
+                  val sourcepath = sourceroot.resolve(doc.getUri)
+                  val source =
+                    new String(
+                      Files.readAllBytes(sourcepath),
+                      StandardCharsets.UTF_8
+                    )
+                  semanticdbFiles +=
+                    TextDocument.newBuilder(doc).setText(source).build()
+                }
+            }
+            super.visitFile(file, attrs)
+          }
+        }
+      )
+    }
+
+    semanticdbFiles.foreach { doc =>
+      val document = SemanticdbPrinters.printTextDocument(doc)
+      val snapshotOutput = output.resolve(doc.getUri)
+      Files.createDirectories(snapshotOutput.getParent)
+      Files.write(snapshotOutput, document.getBytes(StandardCharsets.UTF_8))
+    }
+
+    0
+  }
+}
+
+object SnapshotCommand {
+  implicit val parser = CommandParser.derive(SnapshotCommand())
+}

--- a/tests/snapshots/src/main/scala/tests/LibrarySnapshotGenerator.scala
+++ b/tests/snapshots/src/main/scala/tests/LibrarySnapshotGenerator.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 
 import com.sourcegraph.lsif_java.DeleteVisitor
+import com.sourcegraph.lsif_java.SemanticdbPrinters
 import coursier.core.Repository
 import coursier.maven.MavenRepository
 

--- a/tests/snapshots/src/main/scala/tests/MinimizedSnapshotGenerator.scala
+++ b/tests/snapshots/src/main/scala/tests/MinimizedSnapshotGenerator.scala
@@ -2,6 +2,8 @@ package tests
 
 import scala.meta.io.AbsolutePath
 
+import com.sourcegraph.lsif_java.SemanticdbPrinters
+
 class MinimizedSnapshotGenerator extends SnapshotGenerator {
   override def run(context: SnapshotContext, handler: SnapshotHandler): Unit = {
     val sourceroot = AbsolutePath(BuildInfo.sourceroot)

--- a/tests/unit/src/test/scala/tests/SnapshotCommandSuite.scala
+++ b/tests/unit/src/test/scala/tests/SnapshotCommandSuite.scala
@@ -1,0 +1,51 @@
+package tests
+
+import java.nio.file.Files
+
+import scala.meta.inputs.Input
+
+import com.sourcegraph.lsif_java.LsifJava
+import moped.testkit.FileLayout
+import moped.testkit.MopedSuite
+
+class SnapshotCommandSuite extends MopedSuite(LsifJava.app) {
+  test("snapshot") {
+    FileLayout.fromString(
+      """/main/Sample.java
+        |package main;
+        |
+        |public class Sample {
+        |   public static void main(String[] asdf) {}
+        |}
+        |""".stripMargin,
+      workingDirectory
+    )
+
+    val targetroot = workingDirectory.resolve("target/main")
+    val sourcepath = workingDirectory.resolve("main/Sample.java")
+    val code = new String(Files.readAllBytes(sourcepath))
+    new TestCompiler(targetroot)
+      .compileSemanticdb(List(Input.VirtualFile("main/Sample.java", code)))
+
+    val generatedpath = workingDirectory.resolve("generated")
+    val exitCode = app().run(
+      List("snapshot", "--output", generatedpath.toString, targetroot.toString)
+    )
+    assertEquals(exitCode, 0, clues(app.capturedOutput))
+    assertNoDiff(
+      FileLayout.asString(generatedpath),
+      """|/main/Sample.java
+         |package main;
+         |
+         |public class Sample {
+         |//     ^^^^^^ definition main/Sample#
+         |//     ^^^^^^ definition main/Sample#`<init>`().
+         |   public static void main(String[] asdf) {}
+         |//                    ^^^^ definition main/Sample#main().
+         |//                         ^^^^^^ reference java/lang/String#
+         |//                                  ^^^^ definition local0
+         |}
+         |""".stripMargin
+    )
+  }
+}


### PR DESCRIPTION
Allows for emitting snapshots based on the semanticdb files, in the same style as our snapshot tests for a visual look at how files are being indexed.

Thanks @olafurpg for the Scala tutoring :man_dancing: 