### PR TITLE
fixes snapshot generator comment // insertion

### DIFF
--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AfterPropsSet.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AfterPropsSet.java
@@ -31,11 +31,11 @@ import java.lang.annotation.Target;
  * screen, and after partial binds when an onscreen view is updated.
  */
 @Target(ElementType.METHOD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface AfterPropsSet {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -50,10 +50,10 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback;
  * Also adds support for canceling an in progress diff, and makes everything thread safe.
  */
 class AsyncEpoxyDiffer {
-^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#
+//^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#
 
   interface ResultCallback {
-  ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#
+//^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#
     void onResult(@NonNull DiffResult result);
 //       ^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#onResult().
 //                 ^^^^^^^ reference androidx/annotation/NonNull#
@@ -78,7 +78,7 @@ class AsyncEpoxyDiffer {
 //                                                        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
 
   AsyncEpoxyDiffer(
-  ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`().
       @NonNull Handler handler,
 //     ^^^^^^^ reference androidx/annotation/NonNull#
 //             ^^^^^^^ reference _root_/
@@ -110,7 +110,7 @@ class AsyncEpoxyDiffer {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   private volatile List<? extends EpoxyModel<?>> list;
 //                 ^^^^ reference java/util/List#
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -122,7 +122,7 @@ class AsyncEpoxyDiffer {
    * Collections.emptyList when list is null, wrapped by Collections.unmodifiableList otherwise
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   private volatile List<? extends EpoxyModel<?>> readOnlyList = Collections.emptyList();
 //                 ^^^^ reference java/util/List#
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -142,9 +142,9 @@ class AsyncEpoxyDiffer {
    * @return current List.
    */
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public List<? extends EpoxyModel<?>> getCurrentList() {
 //       ^^^^ reference java/util/List#
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -158,9 +158,9 @@ class AsyncEpoxyDiffer {
    * diff to cancel, false otherwise.
    */
   @SuppressWarnings("WeakerAccess")
-   ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   public boolean cancelDiff() {
 //               ^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#cancelDiff().
     return generationTracker.finishMaxGeneration();
@@ -172,9 +172,9 @@ class AsyncEpoxyDiffer {
    * @return True if a diff operation is in progress.
    */
   @SuppressWarnings("WeakerAccess")
-   ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   public boolean isDiffInProgress() {
 //               ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#isDiffInProgress().
     return generationTracker.hasUnfinishedGeneration();
@@ -189,7 +189,7 @@ class AsyncEpoxyDiffer {
    * synced.
    */
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   public synchronized boolean forceListOverride(@Nullable List<EpoxyModel<?>> newList) {
 //                            ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#forceListOverride().
 //                                               ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -223,9 +223,9 @@ class AsyncEpoxyDiffer {
    * and the new List will be swapped in.
    */
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   @SuppressWarnings("WeakerAccess")
-   ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
   public void submitList(@Nullable final List<? extends EpoxyModel<?>> newList) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#submitList().
 //                        ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -400,7 +400,7 @@ class AsyncEpoxyDiffer {
    * set. False if the generation is old and the list was ignored.
    */
   @AnyThread
-   ^^^^^^^^^ reference androidx/annotation/AnyThread#
+// ^^^^^^^^^ reference androidx/annotation/AnyThread#
   private synchronized boolean tryLatchList(@Nullable List<? extends EpoxyModel<?>> newList,
 //                             ^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#tryLatchList().
 //                                           ^^^^^^^^ reference androidx/annotation/Nullable#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AutoModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AutoModel.java
@@ -28,11 +28,11 @@ import java.lang.annotation.Target;
  * adapter, so it can be used for saving state of a model.
  */
 @Target(ElementType.FIELD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^ reference java/lang/annotation/ElementType#FIELD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface AutoModel {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -157,7 +157,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getItemCount() {
 //           ^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getItemCount().
     return getCurrentModels().size();
@@ -179,7 +179,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public long getItemId(int position) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getItemId().
 //                          ^^^^^^^^ definition local5
@@ -194,7 +194,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getItemViewType(int position) {
 //           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getItemViewType().
 //                               ^^^^^^^^ definition local6
@@ -206,7 +206,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public EpoxyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                       ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onCreateViewHolder().
@@ -236,7 +236,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onBindViewHolder(EpoxyViewHolder holder, int position) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onBindViewHolder().
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -251,7 +251,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onBindViewHolder(EpoxyViewHolder holder, int position, List<Object> payloads) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onBindViewHolder(+1).
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -396,7 +396,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   EpoxyModel<?> getModelForPosition(int position) {
-  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
 //                                      ^^^^^^^^ definition local29
     return getCurrentModels().get(position);
@@ -406,7 +406,7 @@ public abstract class BaseEpoxyAdapter
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewRecycled(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewRecycled().
 //                           ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -435,9 +435,9 @@ public abstract class BaseEpoxyAdapter
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onDetachedFromRecyclerView().
 //                                        ^^^^^^^ reference androidx/annotation/NonNull#
@@ -465,9 +465,9 @@ public abstract class BaseEpoxyAdapter
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean onFailedToRecycleView(EpoxyViewHolder holder) {
 //               ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onFailedToRecycleView().
 //                                     ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -483,9 +483,9 @@ public abstract class BaseEpoxyAdapter
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewAttachedToWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewAttachedToWindow().
 //                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -501,9 +501,9 @@ public abstract class BaseEpoxyAdapter
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#onViewDetachedFromWindow().
 //                                     ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -669,7 +669,7 @@ public abstract class BaseEpoxyAdapter
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void setupStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#setupStickyHeaderView().
 //                                   ^^^^^^^ reference org/jetbrains/annotations/NotNull#
@@ -686,7 +686,7 @@ public abstract class BaseEpoxyAdapter
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void teardownStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference org/jetbrains/annotations/NotNull#
@@ -703,7 +703,7 @@ public abstract class BaseEpoxyAdapter
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean isStickyHeader(int position) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#isStickyHeader().
 //                                  ^^^^^^^^ definition local47

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
@@ -6,7 +6,7 @@ import android.view.View;
 //                  ^^^^ reference android/view/View#
 
 interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
-^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyTouchCallback#
+//^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                         ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
@@ -21,7 +21,7 @@ import androidx.collection.LongSparseArray;
 
 /** Helper class for keeping track of {@link EpoxyViewHolder}s that are currently bound. */
 @SuppressWarnings("WeakerAccess")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
 //     ^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#`<init>`().
 //     ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#
@@ -35,7 +35,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
 //                                                             ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public EpoxyViewHolder get(EpoxyViewHolder holder) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                       ^^^ definition com/airbnb/epoxy/BoundViewHolders#get().
@@ -79,7 +79,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public Iterator<EpoxyViewHolder> iterator() {
 //       ^^^^^^^^ reference java/util/Iterator#
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -90,7 +90,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public EpoxyViewHolder getHolderForModel(EpoxyModel<?> model) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                       ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#getHolderForModel().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/CallbackProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/CallbackProp.java
@@ -35,13 +35,13 @@ import java.lang.annotation.Target;
  * changing the value of the listener will not trigger an update to the view.
  */
 @Target({ElementType.METHOD, ElementType.FIELD})
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //       ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                   ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 //                           ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                                       ^^^^^ reference java/lang/annotation/ElementType#FIELD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface CallbackProp {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -104,7 +104,7 @@ import androidx.recyclerview.widget.SnapHelper;
  * EpoxyModel.
  */
 @ModelView(saveViewState = true, autoLayout = Size.MATCH_WIDTH_WRAP_HEIGHT)
- ^^^^^^^^^ reference com/airbnb/epoxy/ModelView#
+//^^^^^^^^ reference com/airbnb/epoxy/ModelView#
 //         ^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelView#saveViewState().
 //                               ^^^^^^^^^^ reference com/airbnb/epoxy/ModelView#autoLayout().
 //                                            ^^^^ reference com/airbnb/epoxy/ModelView#Size#
@@ -140,7 +140,7 @@ public class Carousel extends EpoxyRecyclerView {
       };
 
   @Dimension(unit = Dimension.DP)
-   ^^^^^^^^^ reference androidx/annotation/Dimension#
+// ^^^^^^^^^ reference androidx/annotation/Dimension#
 //           ^^^^ reference androidx/annotation/Dimension#unit().
 //                  ^^^^^^^^^ reference androidx/annotation/Dimension#
 //                            ^^ reference androidx/annotation/Dimension#DP.
@@ -185,7 +185,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void init() {
 //               ^^^^ definition com/airbnb/epoxy/Carousel#init().
     super.init();
@@ -242,7 +242,7 @@ public class Carousel extends EpoxyRecyclerView {
    * snap helper to be attached automatically.
    */
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   protected SnapHelperFactory getSnapHelperFactory() {
 //          ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#SnapHelperFactory#
 //                            ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#getSnapHelperFactory().
@@ -269,9 +269,9 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @ModelProp
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void setHasFixedSize(boolean hasFixedSize) {
 //            ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setHasFixedSize().
 //                                    ^^^^^^^^^^^^ definition local13
@@ -300,7 +300,7 @@ public class Carousel extends EpoxyRecyclerView {
    * use {@link #setInitialPrefetchItemCount(int)}
    */
   @ModelProp(group = "prefetch")
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
 //           ^^^^^ reference com/airbnb/epoxy/ModelProp#group().
   public void setNumViewsToShowOnScreen(float viewCount) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setNumViewsToShowOnScreen().
@@ -332,7 +332,7 @@ public class Carousel extends EpoxyRecyclerView {
    * @see LinearLayoutManager#setInitialPrefetchItemCount(int)
    */
   @ModelProp(group = "prefetch")
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
 //           ^^^^^ reference com/airbnb/epoxy/ModelProp#group().
   public void setInitialPrefetchItemCount(int numItemsToPrefetch) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setInitialPrefetchItemCount().
@@ -366,7 +366,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onChildAttachedToWindow(View child) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#onChildAttachedToWindow().
 //                                    ^^^^ reference _root_/
@@ -463,7 +463,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @Px
-   ^^ reference androidx/annotation/Px#
+// ^^ reference androidx/annotation/Px#
   private static int getTotalWidthPx(View view) {
 //                   ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#getTotalWidthPx().
 //                                   ^^^^ reference _root_/
@@ -499,7 +499,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @Px
-   ^^ reference androidx/annotation/Px#
+// ^^ reference androidx/annotation/Px#
   private static int getTotalHeightPx(View view) {
 //                   ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#getTotalHeightPx().
 //                                    ^^^^ reference _root_/
@@ -534,7 +534,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onChildDetachedFromWindow(View child) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#onChildDetachedFromWindow().
 //                                      ^^^^ reference _root_/
@@ -595,7 +595,7 @@ public class Carousel extends EpoxyRecyclerView {
    * subclasses can override this to specify their own value.
    */
   @Dimension(unit = Dimension.DP)
-   ^^^^^^^^^ reference androidx/annotation/Dimension#
+// ^^^^^^^^^ reference androidx/annotation/Dimension#
 //           ^^^^ reference androidx/annotation/Dimension#unit().
 //                  ^^^^^^^^^ reference androidx/annotation/Dimension#
 //                            ^^ reference androidx/annotation/Dimension#DP.
@@ -610,7 +610,7 @@ public class Carousel extends EpoxyRecyclerView {
    * in between carousel items.
    */
   @ModelProp(group = "padding")
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
 //           ^^^^^ reference com/airbnb/epoxy/ModelProp#group().
   public void setPaddingRes(@DimenRes int paddingRes) {
 //            ^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setPaddingRes().
@@ -638,7 +638,7 @@ public class Carousel extends EpoxyRecyclerView {
    * <p>The default as the value returned by {@link #getDefaultSpacingBetweenItemsDp()}
    */
   @ModelProp(defaultValue = "NO_VALUE_SET", group = "padding")
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
 //           ^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#defaultValue().
 //                                          ^^^^^ reference com/airbnb/epoxy/ModelProp#group().
   public void setPaddingDp(@Dimension(unit = Dimension.DP) int paddingDp) {
@@ -673,7 +673,7 @@ public class Carousel extends EpoxyRecyclerView {
    * <p>A value of null will set all padding and item spacing to 0.
    */
   @ModelProp(group = "padding")
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
 //           ^^^^^ reference com/airbnb/epoxy/ModelProp#group().
   public void setPadding(@Nullable Padding padding) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setPadding().
@@ -1127,7 +1127,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @ModelProp
-   ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
+// ^^^^^^^^^ reference com/airbnb/epoxy/ModelProp#
   public void setModels(@NonNull List<? extends EpoxyModel<?>> models) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/Carousel#setModels().
 //                       ^^^^^^^ reference androidx/annotation/NonNull#
@@ -1141,7 +1141,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @OnViewRecycled
-   ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/OnViewRecycled#
+// ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/OnViewRecycled#
   public void clear() {
 //            ^^^^^ definition com/airbnb/epoxy/Carousel#clear().
     super.clear();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
@@ -30,8 +30,8 @@ import androidx.annotation.Nullable;
  * be returned.
  */
 class ControllerHelperLookup {
-^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#`<init>`().
-^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#
+//^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#`<init>`().
+//^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#
   private static final String GENERATED_HELPER_CLASS_SUFFIX = "_EpoxyHelper";
 //                     ^^^^^^ reference java/lang/String#
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#GENERATED_HELPER_CLASS_SUFFIX.
@@ -117,7 +117,7 @@ class ControllerHelperLookup {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   private static Constructor<?> findConstructorForClass(Class<?> controllerClass) {
 //               ^^^^^^^^^^^ reference java/lang/reflect/Constructor#
 //                              ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#findConstructorForClass().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
@@ -8,7 +8,7 @@ package com.airbnb.epoxy;
  * why it doesn't do anything.
  */
 class ControllerModelList extends ModelList {
-^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#
+//^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#
 //                                ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#
 
   private static final ModelListObserver OBSERVER = new ModelListObserver() {
@@ -44,7 +44,7 @@ class ControllerModelList extends ModelList {
   };
 
   ControllerModelList(int expectedModelCount) {
-  ^^^^^^ definition com/airbnb/epoxy/ControllerModelList#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/ControllerModelList#`<init>`().
 //                        ^^^^^^^^^^^^^^^^^^ definition local8
     super(expectedModelCount);
 //  ^^^^^ reference com/airbnb/epoxy/ModelList#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
@@ -6,7 +6,7 @@ import android.util.Log;
 //                  ^^^ reference android/util/Log#
 
 class DebugTimer implements Timer {
-^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#
+//^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#
 //                          ^^^^^ reference com/airbnb/epoxy/Timer#
 
   private final String tag;
@@ -19,7 +19,7 @@ class DebugTimer implements Timer {
 //               ^^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#sectionName.
 
   DebugTimer(String tag) {
-  ^^^^^^ definition com/airbnb/epoxy/DebugTimer#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/DebugTimer#`<init>`().
 //           ^^^^^^ reference java/lang/String#
 //                  ^^^ definition local0
     this.tag = tag;
@@ -39,7 +39,7 @@ class DebugTimer implements Timer {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void start(String sectionName) {
 //            ^^^^^ definition com/airbnb/epoxy/DebugTimer#start().
 //                  ^^^^^^ reference java/lang/String#
@@ -62,7 +62,7 @@ class DebugTimer implements Timer {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void stop() {
 //            ^^^^ definition com/airbnb/epoxy/DebugTimer#stop().
     if (startTime == -1) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -36,7 +36,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * Helper to track changes in the models list.
  */
 class DiffHelper {
-^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#
+//^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#
   private ArrayList<ModelState> oldStateList = new ArrayList<>();
 //        ^^^^^^^^^ reference java/util/ArrayList#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
@@ -73,7 +73,7 @@ class DiffHelper {
 
 
   DiffHelper(BaseEpoxyAdapter adapter, boolean immutableModels) {
-  ^^^^^^ definition com/airbnb/epoxy/DiffHelper#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/DiffHelper#`<init>`().
 //           ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
 //                            ^^^^^^^ definition local0
 //                                             ^^^^^^^^^^^^^^^ definition local1
@@ -1084,7 +1084,7 @@ class DiffHelper {
    * Gets the next item in the list that has a pair, meaning it wasn't inserted or removed.
    */
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   private ModelState getNextItemWithPair(Iterator<ModelState> iterator) {
 //        ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                   ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#getNextItemWithPair().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
@@ -39,7 +39,7 @@ public class DiffPayload {
 //                                             ^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#modelsById.
 
   DiffPayload(List<? extends EpoxyModel<?>> models) {
-  ^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`().
 //            ^^^^ reference java/util/List#
 //                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                          ^^^^^^ definition local0
@@ -104,7 +104,7 @@ public class DiffPayload {
    * throw if an unexpected type is found.
    */
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public static EpoxyModel<?> getModelFromPayload(List<Object> payloads, long modelId) {
 //              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#getModelFromPayload().
@@ -160,7 +160,7 @@ public class DiffPayload {
   }
 
   @VisibleForTesting
-   ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
+// ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
   boolean equalsForTesting(DiffPayload that) {
 //        ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#equalsForTesting().
 //                         ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
@@ -45,12 +45,12 @@ import androidx.recyclerview.widget.RecyclerView.Adapter;
 public class DiffResult {
 //     ^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#
   @NonNull final List<? extends EpoxyModel<?>> previousModels;
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
 //               ^^^^ reference java/util/List#
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#previousModels.
   @NonNull final List<? extends EpoxyModel<?>> newModels;
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
 //               ^^^^ reference java/util/List#
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                             ^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#newModels.
@@ -61,7 +61,7 @@ public class DiffResult {
    * we can simply add all or clear all items and skipped running the full diffing.
    */
   @Nullable final DiffUtil.DiffResult differResult;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                ^^^^^^^^ reference DiffUtil/
 //                         ^^^^^^^^^^ reference DiffUtil/DiffResult#
 //                                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#differResult.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
@@ -33,7 +33,7 @@ import androidx.annotation.Nullable;
  * support this then disable it in your base class (not recommended).
  */
 @SuppressWarnings("WeakerAccess")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //              ^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#`<init>`().
 //              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#
@@ -59,9 +59,9 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //                   ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#diffHelper.
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   List<EpoxyModel<?>> getCurrentModels() {
-  ^^^^ reference java/util/List#
+//^^^^ reference java/util/List#
 //     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#getCurrentModels().
     return models;
@@ -106,9 +106,9 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   EpoxyModel<?> getModelForPosition(int position) {
-  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#getModelForPosition().
 //                                      ^^^^^^^^ definition local0
     EpoxyModel<?> model = models.get(position);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -74,7 +74,7 @@ public final class EpoxyAsyncUtil {
    * each {@link Message} that is sent to it or {@link Runnable} that is posted to it
    */
   @MainThread
-   ^^^^^^^^^^ reference androidx/annotation/MainThread#
+// ^^^^^^^^^^ reference androidx/annotation/MainThread#
   public static Handler getAsyncBackgroundHandler() {
 //              ^^^^^^^ reference _root_/
 //                      ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#getAsyncBackgroundHandler().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
@@ -27,11 +27,11 @@ import java.lang.annotation.Target;
  * getters, setters, equals, and hashcode for the annotated fields.
  */
 @Target(ElementType.FIELD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^ reference java/lang/annotation/ElementType#FIELD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyAttribute {
@@ -41,8 +41,8 @@ public @interface EpoxyAttribute {
    * created.
    */
   enum Option {
-  ^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#
-  ^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#
+//^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
     /**
      * A getter is generated for this attribute by default. Add this option to prevent a getter from
      * being generated.
@@ -98,7 +98,7 @@ public @interface EpoxyAttribute {
 
   /** Specify any {@link Option} values that should be used when generating the model class. */
   Option[] value() default {};
-  ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#
+//^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#
 //         ^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#value().
 
   /**
@@ -110,7 +110,7 @@ public @interface EpoxyAttribute {
    * @deprecated Use {@link Option#DoNotHash} instead.
    */
   @Deprecated
-   ^^^^^^^^^^ reference java/lang/Deprecated#
+// ^^^^^^^^^^ reference java/lang/Deprecated#
   boolean hash() default true;
 //        ^^^^ definition com/airbnb/epoxy/EpoxyAttribute#hash().
 
@@ -123,7 +123,7 @@ public @interface EpoxyAttribute {
    * @deprecated Use {@link Option#NoSetter} instead.
    */
   @Deprecated
-   ^^^^^^^^^^ reference java/lang/Deprecated#
+// ^^^^^^^^^^ reference java/lang/Deprecated#
   boolean setter() default true;
 //        ^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#setter().
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -259,18 +259,18 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * current call and posting it again.
    */
   @RequestedModelBuildType private volatile int requestedModelBuildType =
-   ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
+// ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                                              ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#requestedModelBuildType.
       RequestedModelBuildType.NONE;
 //    ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                            ^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#NONE.
 
   @Retention(RetentionPolicy.SOURCE)
-   ^^^^^^^^^ reference java/lang/annotation/Retention#
+// ^^^^^^^^^ reference java/lang/annotation/Retention#
 //           ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                           ^^^^^^ reference java/lang/annotation/RetentionPolicy#SOURCE.
   @IntDef({RequestedModelBuildType.NONE,
-   ^^^^^^ reference androidx/annotation/IntDef#
+// ^^^^^^ reference androidx/annotation/IntDef#
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                                 ^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#NONE.
       RequestedModelBuildType.NEXT_FRAME,
@@ -682,7 +682,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * to allow changes.
    */
   interface ModelInterceptorCallback {
-  ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
+//^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
     void onInterceptorsStarted(EpoxyController controller);
 //       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#onInterceptorsStarted().
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
@@ -1312,7 +1312,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * RecyclerView, or to get information about models currently in use.
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyControllerAdapter getAdapter() {
 //       ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#
 //                              ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#getAdapter().
@@ -1349,7 +1349,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * the span count is correct.
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public SpanSizeLookup getSpanSizeLookup() {
 //       ^^^^^^^^^^^^^^ reference _root_/
 //                      ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#getSpanSizeLookup().
@@ -1678,7 +1678,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void setupStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#setupStickyHeaderView().
 //                                   ^^^^^^^ reference org/jetbrains/annotations/NotNull#
@@ -1695,7 +1695,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void teardownStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference org/jetbrains/annotations/NotNull#
@@ -1712,7 +1712,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * using sticky header feature.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean isStickyHeader(int position) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#isStickyHeader().
 //                                  ^^^^^^^^ definition local84

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -80,7 +80,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                                                           ^^^^^^^^^ reference java/util/ArrayList#
 
   EpoxyControllerAdapter(@NonNull EpoxyController epoxyController, Handler diffingHandler) {
-  ^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`().
 //                        ^^^^^^^ reference androidx/annotation/NonNull#
 //                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                                ^^^^^^^^^^^^^^^ definition local0
@@ -107,7 +107,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onExceptionSwallowed(@NonNull RuntimeException exception) {
 //               ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onExceptionSwallowed().
 //                                     ^^^^^^^ reference androidx/annotation/NonNull#
@@ -120,11 +120,11 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   List<? extends EpoxyModel<?>> getCurrentModels() {
-  ^^^^ reference java/util/List#
+//^^^^ reference java/util/List#
 //               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
     return differ.getCurrentList();
@@ -133,7 +133,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getItemCount() {
 //           ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getItemCount().
     // RecyclerView calls this A LOT. The base class implementation does
@@ -209,7 +209,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 
   // Called on diff results from the differ
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onResult(@NonNull DiffResult result) {
 //            ^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onResult().
 //                      ^^^^^^^ reference androidx/annotation/NonNull#
@@ -267,14 +267,14 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   boolean diffPayloadsEnabled() {
 //        ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#diffPayloadsEnabled().
     return true;
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onAttachedToRecyclerView(@NonNull RecyclerView recyclerView) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onAttachedToRecyclerView().
 //                                      ^^^^^^^ reference androidx/annotation/NonNull#
@@ -291,7 +291,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onDetachedFromRecyclerView().
 //                                        ^^^^^^^ reference androidx/annotation/NonNull#
@@ -308,7 +308,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewAttachedToWindow(@NonNull EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onViewAttachedToWindow().
 //                                    ^^^^^^^ reference androidx/annotation/NonNull#
@@ -327,7 +327,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewDetachedFromWindow(@NonNull EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onViewDetachedFromWindow().
 //                                      ^^^^^^^ reference androidx/annotation/NonNull#
@@ -346,7 +346,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onModelBound(@NonNull EpoxyViewHolder holder, @NonNull EpoxyModel<?> model,
 //               ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onModelBound().
 //                             ^^^^^^^ reference androidx/annotation/NonNull#
@@ -370,7 +370,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onModelUnbound(@NonNull EpoxyViewHolder holder, @NonNull EpoxyModel<?> model) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#onModelUnbound().
 //                               ^^^^^^^ reference androidx/annotation/NonNull#
@@ -388,7 +388,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 
   /** Get an unmodifiable copy of the current models set on the adapter. */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public List<EpoxyModel<?>> getCopyOfModels() {
 //       ^^^^ reference java/util/List#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -405,7 +405,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    *                                   list.
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<?> getModelAtPosition(int position) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getModelAtPosition().
@@ -421,7 +421,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    * one is found, otherwise null is returned.
    */
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public EpoxyModel<?> getModelById(long id) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                     ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getModelById().
@@ -443,7 +443,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getModelPosition(@NonNull EpoxyModel<?> targetModel) {
 //           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getModelPosition().
 //                             ^^^^^^^ reference androidx/annotation/NonNull#
@@ -478,9 +478,9 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public BoundViewHolders getBoundViewHolders() {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#
 //                        ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#getBoundViewHolders().
@@ -490,7 +490,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @UiThread
-   ^^^^^^^^ reference androidx/annotation/UiThread#
+// ^^^^^^^^ reference androidx/annotation/UiThread#
   void moveModel(int fromPosition, int toPosition) {
 //     ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#moveModel().
 //                   ^^^^^^^^^^^^ definition local28
@@ -538,7 +538,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   }
 
   @UiThread
-   ^^^^^^^^ reference androidx/annotation/UiThread#
+// ^^^^^^^^ reference androidx/annotation/UiThread#
   void notifyModelChanged(int position) {
 //     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#notifyModelChanged().
 //                            ^^^^^^^^ definition local32
@@ -636,7 +636,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    * to the controller.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean isStickyHeader(int position) {
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#isStickyHeader().
 //                                  ^^^^^^^^ definition local45
@@ -651,7 +651,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    * to the controller.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void setupStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#setupStickyHeaderView().
 //                                   ^^^^^^^ reference org/jetbrains/annotations/NotNull#
@@ -668,7 +668,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
    * to the controller.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void teardownStickyHeaderView(@NotNull View stickyHeader) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference org/jetbrains/annotations/NotNull#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
@@ -38,18 +38,18 @@ import androidx.annotation.LayoutRes;
  * layout.
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyDataBindingLayouts {
 //      ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingLayouts#
   /** A list of databinding layout resources that should have EpoxyModel's generated for them. */
   @LayoutRes int[] value();
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                 ^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingLayouts#value().
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingPattern.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingPattern.java
@@ -30,11 +30,11 @@ import java.lang.annotation.Target;
  * class="com.example.CustomClassName" override in the layout xml.
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyDataBindingPattern {
@@ -44,7 +44,7 @@ public @interface EpoxyDataBindingPattern {
    * look up layout files.
    */
   Class<?> rClass();
-  ^^^^^ reference java/lang/Class#
+//^^^^^ reference java/lang/Class#
 //         ^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingPattern#rClass().
   /**
    * A string prefix that your databinding layouts start with. Epoxy will generate a model for each
@@ -54,7 +54,7 @@ public @interface EpoxyDataBindingPattern {
    * databinding layout, Epoxy will generate a HeaderBindingModel_ class for that layout.
    */
   String layoutPrefix();
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingPattern#layoutPrefix().
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
@@ -45,7 +45,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeChanged(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#onItemRangeChanged().
 //                                   ^^^^^^^^^^^^^ definition local1
@@ -59,7 +59,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeChanged(int positionStart, int itemCount, @Nullable Object payload) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#onItemRangeChanged(+1).
 //                                   ^^^^^^^^^^^^^ definition local3
@@ -85,7 +85,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeInserted(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#onItemRangeInserted().
 //                                    ^^^^^^^^^^^^^ definition local6
@@ -99,7 +99,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeRemoved(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#onItemRangeRemoved().
 //                                   ^^^^^^^^^^^^^ definition local8
@@ -113,7 +113,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#onItemRangeMoved().
 //                                 ^^^^^^^^^^^^ definition local10

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
@@ -108,7 +108,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
   }
 
   @Px
-   ^^ reference androidx/annotation/Px#
+// ^^ reference androidx/annotation/Px#
   public int getPxBetweenItems() {
 //           ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#getPxBetweenItems().
     return pxBetweenItems;
@@ -116,7 +116,7 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void getItemOffsets(Rect outRect, View view, RecyclerView parent, State state) {
 //            ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#getItemOffsets().
 //                           ^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -89,7 +89,7 @@ public abstract class EpoxyModel<T> {
   private long id;
 //             ^^ definition com/airbnb/epoxy/EpoxyModel#id.
   @LayoutRes private int layout;
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                       ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#layout.
   private boolean shown = true;
 //                ^^^^^ definition com/airbnb/epoxy/EpoxyModel#shown.
@@ -113,7 +113,7 @@ public abstract class EpoxyModel<T> {
    * allowed for AutoModels, and only if implicit adding is enabled.
    */
   EpoxyController controllerToStageTo;
-  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
+//^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#controllerToStageTo.
   private boolean currentlyInInterceptors;
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#currentlyInInterceptors.
@@ -122,7 +122,7 @@ public abstract class EpoxyModel<T> {
   private boolean hasDefaultId;
 //                ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#hasDefaultId.
   @Nullable private SpanSizeOverrideCallback spanSizeOverride;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#SpanSizeOverrideCallback#
 //                                           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#spanSizeOverride.
 
@@ -534,12 +534,12 @@ public abstract class EpoxyModel<T> {
    * dynamically.
    */
   @LayoutRes
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
   protected abstract int getDefaultLayout();
 //                       ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#getDefaultLayout().
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<T> layout(@LayoutRes int layoutRes) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
@@ -556,7 +556,7 @@ public abstract class EpoxyModel<T> {
   }
 
   @LayoutRes
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
   public final int getLayout() {
 //                 ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#getLayout().
     if (layout == 0) {
@@ -573,7 +573,7 @@ public abstract class EpoxyModel<T> {
    * Sets fields of the model to default ones.
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<T> reset() {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
@@ -846,7 +846,7 @@ public abstract class EpoxyModel<T> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -887,7 +887,7 @@ public abstract class EpoxyModel<T> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#hashCode().
     int result = (int) (id ^ (id >>> 32));
@@ -978,7 +978,7 @@ public abstract class EpoxyModel<T> {
    * EpoxyController}
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<T> show() {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
@@ -993,7 +993,7 @@ public abstract class EpoxyModel<T> {
    * EpoxyController}
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<T> show(boolean show) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
@@ -1014,7 +1014,7 @@ public abstract class EpoxyModel<T> {
    * EpoxyController}
    */
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModel<T> hide() {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModel#[T]
@@ -1086,7 +1086,7 @@ public abstract class EpoxyModel<T> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String toString() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#toString().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelClass.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelClass.java
@@ -33,11 +33,11 @@ import androidx.annotation.LayoutRes;
  * boilerplate reduction.
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyModelClass {
@@ -47,7 +47,7 @@ public @interface EpoxyModelClass {
    * don't have to implement `getDefaultLayout`; it will be generated for you.
    */
   @LayoutRes int layout() default 0;
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //               ^^^^^^ definition com/airbnb/epoxy/EpoxyModelClass#layout().
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -95,7 +95,7 @@ import androidx.annotation.Nullable;
  * manage their children. The shared pool is cleaned up when the activity is destroyed.
  */
 @SuppressWarnings("rawtypes")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#
 //                                   ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelWithHolder#
@@ -110,7 +110,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewStateDefault.
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   private Boolean shouldSaveViewState = null;
 //        ^^^^^^^ reference java/lang/Boolean#
 //                ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState.
@@ -250,9 +250,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull ModelGroupHolder holder) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#bind().
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -290,9 +290,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull ModelGroupHolder holder, @NonNull final List<Object> payloads) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#bind(+1).
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -334,7 +334,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull ModelGroupHolder holder, @NonNull EpoxyModel<?> previouslyBoundModel) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#bind(+2).
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -445,9 +445,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void unbind(@NonNull ModelGroupHolder holder) {
 //            ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#unbind().
 //                    ^^^^^^^ reference androidx/annotation/NonNull#
@@ -459,9 +459,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewAttachedToWindow(ModelGroupHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#onViewAttachedToWindow().
 //                                   ^^^^^^^^^^^^^^^^ reference _root_/
@@ -493,9 +493,9 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewDetachedFromWindow(ModelGroupHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#onViewDetachedFromWindow().
 //                                     ^^^^^^^^^^^^^^^^ reference _root_/
@@ -572,7 +572,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getSpanSize(int totalSpanCount, int position, int itemCount) {
 //           ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#getSpanSize().
 //                           ^^^^^^^^^^^^^^ definition local59
@@ -589,7 +589,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final int getDefaultLayout() {
 //                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#getDefaultLayout().
     throw new UnsupportedOperationException(
@@ -599,7 +599,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   public EpoxyModelGroup shouldSaveViewState(boolean shouldSaveViewState) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#
 //                       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState().
@@ -615,7 +615,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean shouldSaveViewState() {
 //               ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+1).
     // By default state is saved if any of the models have saved state enabled.
@@ -648,7 +648,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final ModelGroupHolder createNewHolder(@NonNull ViewParent parent) {
 //                ^^^^^^^^^^^^^^^^ reference _root_/
 //                                 ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#createNewHolder().
@@ -662,7 +662,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -698,7 +698,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#hashCode().
     int result = super.hashCode();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
@@ -52,7 +52,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //                         ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#TOUCH_DEBOUNCE_MILLIS.
 
   @Nullable private final EpoxyController controller;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                        ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#controller.
   private final Class<T> targetModelClass;
@@ -85,7 +85,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected int getMovementFlags(RecyclerView recyclerView, EpoxyViewHolder viewHolder) {
 //              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#getMovementFlags().
 //                               ^^^^^^^^^^^^ reference _root_/
@@ -128,7 +128,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected boolean canDropOver(RecyclerView recyclerView, EpoxyViewHolder current,
 //                  ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#canDropOver().
 //                              ^^^^^^^^^^^^ reference _root_/
@@ -156,7 +156,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected boolean onMove(RecyclerView recyclerView, EpoxyViewHolder viewHolder,
 //                  ^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onMove().
 //                         ^^^^^^^^^^^^ reference _root_/
@@ -218,7 +218,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onModelMoved(int fromPosition, int toPosition, T modelBeingMoved, View itemView) {
 //            ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onModelMoved().
 //                             ^^^^^^^^^^^^ definition local16
@@ -231,7 +231,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onSwiped(EpoxyViewHolder viewHolder, int direction) {
 //               ^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSwiped().
 //                        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
@@ -274,7 +274,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onSwipeCompleted(T model, View itemView, int position, int direction) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeCompleted().
 //                             ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -287,7 +287,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onSelectedChanged(@Nullable EpoxyViewHolder viewHolder, int actionState) {
 //               ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSelectedChanged().
 //                                  ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -424,7 +424,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onSwipeStarted(T model, View itemView, int adapterPosition) {
 //            ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeStarted().
 //                           ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -436,7 +436,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onSwipeReleased(T model, View itemView) {
 //            ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeReleased().
 //                            ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -447,7 +447,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onDragStarted(T model, View itemView, int adapterPosition) {
 //            ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onDragStarted().
 //                          ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -459,7 +459,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onDragReleased(T model, View itemView) {
 //            ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onDragReleased().
 //                           ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -470,7 +470,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void clearView(final RecyclerView recyclerView, EpoxyViewHolder viewHolder) {
 //               ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
 //                               ^^^^^^^^^^^^ reference _root_/
@@ -516,7 +516,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void clearView(T model, View itemView) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
 //                      ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]
@@ -527,7 +527,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void onChildDraw(Canvas c, RecyclerView recyclerView, EpoxyViewHolder viewHolder,
 //               ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onChildDraw().
 //                           ^^^^^^ reference _root_/
@@ -616,7 +616,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onSwipeProgressChanged(T model, View itemView, float swipeProgress,
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeProgressChanged().
 //                                   ^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -61,7 +61,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
 //                                                         ^^^^^^ definition local1
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull T holder) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#bind().
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -74,7 +74,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull T holder, @NonNull List<Object> payloads) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#bind(+1).
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -92,7 +92,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull T holder, @NonNull EpoxyModel<?> previouslyBoundModel) {
 //            ^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#bind(+2).
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -109,7 +109,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void unbind(@NonNull T holder) {
 //            ^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#unbind().
 //                    ^^^^^^^ reference androidx/annotation/NonNull#
@@ -123,7 +123,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
 
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onVisibilityStateChanged(@Visibility int visibilityState, @NonNull T holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityStateChanged().
 //                                      ^^^^^^^^^^ reference com/airbnb/epoxy/VisibilityState#Visibility#
@@ -139,7 +139,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onVisibilityChanged(
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityChanged().
       @FloatRange(from = 0, to = 100) float percentVisibleHeight,
@@ -175,7 +175,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean onFailedToRecycleView(T holder) {
 //               ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#onFailedToRecycleView().
 //                                     ^ reference com/airbnb/epoxy/EpoxyModelWithHolder#[T]
@@ -187,7 +187,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewAttachedToWindow(T holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#onViewAttachedToWindow().
 //                                   ^ reference com/airbnb/epoxy/EpoxyModelWithHolder#[T]
@@ -199,7 +199,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onViewDetachedFromWindow(T holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#onViewDetachedFromWindow().
 //                                     ^ reference com/airbnb/epoxy/EpoxyModelWithHolder#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
@@ -48,7 +48,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
    * @see androidx.recyclerview.widget.RecyclerView.Adapter#getItemViewType(int)
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected int getViewType() {
 //              ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#getViewType().
     return 0;
@@ -61,7 +61,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
    * @param parent The parent ViewGroup that the returned view will be added to.
    */
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected abstract T buildView(@NonNull ViewGroup parent);
 //                   ^ reference com/airbnb/epoxy/EpoxyModelWithView#[T]
 //                     ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#buildView().
@@ -70,7 +70,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
 //                                                  ^^^^^^ definition local0
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final int getDefaultLayout() {
 //                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#getDefaultLayout().
     throw new UnsupportedOperationException(
@@ -80,7 +80,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public EpoxyModel<T> layout(@LayoutRes int layoutRes) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                  ^ reference com/airbnb/epoxy/EpoxyModelWithView#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
@@ -38,7 +38,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                                                                     ^^^^^^^^ reference ItemTouchHelper/Callback#
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final int getMovementFlags(RecyclerView recyclerView, ViewHolder viewHolder) {
 //                 ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#getMovementFlags().
 //                                  ^^^^^^^^^^^^ reference _root_/
@@ -63,7 +63,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                                                                                   ^^^^^^^^^^ definition local3
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final boolean onMove(RecyclerView recyclerView, ViewHolder viewHolder, ViewHolder target) {
 //                     ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onMove().
 //                            ^^^^^^^^^^^^ reference _root_/
@@ -95,7 +95,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                    ^^^^^^ definition local9
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void onSwiped(ViewHolder viewHolder, int direction) {
 //                  ^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onSwiped().
 //                           ^^^^^^^^^^ reference _root_/
@@ -118,7 +118,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                                                                 ^^^^^^^^^ definition local13
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final boolean canDropOver(RecyclerView recyclerView, ViewHolder current,
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#canDropOver().
 //                                 ^^^^^^^^^^^^ reference _root_/
@@ -158,7 +158,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final float getSwipeThreshold(ViewHolder viewHolder) {
 //                   ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#getSwipeThreshold().
 //                                     ^^^^^^^^^^ reference _root_/
@@ -183,7 +183,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final float getMoveThreshold(ViewHolder viewHolder) {
 //                   ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#getMoveThreshold().
 //                                    ^^^^^^^^^^ reference _root_/
@@ -208,7 +208,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final ViewHolder chooseDropTarget(ViewHolder selected, List dropTargets, int curX,
 //             ^^^^^^^^^^ reference _root_/
 //                        ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#chooseDropTarget().
@@ -260,7 +260,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void onSelectedChanged(ViewHolder viewHolder, int actionState) {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onSelectedChanged().
 //                                    ^^^^^^^^^^ reference _root_/
@@ -289,7 +289,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void onMoved(RecyclerView recyclerView, ViewHolder viewHolder, int fromPos,
 //                  ^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onMoved().
 //                          ^^^^^^^^^^^^ reference _root_/
@@ -347,7 +347,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void clearView(RecyclerView recyclerView, ViewHolder viewHolder) {
 //                  ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#clearView().
 //                            ^^^^^^^^^^^^ reference _root_/
@@ -378,7 +378,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void onChildDraw(Canvas c, RecyclerView recyclerView, ViewHolder viewHolder,
 //                  ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onChildDraw().
 //                              ^^^^^^ reference _root_/
@@ -436,7 +436,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void onChildDrawOver(Canvas c, RecyclerView recyclerView, ViewHolder viewHolder,
 //                  ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#onChildDrawOver().
 //                                  ^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -50,13 +50,13 @@ import androidx.recyclerview.widget.RecyclerView;
 //                                  ^^^^^^^^^^^^ reference androidx/recyclerview/widget/RecyclerView#
 
 @SuppressWarnings("WeakerAccess")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class EpoxyViewHolder extends RecyclerView.ViewHolder {
 //     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#
 //                                   ^^^^^^^^^^^^ reference RecyclerView/
 //                                                ^^^^^^^^^^ reference RecyclerView/ViewHolder#
   @SuppressWarnings("rawtypes") private EpoxyModel epoxyModel;
-   ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 //                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                 ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#epoxyModel.
   private List<Object> payloads;
@@ -67,7 +67,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
 //        ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyHolder#
 //                    ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#epoxyHolder.
   @Nullable ViewHolderState.ViewState initialViewState;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //          ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                          ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#initialViewState.
@@ -213,9 +213,9 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   Object objectToBind() {
-  ^^^^^^ reference java/lang/Object#
+//^^^^^^ reference java/lang/Object#
 //       ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#objectToBind().
     return epoxyHolder != null ? epoxyHolder : itemView;
 //         ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#epoxyHolder.
@@ -325,7 +325,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String toString() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#toString().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
@@ -27,14 +27,14 @@ import androidx.annotation.NonNull;
  * same as the handler's thread.
  */
 class HandlerExecutor implements Executor {
-^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#
+//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#
 //                               ^^^^^^^^ reference java/util/concurrent/Executor#
   final Handler handler;
 //      ^^^^^^^ reference _root_/
 //              ^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#handler.
 
   HandlerExecutor(Handler handler) {
-  ^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#`<init>`().
 //                ^^^^^^^ reference _root_/
 //                        ^^^^^^^ definition local0
     this.handler = handler;
@@ -44,7 +44,7 @@ class HandlerExecutor implements Executor {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void execute(@NonNull Runnable command) {
 //            ^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#execute().
 //                     ^^^^^^^ reference androidx/annotation/NonNull#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/HiddenEpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/HiddenEpoxyModel.java
@@ -18,12 +18,12 @@ import com.airbnb.viewmodeladapter.R;
  * view.
  */
 class HiddenEpoxyModel extends EpoxyModel<Space> {
-^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
-^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#
+//^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
+//^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#
 //                             ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                        ^^^^^ reference _root_/
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getDefaultLayout() {
 //           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#getDefaultLayout().
     return R.layout.view_holder_empty_view;
@@ -33,7 +33,7 @@ class HiddenEpoxyModel extends EpoxyModel<Space> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getSpanSize(int spanCount, int position, int itemCount) {
 //           ^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#getSpanSize().
 //                           ^^^^^^^^^ definition local0

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
  * Thrown if a model is changed after it is added to an {@link com.airbnb.epoxy.EpoxyController}.
  */
 class ImmutableModelException extends RuntimeException {
-^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#
+//^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#
 //                                    ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
   private static final String MODEL_CANNOT_BE_CHANGED_MESSAGE =
 //                     ^^^^^^ reference java/lang/String#
@@ -23,7 +23,7 @@ class ImmutableModelException extends RuntimeException {
           + " call `requestModelBuild` instead to recreate all models.";
 
   ImmutableModelException(EpoxyModel model, int modelPosition) {
-  ^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`().
 //                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                   ^^^^^ definition local0
 //                                              ^^^^^^^^^^^^^ definition local1
@@ -34,7 +34,7 @@ class ImmutableModelException extends RuntimeException {
   }
 
   ImmutableModelException(EpoxyModel model,
-  ^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(+1).
+//^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(+1).
 //                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                   ^^^^^ definition local2
       String descriptionOfWhenChangeHappened, int modelPosition) {
@@ -50,7 +50,7 @@ class ImmutableModelException extends RuntimeException {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   private static String buildMessage(EpoxyModel model,
 //               ^^^^^^ reference java/lang/String#
 //                      ^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#buildMessage().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
@@ -30,7 +30,7 @@ public class ListenersUtils {
 //     ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   static EpoxyViewHolder getEpoxyHolderForChildView(View v) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#getEpoxyHolderForChildView().
@@ -69,7 +69,7 @@ public class ListenersUtils {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   private static RecyclerView findParentRecyclerView(@Nullable View v) {
 //               ^^^^^^^^^^^^ reference _root_/
 //                            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#findParentRecyclerView().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
@@ -12,7 +12,7 @@ import static com.airbnb.epoxy.EpoxyAsyncUtil.MAIN_THREAD_HANDLER;
 //                             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAsyncUtil#
 
 class MainThreadExecutor extends HandlerExecutor {
-^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#
+//^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#
 //                               ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#
   static final MainThreadExecutor INSTANCE = new MainThreadExecutor(false);
 //             ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
@@ -26,7 +26,7 @@ class MainThreadExecutor extends HandlerExecutor {
 //                                                     ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
 
   MainThreadExecutor(boolean async) {
-  ^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#`<init>`().
 //                           ^^^^^ definition local0
     super(async ? AYSNC_MAIN_THREAD_HANDLER : MAIN_THREAD_HANDLER);
 //  ^^^^^ reference com/airbnb/epoxy/HandlerExecutor#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
@@ -44,12 +44,12 @@ import androidx.annotation.NonNull;
  * diffing since we have a knowledge of what changed in the list.
  */
 class ModelList extends ArrayList<EpoxyModel<?>> {
-^^^^^^^^^ definition com/airbnb/epoxy/ModelList#
+//^^^^^^^^^ definition com/airbnb/epoxy/ModelList#
 //                      ^^^^^^^^^ reference java/util/ArrayList#
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
   ModelList(int expectedModelCount) {
-  ^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`().
 //              ^^^^^^^^^^^^^^^^^^ definition local0
     super(expectedModelCount);
 //  ^^^^^ reference java/util/ArrayList#`<init>`().
@@ -57,12 +57,12 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   ModelList() {
-  ^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(+1).
+//^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(+1).
 
   }
 
   interface ModelListObserver {
-  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#
+//^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#
     void onItemRangeInserted(int positionStart, int itemCount);
 //       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#onItemRangeInserted().
 //                               ^^^^^^^^^^^^^ definition local1
@@ -144,7 +144,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public EpoxyModel<?> set(int index, EpoxyModel<?> element) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                     ^^^ definition com/airbnb/epoxy/ModelList#set().
@@ -177,7 +177,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean add(EpoxyModel<?> epoxyModel) {
 //               ^^^ definition com/airbnb/epoxy/ModelList#add().
 //                   ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -192,7 +192,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void add(int index, EpoxyModel<?> element) {
 //            ^^^ definition com/airbnb/epoxy/ModelList#add(+1).
 //                    ^^^^^ definition local14
@@ -209,7 +209,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean addAll(Collection<? extends EpoxyModel<?>> c) {
 //               ^^^^^^ definition com/airbnb/epoxy/ModelList#addAll().
 //                      ^^^^^^^^^^ reference java/util/Collection#
@@ -227,7 +227,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean addAll(int index, Collection<? extends EpoxyModel<?>> c) {
 //               ^^^^^^ definition com/airbnb/epoxy/ModelList#addAll(+1).
 //                          ^^^^^ definition local17
@@ -247,7 +247,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public EpoxyModel<?> remove(int index) {
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                     ^^^^^^ definition com/airbnb/epoxy/ModelList#remove().
@@ -262,7 +262,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean remove(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/ModelList#remove(+1).
 //                      ^^^^^^ reference java/lang/Object#
@@ -288,7 +288,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void clear() {
 //            ^^^^^ definition com/airbnb/epoxy/ModelList#clear().
     if (!isEmpty()) {
@@ -303,7 +303,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected void removeRange(int fromIndex, int toIndex) {
 //               ^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#removeRange().
 //                               ^^^^^^^^^ definition local22
@@ -327,7 +327,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean removeAll(Collection<?> collection) {
 //               ^^^^^^^^^ definition com/airbnb/epoxy/ModelList#removeAll().
 //                         ^^^^^^^^^^ reference java/util/Collection#
@@ -361,7 +361,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean retainAll(Collection<?> collection) {
 //               ^^^^^^^^^ definition com/airbnb/epoxy/ModelList#retainAll().
 //                         ^^^^^^^^^^ reference java/util/Collection#
@@ -395,9 +395,9 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public Iterator<EpoxyModel<?>> iterator() {
 //       ^^^^^^^^ reference java/util/Iterator#
 //                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -503,9 +503,9 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public ListIterator<EpoxyModel<?>> listIterator() {
 //       ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -516,9 +516,9 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public ListIterator<EpoxyModel<?>> listIterator(int index) {
 //       ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -662,9 +662,9 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   @NonNull
-   ^^^^^^^ reference androidx/annotation/NonNull#
+// ^^^^^^^ reference androidx/annotation/NonNull#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public List<EpoxyModel<?>> subList(int start, int end) {
 //       ^^^^ reference java/util/List#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
@@ -38,21 +38,21 @@ import java.lang.annotation.Target;
  * Alternatively, the {@link #options()} parameter can be used to configure a prop.
  */
 @Target({ElementType.METHOD, ElementType.FIELD})
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //       ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                   ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 //                           ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                                       ^^^^^ reference java/lang/annotation/ElementType#FIELD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface ModelProp {
 //      ^^^^^^^^^ definition com/airbnb/epoxy/ModelProp#
 
   enum Option {
-  ^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#
-  ^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#
+//^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#`<init>`().
     /**
      * By default every prop's hashCode and equals method is called when determining the
      * model's state. This option can be used to exclude an prop's hashCode/equals from
@@ -103,7 +103,7 @@ public @interface ModelProp {
 
   /** Specify any {@link Option} values that should be used when generating the model class. */
   Option[] options() default {};
-  ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#
+//^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#
 //         ^^^^^^^ definition com/airbnb/epoxy/ModelProp#options().
 
   /**
@@ -111,7 +111,7 @@ public @interface ModelProp {
    * "@ModelProp(DoNotHash)".
    */
   Option[] value() default {};
-  ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#
+//^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#
 //         ^^^^^ definition com/airbnb/epoxy/ModelProp#value().
 
   /**
@@ -126,7 +126,7 @@ public @interface ModelProp {
    * objects are not valid annotation parameters.
    */
   String defaultValue() default "";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelProp#defaultValue().
 
   /**
@@ -136,6 +136,6 @@ public @interface ModelProp {
    * https://github.com/airbnb/epoxy/wiki/Generating-Models-from-View-Annotations#prop-groups
    */
   String group() default "";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^ definition com/airbnb/epoxy/ModelProp#group().
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
@@ -2,8 +2,8 @@ package com.airbnb.epoxy;
 
 /** Helper to store relevant information about a model that we need to determine if it changed. */
 class ModelState {
-^^^^^^ definition com/airbnb/epoxy/ModelState#`<init>`().
-^^^^^^^^^^ definition com/airbnb/epoxy/ModelState#
+//^^^^^^ definition com/airbnb/epoxy/ModelState#`<init>`().
+//^^^^^^^^^^ definition com/airbnb/epoxy/ModelState#
   long id;
 //     ^^ definition com/airbnb/epoxy/ModelState#id.
   int hashCode;
@@ -11,7 +11,7 @@ class ModelState {
   int position;
 //    ^^^^^^^^ definition com/airbnb/epoxy/ModelState#position.
   EpoxyModel<?> model;
-  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^ definition com/airbnb/epoxy/ModelState#model.
 
   /**
@@ -20,7 +20,7 @@ class ModelState {
    * prevent having to look up the matching pair in a hash map every time.
    */
   ModelState pair;
-  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //           ^^^^ definition com/airbnb/epoxy/ModelState#pair.
 
   /**
@@ -124,7 +124,7 @@ class ModelState {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String toString() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^ definition com/airbnb/epoxy/ModelState#toString().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
@@ -33,11 +33,11 @@ import androidx.annotation.LayoutRes;
  * See https://github.com/airbnb/epoxy/wiki/Generating-Models-from-View-Annotations
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface ModelView {
@@ -49,8 +49,8 @@ public @interface ModelView {
    * layout_width} and {@code layout_height}.
    */
   enum Size {
-  ^^^^ definition com/airbnb/epoxy/ModelView#Size#
-  ^^^^^^ definition com/airbnb/epoxy/ModelView#Size#`<init>`().
+//^^^^ definition com/airbnb/epoxy/ModelView#Size#
+//^^^^^^ definition com/airbnb/epoxy/ModelView#Size#`<init>`().
     NONE,
 //  ^^^^ definition com/airbnb/epoxy/ModelView#Size#NONE.
     WRAP_WIDTH_WRAP_HEIGHT,
@@ -73,7 +73,7 @@ public @interface ModelView {
    * creating the view.
    */
   Size autoLayout() default Size.NONE;
-  ^^^^ reference com/airbnb/epoxy/ModelView#Size#
+//^^^^ reference com/airbnb/epoxy/ModelView#Size#
 //     ^^^^^^^^^^ definition com/airbnb/epoxy/ModelView#autoLayout().
 //                          ^^^^ reference com/airbnb/epoxy/ModelView#Size#
 //                               ^^^^ reference com/airbnb/epoxy/ModelView#Size#NONE.
@@ -85,7 +85,7 @@ public @interface ModelView {
    * Overrides any default set in {@link PackageModelViewConfig}
    */
   @LayoutRes int defaultLayout() default 0;
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //               ^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelView#defaultLayout().
   /**
    * An optional EpoxyModel subclass to use as the base class of the generated view. A default can
@@ -94,7 +94,7 @@ public @interface ModelView {
    * * Overrides any default set in {@link PackageModelViewConfig}
    */
   Class<?> baseModelClass() default Void.class;
-  ^^^^^ reference java/lang/Class#
+//^^^^^ reference java/lang/Class#
 //         ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelView#baseModelClass().
 //                                  ^^^^ reference java/lang/Void#
 //                                       ^^^^^ reference java/lang/Void#class.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpControllerHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpControllerHelper.java
@@ -5,13 +5,13 @@ package com.airbnb.epoxy;
  * com.airbnb.epoxy.AutoModel} usage.
  */
 class NoOpControllerHelper extends ControllerHelper<EpoxyController> {
-^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
-^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#
+//^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
+//^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#
 //                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerHelper#
 //                                                  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void resetAutoModels() {
 //            ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#resetAutoModels().
     // No - Op

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpTimer.java
@@ -1,11 +1,11 @@
 package com.airbnb.epoxy;
 
 class NoOpTimer implements Timer {
-^^^^^^ definition com/airbnb/epoxy/NoOpTimer#`<init>`().
-^^^^^^^^^ definition com/airbnb/epoxy/NoOpTimer#
+//^^^^^^ definition com/airbnb/epoxy/NoOpTimer#`<init>`().
+//^^^^^^^^^ definition com/airbnb/epoxy/NoOpTimer#
 //                         ^^^^^ reference com/airbnb/epoxy/Timer#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void start(String sectionName) {
 //            ^^^^^ definition com/airbnb/epoxy/NoOpTimer#start().
 //                  ^^^^^^ reference java/lang/String#
@@ -14,7 +14,7 @@ class NoOpTimer implements Timer {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void stop() {
 //            ^^^^ definition com/airbnb/epoxy/NoOpTimer#stop().
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
@@ -15,8 +15,8 @@ import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver;
  * This observer throws upon any changes done outside of diffing.
  */
 class NotifyBlocker extends AdapterDataObserver {
-^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#`<init>`().
-^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#
+//^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#`<init>`().
+//^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#
 //                          ^^^^^^^^^^^^^^^^^^^ reference _root_/
 
   private boolean changesAllowed;
@@ -35,7 +35,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onChanged() {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onChanged().
     if (!changesAllowed) {
@@ -48,7 +48,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeChanged(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onItemRangeChanged().
 //                                   ^^^^^^^^^^^^^ definition local0
@@ -58,7 +58,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeChanged(int positionStart, int itemCount, Object payload) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onItemRangeChanged(+1).
 //                                   ^^^^^^^^^^^^^ definition local2
@@ -70,7 +70,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeInserted(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onItemRangeInserted().
 //                                    ^^^^^^^^^^^^^ definition local5
@@ -80,7 +80,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeRemoved(int positionStart, int itemCount) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onItemRangeRemoved().
 //                                   ^^^^^^^^^^^^^ definition local7
@@ -90,7 +90,7 @@ class NotifyBlocker extends AdapterDataObserver {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#onItemRangeMoved().
 //                                 ^^^^^^^^^^^^ definition local9

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnViewRecycled.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnViewRecycled.java
@@ -27,11 +27,11 @@ import java.lang.annotation.Target;
  * RecyclerView.
  */
 @Target(ElementType.METHOD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnViewRecycled {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityChanged.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityChanged.java
@@ -37,11 +37,11 @@ import java.lang.annotation.Target;
  * @see OnModelVisibilityChangedListener
  */
 @Target(ElementType.METHOD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnVisibilityChanged {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityStateChanged.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityStateChanged.java
@@ -37,13 +37,13 @@ import java.lang.annotation.Target;
  * @see OnModelVisibilityStateChangedListener
  */
 @SuppressWarnings("JavadocReference")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 @Target(ElementType.METHOD)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnVisibilityStateChanged {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -31,11 +31,11 @@ import java.lang.annotation.Target;
  * See https://github.com/airbnb/epoxy/wiki/Configuration for more details on these options.
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface PackageEpoxyConfig {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageModelViewConfig.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageModelViewConfig.java
@@ -27,11 +27,11 @@ import java.lang.annotation.Target;
  * packages.
  */
 @Target(ElementType.TYPE)
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                  ^^^^ reference java/lang/annotation/ElementType#TYPE.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface PackageModelViewConfig {
@@ -41,7 +41,7 @@ public @interface PackageModelViewConfig {
    * look up layout files.
    */
   Class<?> rClass();
-  ^^^^^ reference java/lang/Class#
+//^^^^^ reference java/lang/Class#
 //         ^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#rClass().
   /**
    * A default layout pattern to be used for specifying layouts for generated models. If this is set
@@ -52,12 +52,12 @@ public @interface PackageModelViewConfig {
    * changed to "view_holder_%s" then the layout used would be "R.layout.view_holder_my_view".
    */
   String defaultLayoutPattern() default "%s";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#defaultLayoutPattern().
 
   /** An optional EpoxyModel subclass that generated models should extend. */
   Class<?> defaultBaseModelClass() default Void.class;
-  ^^^^^ reference java/lang/Class#
+//^^^^^ reference java/lang/Class#
 //         ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#defaultBaseModelClass().
 //                                         ^^^^ reference java/lang/Void#
 //                                              ^^^^^ reference java/lang/Void#class.
@@ -77,7 +77,7 @@ public @interface PackageModelViewConfig {
    * Suffix, which will be appended to generated model's names. "Model_" is a default value.
    */
   String generatedModelSuffix() default "Model_";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#generatedModelSuffix().
 
   /**
@@ -92,7 +92,7 @@ public @interface PackageModelViewConfig {
    * Default is false. This may also be set project wide with an annotation processor option.
    */
   Option disableGenerateBuilderOverloads() default Option.Default;
-  ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
+//^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#disableGenerateBuilderOverloads().
 //                                                 ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //                                                        ^^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#Default.
@@ -106,7 +106,7 @@ public @interface PackageModelViewConfig {
    * Default is false. This may also be set project wide with an annotation processor option.
    */
   Option disableGenerateGetters() default Option.Default;
-  ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
+//^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //       ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#disableGenerateGetters().
 //                                        ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //                                               ^^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#Default.
@@ -121,7 +121,7 @@ public @interface PackageModelViewConfig {
    * Default is false. This may also be set project wide with an annotation processor option.
    */
   Option disableGenerateReset() default Option.Default;
-  ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
+//^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#disableGenerateReset().
 //                                      ^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#
 //                                             ^^^^^^^ reference com/airbnb/epoxy/PackageModelViewConfig#Option#Default.
@@ -130,8 +130,8 @@ public @interface PackageModelViewConfig {
    * Enable or Disable an option, or inherit the default.
    */
   enum Option {
-  ^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#
-  ^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#
+//^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#`<init>`().
     Default,
 //  ^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#Default.
     Enabled,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
@@ -22,12 +22,12 @@ import androidx.annotation.PluralsRes;
 public class QuantityStringResAttribute {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#
   @PluralsRes private final int id;
-   ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
+// ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
 //                              ^^ definition com/airbnb/epoxy/QuantityStringResAttribute#id.
   private final int quantity;
 //                  ^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#quantity.
   @Nullable private final Object[] formatArgs;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                        ^^^^^^ reference java/lang/Object#
 //                                 ^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#formatArgs.
 
@@ -65,7 +65,7 @@ public class QuantityStringResAttribute {
   }
 
   @PluralsRes
-   ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
+// ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
   public int getId() {
 //           ^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#getId().
     return id;
@@ -79,7 +79,7 @@ public class QuantityStringResAttribute {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public Object[] getFormatArgs() {
 //       ^^^^^^ reference java/lang/Object#
 //                ^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#getFormatArgs().
@@ -114,7 +114,7 @@ public class QuantityStringResAttribute {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -158,7 +158,7 @@ public class QuantityStringResAttribute {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#hashCode().
     int result = id;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyAdapter.java
@@ -28,7 +28,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void enableDiffing() {
 //            ^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#enableDiffing().
     super.enableDiffing();
@@ -37,7 +37,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void notifyModelsChanged() {
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelsChanged().
     super.notifyModelsChanged();
@@ -46,7 +46,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public BoundViewHolders getBoundViewHolders() {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#
 //                        ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#getBoundViewHolders().
@@ -56,7 +56,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void notifyModelChanged(EpoxyModel<?> model) {
 //            ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelChanged().
 //                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -68,7 +68,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void addModels(EpoxyModel<?>... modelsToAdd) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#addModels().
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -80,7 +80,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void addModels(Collection<? extends EpoxyModel<?>> modelsToAdd) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#addModels(+1).
 //                      ^^^^^^^^^^ reference java/util/Collection#
@@ -93,7 +93,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void insertModelBefore(EpoxyModel<?> modelToInsert, EpoxyModel<?> modelToInsertBefore) {
 //            ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelBefore().
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -108,7 +108,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void insertModelAfter(EpoxyModel<?> modelToInsert, EpoxyModel<?> modelToInsertAfter) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelAfter().
 //                             ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -123,7 +123,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void removeModel(EpoxyModel<?> model) {
 //            ^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#removeModel().
 //                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -135,7 +135,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void removeAllModels() {
 //            ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllModels().
     super.removeAllModels();
@@ -144,7 +144,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void removeAllAfterModel(EpoxyModel<?> model) {
 //            ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllAfterModel().
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -156,7 +156,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModel(EpoxyModel<?> model, boolean show) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModel().
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -170,7 +170,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModel(EpoxyModel<?> model) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModel(+1).
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -182,7 +182,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModels(EpoxyModel<?>... models) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModels().
 //                       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -194,7 +194,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModels(boolean show, EpoxyModel<?>... models) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+1).
 //                               ^^^^ definition local13
@@ -208,7 +208,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModels(Iterable<EpoxyModel<?>> epoxyModels) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+2).
 //                       ^^^^^^^^ reference java/lang/Iterable#
@@ -221,7 +221,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void showModels(Iterable<EpoxyModel<?>> epoxyModels, boolean show) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+3).
 //                       ^^^^^^^^ reference java/lang/Iterable#
@@ -236,7 +236,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void hideModel(EpoxyModel<?> model) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#hideModel().
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -248,7 +248,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void hideModels(Iterable<EpoxyModel<?>> epoxyModels) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels().
 //                       ^^^^^^^^ reference java/lang/Iterable#
@@ -261,7 +261,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void hideModels(EpoxyModel<?>... models) {
 //            ^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels(+1).
 //                       ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -273,7 +273,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void hideAllAfterModel(EpoxyModel<?> model) {
 //            ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#hideAllAfterModel().
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -285,7 +285,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public List<EpoxyModel<?>> getAllModelsAfter(EpoxyModel<?> model) {
 //       ^^^^ reference java/util/List#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -299,7 +299,7 @@ public class SimpleEpoxyAdapter extends EpoxyAdapter {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getModelPosition(EpoxyModel<?> model) {
 //           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#getModelPosition().
 //                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
@@ -41,7 +41,7 @@ public class SimpleEpoxyController extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void requestModelBuild() {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#requestModelBuild().
     if (!insideSetModels) {
@@ -57,7 +57,7 @@ public class SimpleEpoxyController extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final void buildModels() {
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#buildModels().
     if (!isBuildingModels()) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
@@ -29,7 +29,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
 //                                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                               ^^^^ reference _root_/
   @LayoutRes private final int layoutRes;
-   ^^^^^^^^^ reference androidx/annotation/LayoutRes#
+// ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                             ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#layoutRes.
   private View.OnClickListener onClickListener;
 //        ^^^^ reference View/
@@ -74,9 +74,9 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void bind(@NonNull View view) {
 //            ^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#bind().
 //                  ^^^^^^^ reference androidx/annotation/NonNull#
@@ -97,9 +97,9 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @CallSuper
-   ^^^^^^^^^ reference androidx/annotation/CallSuper#
+// ^^^^^^^^^ reference androidx/annotation/CallSuper#
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void unbind(@NonNull View view) {
 //            ^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#unbind().
 //                    ^^^^^^^ reference androidx/annotation/NonNull#
@@ -115,7 +115,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected int getDefaultLayout() {
 //              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#getDefaultLayout().
     return layoutRes;
@@ -123,7 +123,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int getSpanSize(int totalSpanCount, int position, int itemCount) {
 //           ^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#getSpanSize().
 //                           ^^^^^^^^^^^^^^ definition local5
@@ -134,7 +134,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -186,7 +186,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#hashCode().
     int result = super.hashCode();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
@@ -28,27 +28,27 @@ public class StringAttributeData {
   private final boolean hasDefault;
 //                      ^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#hasDefault.
   @Nullable private final CharSequence defaultString;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                        ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                     ^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#defaultString.
   @StringRes private final int defaultStringRes;
-   ^^^^^^^^^ reference androidx/annotation/StringRes#
+// ^^^^^^^^^ reference androidx/annotation/StringRes#
 //                             ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#defaultStringRes.
 
   @Nullable private CharSequence string;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                  ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                               ^^^^^^ definition com/airbnb/epoxy/StringAttributeData#string.
   @StringRes private int stringRes;
-   ^^^^^^^^^ reference androidx/annotation/StringRes#
+// ^^^^^^^^^ reference androidx/annotation/StringRes#
 //                       ^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#stringRes.
   @PluralsRes private int pluralRes;
-   ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
+// ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
 //                        ^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#pluralRes.
   private int quantity;
 //            ^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#quantity.
   @Nullable private Object[] formatArgs;
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
 //                  ^^^^^^ reference java/lang/Object#
 //                           ^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#formatArgs.
 
@@ -249,7 +249,7 @@ public class StringAttributeData {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/StringAttributeData#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -309,7 +309,7 @@ public class StringAttributeData {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#hashCode().
     int result = string != null ? string.hashCode() : 0;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TextProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TextProp.java
@@ -35,19 +35,19 @@ import androidx.annotation.StringRes;
  * com.airbnb.epoxy.ModelProp.Option#GenerateStringOverloads}
  */
 @Target({ElementType.METHOD, ElementType.FIELD})
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //       ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                   ^^^^^^ reference java/lang/annotation/ElementType#METHOD.
 //                           ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 //                                       ^^^^^ reference java/lang/annotation/ElementType#FIELD.
 @Retention(RetentionPolicy.CLASS)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface TextProp {
 //      ^^^^^^^^ definition com/airbnb/epoxy/TextProp#
 
   @StringRes int defaultRes() default 0;
-   ^^^^^^^^^ reference androidx/annotation/StringRes#
+// ^^^^^^^^^ reference androidx/annotation/StringRes#
 //               ^^^^^^^^^^ definition com/airbnb/epoxy/TextProp#defaultRes().
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
@@ -1,7 +1,7 @@
 package com.airbnb.epoxy;
 
 interface Timer {
-^^^^^ definition com/airbnb/epoxy/Timer#
+//^^^^^ definition com/airbnb/epoxy/Timer#
   void start(String sectionName);
 //     ^^^^^ definition com/airbnb/epoxy/Timer#start().
 //           ^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
@@ -75,7 +75,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void requestModelBuild() {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#requestModelBuild().
     if (!allowModelBuildRequests) {
@@ -92,7 +92,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void moveModel(int fromPosition, int toPosition) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#moveModel().
 //                          ^^^^^^^^^^^^ definition local4
@@ -109,7 +109,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void requestDelayedModelBuild(int delayMs) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#requestDelayedModelBuild().
 //                                         ^^^^^^^ definition local6
@@ -128,7 +128,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final void buildModels() {
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#buildModels().
     if (!isBuildingModels()) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
@@ -84,7 +84,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void requestModelBuild() {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#requestModelBuild().
     if (!allowModelBuildRequests) {
@@ -101,7 +101,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void moveModel(int fromPosition, int toPosition) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#moveModel().
 //                          ^^^^^^^^^^^^ definition local5
@@ -118,7 +118,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void requestDelayedModelBuild(int delayMs) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#requestDelayedModelBuild().
 //                                         ^^^^^^^ definition local7
@@ -137,7 +137,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final void buildModels() {
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#buildModels().
     if (!isBuildingModels()) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
@@ -93,7 +93,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void requestModelBuild() {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#requestModelBuild().
     if (!allowModelBuildRequests) {
@@ -110,7 +110,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void moveModel(int fromPosition, int toPosition) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#moveModel().
 //                          ^^^^^^^^^^^^ definition local6
@@ -127,7 +127,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void requestDelayedModelBuild(int delayMs) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#requestDelayedModelBuild().
 //                                         ^^^^^^^ definition local8
@@ -146,7 +146,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final void buildModels() {
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#buildModels().
     if (!isBuildingModels()) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
@@ -64,7 +64,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public final void requestModelBuild() {
 //                  ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#requestModelBuild().
     if (!allowModelBuildRequests) {
@@ -81,7 +81,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void moveModel(int fromPosition, int toPosition) {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#moveModel().
 //                          ^^^^^^^^^^^^ definition local3
@@ -98,7 +98,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void requestDelayedModelBuild(int delayMs) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#requestDelayedModelBuild().
 //                                         ^^^^^^^ definition local5
@@ -117,7 +117,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
   }
 
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   public final T getCurrentData() {
 //             ^ reference com/airbnb/epoxy/TypedEpoxyController#[T]
 //               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#getCurrentData().
@@ -126,7 +126,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   protected final void buildModels() {
 //                     ^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#buildModels().
     if (!isBuildingModels()) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -27,20 +27,20 @@ import androidx.annotation.Nullable;
 
 /** Defines an operation that makes a change to the epoxy model list. */
 class UpdateOp {
-^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#
+//^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#
 
   @IntDef({ADD, REMOVE, UPDATE, MOVE})
-   ^^^^^^ reference androidx/annotation/IntDef#
+// ^^^^^^ reference androidx/annotation/IntDef#
 //         ^^^ reference com/airbnb/epoxy/UpdateOp#ADD.
 //              ^^^^^^ reference com/airbnb/epoxy/UpdateOp#REMOVE.
 //                      ^^^^^^ reference com/airbnb/epoxy/UpdateOp#UPDATE.
 //                              ^^^^ reference com/airbnb/epoxy/UpdateOp#MOVE.
   @Retention(RetentionPolicy.SOURCE)
-   ^^^^^^^^^ reference java/lang/annotation/Retention#
+// ^^^^^^^^^ reference java/lang/annotation/Retention#
 //           ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                           ^^^^^^ reference java/lang/annotation/RetentionPolicy#SOURCE.
   @interface Type {
-   ^^^^ definition com/airbnb/epoxy/UpdateOp#Type#
+// ^^^^ definition com/airbnb/epoxy/UpdateOp#Type#
   }
 
   static final int ADD = 0;
@@ -53,7 +53,7 @@ class UpdateOp {
 //                 ^^^^ definition com/airbnb/epoxy/UpdateOp#MOVE.
 
   @Type int type;
-   ^^^^ reference com/airbnb/epoxy/UpdateOp#Type#
+// ^^^^ reference com/airbnb/epoxy/UpdateOp#Type#
 //          ^^^^ definition com/airbnb/epoxy/UpdateOp#type.
   int positionStart;
 //    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#positionStart.
@@ -61,7 +61,7 @@ class UpdateOp {
   int itemCount;
 //    ^^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#itemCount.
   ArrayList<EpoxyModel<?>> payloads;
-  ^^^^^^^^^ reference java/util/ArrayList#
+//^^^^^^^^^ reference java/util/ArrayList#
 //          ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                         ^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#payloads.
 
@@ -176,7 +176,7 @@ class UpdateOp {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String toString() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#toString().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
@@ -44,8 +44,8 @@ import static com.airbnb.epoxy.UpdateOp.UPDATE;
 
 /** Helper class to collect changes in a diff, batching when possible. */
 class UpdateOpHelper {
-^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#`<init>`().
-^^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#
+//^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#`<init>`().
+//^^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#
   final List<UpdateOp> opList = new ArrayList<>();
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -57,14 +57,14 @@ import androidx.collection.LongSparseArray;
  * the {@link EpoxyModel}.
  */
 @SuppressWarnings("WeakerAccess")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
-^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#
+//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#
 //                            ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
 //                                            ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                                                  ^^^^^^^^^^ reference _root_/
   ViewHolderState() {
-  ^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`().
+//^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`().
   }
 
   private ViewHolderState(int size) {
@@ -76,14 +76,14 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int describeContents() {
 //           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#describeContents().
     return 0;
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void writeToParcel(Parcel dest, int flags) {
 //            ^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#writeToParcel().
 //                          ^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
@@ -19,8 +19,8 @@ import androidx.annotation.VisibleForTesting;
 //                         ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
 
 class ViewTypeManager {
-^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#`<init>`().
-^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#
+//^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#`<init>`().
+//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#
   private static final Map<Class, Integer> VIEW_TYPE_MAP = new HashMap<>();
 //                     ^^^ reference java/util/Map#
 //                         ^^^^^ reference java/lang/Class#
@@ -33,9 +33,9 @@ class ViewTypeManager {
    * look up what view type belongs to which model.
    */
   @Nullable
-   ^^^^^^^^ reference androidx/annotation/Nullable#
+// ^^^^^^^^ reference androidx/annotation/Nullable#
   EpoxyModel<?> lastModelForViewTypeLookup;
-  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#lastModelForViewTypeLookup.
 
   /**
@@ -45,7 +45,7 @@ class ViewTypeManager {
    * don't carry over values across tests.
    */
   @VisibleForTesting
-   ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
+// ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
   void resetMapForTesting() {
 //     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#resetMapForTesting().
     VIEW_TYPE_MAP.clear();
@@ -127,7 +127,7 @@ class ViewTypeManager {
    * shouldn't be needed, but is a guard against recyclerview behavior changing.
    */
   EpoxyModel<?> getModelForViewType(BaseEpoxyAdapter adapter, int viewType) {
-  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
+//^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#getModelForViewType().
 //                                  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
 //                                                   ^^^^^^^ definition local5

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
@@ -21,11 +21,11 @@ public final class VisibilityState {
 //           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#
 
   @Retention(RetentionPolicy.SOURCE)
-   ^^^^^^^^^ reference java/lang/annotation/Retention#
+// ^^^^^^^^^ reference java/lang/annotation/Retention#
 //           ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                           ^^^^^^ reference java/lang/annotation/RetentionPolicy#SOURCE.
   @IntDef({VISIBLE,
-   ^^^^^^ reference androidx/annotation/IntDef#
+// ^^^^^^ reference androidx/annotation/IntDef#
 //         ^^^^^^^ reference com/airbnb/epoxy/VisibilityState#VISIBLE.
            INVISIBLE,
 //         ^^^^^^^^^ reference com/airbnb/epoxy/VisibilityState#INVISIBLE.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
@@ -54,7 +54,7 @@ public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public void onCheckedChanged(CompoundButton button, boolean isChecked) {
 //            ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#onCheckedChanged().
 //                             ^^^^^^^^^^^^^^ reference _root_/
@@ -103,7 +103,7 @@ public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public boolean equals(Object o) {
 //               ^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#equals().
 //                      ^^^^^^ reference java/lang/Object#
@@ -134,7 +134,7 @@ public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public int hashCode() {
 //           ^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#hashCode().
     return originalCheckedChangeListener.hashCode();

--- a/tests/snapshots/src/main/generated/minimized/Annotations.java
+++ b/tests/snapshots/src/main/generated/minimized/Annotations.java
@@ -28,13 +28,13 @@ import static java.lang.annotation.ElementType.*;
 //                                 ^^^^^^^^^^^ reference java/lang/annotation/ElementType#
 
 @Documented
- ^^^^^^^^^^ reference java/lang/annotation/Documented#
+//^^^^^^^^^ reference java/lang/annotation/Documented#
 @Retention(RetentionPolicy.RUNTIME)
- ^^^^^^^^^ reference java/lang/annotation/Retention#
+//^^^^^^^^ reference java/lang/annotation/Retention#
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^^^ reference java/lang/annotation/RetentionPolicy#RUNTIME.
 @Target(value = {CONSTRUCTOR, FIELD, LOCAL_VARIABLE, METHOD, PACKAGE, PARAMETER, TYPE})
- ^^^^^^ reference java/lang/annotation/Target#
+//^^^^^ reference java/lang/annotation/Target#
 //      ^^^^^ reference java/lang/annotation/Target#value().
 //               ^^^^^^^^^^^ reference java/lang/annotation/ElementType#CONSTRUCTOR.
 //                            ^^^^^ reference java/lang/annotation/ElementType#FIELD.
@@ -47,10 +47,10 @@ public @interface Annotations {
 //      ^^^^^^^^^^^ definition minimized/Annotations#
 
   String value() default "";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^ definition minimized/Annotations#value().
 
   String format() default "";
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^ definition minimized/Annotations#format().
 }

--- a/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 //                        ^^^^^^^^ reference java/util/function/Function#
 
 @SuppressWarnings("ALL")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class AnonymousClasses {
 //     ^^^^^^ definition minimized/AnonymousClasses#`<init>`().
 //     ^^^^^^^^^^^^^^^^ definition minimized/AnonymousClasses#

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -1,5 +1,5 @@
 package minimized;
-^^^^^ reference minimized/Enums#
+//^^^^^ reference minimized/Enums#
 
 import java.util.Arrays;
 //     ^^^^ reference java/
@@ -9,20 +9,20 @@ import java.util.Arrays;
 public enum Enums {
 //     ^^^^^ definition minimized/Enums#
   A("A"),
-  ^ definition minimized/Enums#A.
-   ^^^^^ reference minimized/Enums#`<init>`().
+//^ definition minimized/Enums#A.
+// ^^^^^ reference minimized/Enums#`<init>`().
   B("B"),
-  ^ definition minimized/Enums#B.
-   ^^^^^ reference minimized/Enums#`<init>`().
+//^ definition minimized/Enums#B.
+// ^^^^^ reference minimized/Enums#`<init>`().
   C("C");
-  ^ definition minimized/Enums#C.
-   ^^^^^ reference minimized/Enums#`<init>`().
+//^ definition minimized/Enums#C.
+// ^^^^^ reference minimized/Enums#`<init>`().
   public String value;
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^ definition minimized/Enums#value.
 
   Enums(String value) {
-  ^^^^^^ definition minimized/Enums#`<init>`().
+//^^^^^^ definition minimized/Enums#`<init>`().
 //      ^^^^^^ reference java/lang/String#
 //             ^^^^^ definition local0
     this.value = value;

--- a/tests/snapshots/src/main/generated/minimized/Interfaces.java
+++ b/tests/snapshots/src/main/generated/minimized/Interfaces.java
@@ -3,7 +3,7 @@ package minimized;
 public interface Interfaces {
 //     ^^^^^^^^^^ definition minimized/Interfaces#
   String abstractInterfaceMethod();
-  ^^^^^^ reference java/lang/String#
+//^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^^^^^^^^^^^^ definition minimized/Interfaces#abstractInterfaceMethod().
 
   default String defaultInterfaceMethod() {

--- a/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
@@ -1,7 +1,7 @@
 package minimized;
 
 @Annotations(value = "value", format = "format")
- ^^^^^^^^^^^ reference minimized/Annotations#
+//^^^^^^^^^^ reference minimized/Annotations#
 //           ^^^^^ reference minimized/Annotations#value().
 //                            ^^^^^^ reference minimized/Annotations#format().
 public class MinimizedJavaMain {

--- a/tests/snapshots/src/main/generated/minimized/RawTypes.java
+++ b/tests/snapshots/src/main/generated/minimized/RawTypes.java
@@ -10,7 +10,7 @@ import java.util.List;
 //               ^^^^ reference java/util/List#
 
 @SuppressWarnings("ALL")
- ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class RawTypes {
 //     ^^^^^^ definition minimized/RawTypes#`<init>`().
 //     ^^^^^^^^ definition minimized/RawTypes#

--- a/tests/snapshots/src/main/generated/minimized/SubClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/SubClasses.java
@@ -7,7 +7,7 @@ public class SubClasses extends AbstractClasses implements Interfaces {
 //                                                         ^^^^^^^^^^ reference minimized/Interfaces#
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String abstractImplementation() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^^^^^^^^^^^^^^^ definition minimized/SubClasses#abstractImplementation().
@@ -15,7 +15,7 @@ public class SubClasses extends AbstractClasses implements Interfaces {
   }
 
   @Override
-   ^^^^^^^^ reference java/lang/Override#
+// ^^^^^^^^ reference java/lang/Override#
   public String abstractInterfaceMethod() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^^^^^^^^^^^^^^^^ definition minimized/SubClasses#abstractInterfaceMethod().

--- a/tests/snapshots/src/main/generated/minimized/TypeVariables.java
+++ b/tests/snapshots/src/main/generated/minimized/TypeVariables.java
@@ -18,7 +18,7 @@ public class TypeVariables {
   }
 
   interface I {
-  ^ definition minimized/TypeVariables#I#
+//^ definition minimized/TypeVariables#I#
     void mI();
 //       ^^ definition minimized/TypeVariables#I#mI().
   }

--- a/tests/unit/src/main/scala/tests/SemanticdbPrinters.scala
+++ b/tests/unit/src/main/scala/tests/SemanticdbPrinters.scala
@@ -49,12 +49,17 @@ object SemanticdbPrinters {
       }
     out
       .append(
-        if (r.getStartCharacter > 3)
+        if (r.getStartCharacter > 2)
           "// " + " " * (r.getStartCharacter - 3)
         else
-          " " * r.getStartCharacter
+          "//" //* r.getStartCharacter
       )
-      .append("^" * width)
+      .append(
+        if (r.getStartCharacter == 1)
+          "^" * (width-1)
+        else
+          "^" * width
+      )
       .append(" ")
       .append(occ.getRole.toString.toLowerCase)
       .append(" ")

--- a/tests/unit/src/main/scala/tests/SemanticdbPrinters.scala
+++ b/tests/unit/src/main/scala/tests/SemanticdbPrinters.scala
@@ -52,7 +52,7 @@ object SemanticdbPrinters {
         if (r.getStartCharacter > 2)
           "// " + " " * (r.getStartCharacter - 3)
         else
-          "//" //* r.getStartCharacter
+          "//"
       )
       .append(
         if (r.getStartCharacter == 1)


### PR DESCRIPTION
You can see the change this has by looking at the committed snapshot files :slightly_smiling_face: 

For cases where there is no 1 or more whitespace of leeway, we cut down the number of `^` by one. This mostly affects type decls, who's ranges need to be fixed _anyways_ and annotations on decls