### PR TITLE
fixes range deriving for constructs incl classes/interfaces

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/CompilerRange.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/CompilerRange.java
@@ -28,12 +28,35 @@ public enum CompilerRange {
    * Map the compiler (point + 1) position to SemanticDB start and use (point + symbol name length +
    * 1) for the SemanticDB end position.
    */
-  FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE;
+  FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE,
+
+  /**
+   * Use text search to find the start of the symbol name and use (found start + symbol name length)
+   * for the SemanticDB end position;
+   */
+  FROM_TEXT_SEARCH,
+
+  /**
+   * Use text search to find the start of the symbol name, using the point position as the starting
+   * search offset and using (found start + symbol name length) for the SemanticDB end position;
+   */
+  FROM_POINT_WITH_TEXT_SEARCH;
 
   public boolean isFromPoint() {
     switch (this) {
       case FROM_POINT_TO_SYMBOL_NAME:
       case FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE:
+      case FROM_POINT_WITH_TEXT_SEARCH:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public boolean isFromTextSearch() {
+    switch (this) {
+      case FROM_TEXT_SEARCH:
+      case FROM_POINT_WITH_TEXT_SEARCH:
         return true;
       default:
         return false;

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -1,0 +1,63 @@
+package com.sourcegraph.semanticdb_javac;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.LineMap;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RangeFinder {
+  public static Optional<Semanticdb.Range> findRange(
+      TreePath path, Trees trees, CompilationUnitTree root, Element element, int startPos) {
+    LineMap lineMap = root.getLineMap();
+    Name name = element.getSimpleName();
+    if (name.contentEquals("<init>")) name = element.getEnclosingElement().getSimpleName();
+
+    int endPos = (int) trees.getSourcePositions().getEndPosition(root, path.getLeaf());
+    // false for anonymous classes
+    if (name.length() != 0) {
+      startPos = findNameIn(root, name, startPos, endPos);
+      endPos = startPos + name.length();
+    }
+
+    if (endPos == -1) {
+      return Optional.empty();
+    }
+
+    Semanticdb.Range range =
+        Semanticdb.Range.newBuilder()
+            .setStartLine((int) lineMap.getLineNumber(startPos) - 1)
+            .setStartCharacter((int) lineMap.getColumnNumber(startPos) - 1)
+            .setEndLine((int) lineMap.getLineNumber(endPos) - 1)
+            .setEndCharacter((int) lineMap.getColumnNumber(endPos) - 1)
+            .build();
+    return Optional.of(range);
+  }
+
+  private static int findNameIn(CompilationUnitTree root, CharSequence name, int start, int end) {
+    String contents;
+    try {
+      contents = root.getSourceFile().getCharContent(true).toString();
+    } catch (IOException e) {
+      return -1;
+    }
+
+    if (end == -1) {
+      end = contents.length();
+    }
+
+    Matcher matcher = Pattern.compile("\\b" + name + "\\b").matcher(contents);
+    matcher.region(start, end);
+    if (matcher.find()) {
+      return matcher.start();
+    } else {
+      return -1;
+    }
+  }
+}

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -52,12 +52,10 @@ public class RangeFinder {
       end = contents.length();
     }
 
-    Matcher matcher = Pattern.compile("\\b" + name + "\\b").matcher(contents);
-    matcher.region(start, end);
-    if (matcher.find()) {
-      return matcher.start();
-    } else {
-      return -1;
+    int offset = contents.indexOf(" " + name, start);
+    if (offset > -1) {
+      return offset + 1;
     }
+    return -1;
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -49,7 +49,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     }
     this.occurrences = new ArrayList<>();
     this.symbolInfos = new ArrayList<>();
-    // this.source = "";
+    this.source = semanticdbText();
   }
 
   public Semanticdb.TextDocument buildTextDocument(CompilationUnitTree tree) {
@@ -60,7 +60,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
         .setSchema(Semanticdb.Schema.SEMANTICDB4)
         .setLanguage(Semanticdb.Language.JAVA)
         .setUri(semanticdbUri())
-        .setText(semanticdbText(!options.includeText))
+        .setText(options.includeText ? this.source : "")
         .setMd5(semanticdbMd5())
         .addAllOccurrences(occurrences)
         .addAllSymbols(symbolInfos)
@@ -188,12 +188,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
     if (kind.isFromTextSearch() && sym.name.length() > 0) {
       return RangeFinder.findRange(
-          getCurrentPath(),
-          trees,
-          getCurrentPath().getCompilationUnit(),
-          sym,
-          start,
-          semanticdbText(false));
+          getCurrentPath(), trees, getCurrentPath().getCompilationUnit(), sym, start, this.source);
     } else if (start != Position.NOPOS && end != Position.NOPOS && end > start) {
       LineMap lineMap = event.getCompilationUnit().getLineMap();
       Semanticdb.Range range =
@@ -230,8 +225,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     }
   }
 
-  private String semanticdbText(boolean noop) {
-    if (noop) return "";
+  private String semanticdbText() {
     if (source != null) return source;
     try {
       source = event.getSourceFile().getCharContent(true).toString();

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -107,7 +107,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     if (node instanceof JCTree.JCMethodDecl) {
       JCTree.JCMethodDecl meth = (JCTree.JCMethodDecl) node;
       CompilerRange range = CompilerRange.FROM_POINT_TO_SYMBOL_NAME;
-      if (meth.params.isEmpty() && (meth.sym.flags() & Flags.GENERATEDCONSTR) != 0L) {
+      if ((meth.sym.flags() & Flags.GENERATEDCONSTR) != 0L) {
         range = CompilerRange.FROM_TEXT_SEARCH;
       }
       emitSymbolOccurrence(meth.sym, meth, Role.DEFINITION, range);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AfterPropsSet.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AfterPropsSet.java
@@ -39,6 +39,6 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface AfterPropsSet {
-//      ^^^^^^^^^^^^^ definition com/airbnb/epoxy/AfterPropsSet#
+//                ^^^^^^^^^^^^^ definition com/airbnb/epoxy/AfterPropsSet#
 }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
@@ -23,7 +23,7 @@ import static com.airbnb.epoxy.EpoxyAsyncUtil.getAsyncBackgroundHandler;
  * See https://github.com/airbnb/epoxy/wiki/Epoxy-Controller#asynchronous-support
  */
 public abstract class AsyncEpoxyController extends EpoxyController {
-//              ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#
+//                    ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#
 //                                                 ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -50,10 +50,10 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback;
  * Also adds support for canceling an in progress diff, and makes everything thread safe.
  */
 class AsyncEpoxyDiffer {
-//^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#
+//    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#
 
   interface ResultCallback {
-//^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#
+//          ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#
     void onResult(@NonNull DiffResult result);
 //       ^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#onResult().
 //                 ^^^^^^^ reference androidx/annotation/NonNull#
@@ -322,7 +322,6 @@ class AsyncEpoxyDiffer {
 //                   ^^^^^^^^^^^^^^^^ reference local13 6:5
 //                       ^^^^^^^^ reference java/lang/Runnable#
 //                       ^^^^^^^^ reference java/lang/Runnable#
-//                                  ^ definition local13 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void run() {
@@ -371,7 +370,6 @@ class AsyncEpoxyDiffer {
 //                                            ^^^^^^^^^^^^^^^^ reference local20 8:5
 //                                                ^^^^^^^^ reference java/lang/Runnable#
 //                                                ^^^^^^^^ reference java/lang/Runnable#
-//                                                           ^ definition local20 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void run() {
@@ -449,8 +447,8 @@ class AsyncEpoxyDiffer {
    * generation number is synced with the list state at the time it was created.
    */
   private static class GenerationTracker {
-//               ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#`<init>`().
-//               ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
+//                     ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
+//                     ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#`<init>`().
 
     // Max generation of currently scheduled runnable
     private volatile int maxScheduledGeneration;
@@ -507,7 +505,7 @@ class AsyncEpoxyDiffer {
   }
 
   private static class DiffCallback extends DiffUtil.Callback {
-//               ^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#
+//                     ^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#
 //                                          ^^^^^^^^ reference DiffUtil/
 //                                                   ^^^^^^^^ reference DiffUtil/Callback#
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AutoModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AutoModel.java
@@ -36,6 +36,6 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface AutoModel {
-//      ^^^^^^^^^ definition com/airbnb/epoxy/AutoModel#
+//                ^^^^^^^^^ definition com/airbnb/epoxy/AutoModel#
 
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -60,7 +60,7 @@ import androidx.recyclerview.widget.RecyclerView;
 //                                  ^^^^^^^^^^^^ reference androidx/recyclerview/widget/RecyclerView#
 
 public abstract class BaseEpoxyAdapter
-//              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#
     extends RecyclerView.Adapter<EpoxyViewHolder>
 //          ^^^^^^^^^^^^ reference RecyclerView/
 //                       ^^^^^^^ reference RecyclerView/Adapter#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
@@ -6,7 +6,7 @@ import android.view.View;
 //                  ^^^^ reference android/view/View#
 
 interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
-//^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyTouchCallback#
+//        ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                         ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
@@ -23,8 +23,8 @@ import androidx.collection.LongSparseArray;
 @SuppressWarnings("WeakerAccess")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
-//     ^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#`<init>`().
-//     ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#
+//           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#
+//           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#`<init>`().
 //                                       ^^^^^^^^ reference java/lang/Iterable#
 //                                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
   private final LongSparseArray<EpoxyViewHolder> holders = new LongSparseArray<>();
@@ -104,8 +104,8 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
   }
 
   private class HolderIterator implements Iterator<EpoxyViewHolder> {
-//        ^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#HolderIterator#`<init>`().
-//        ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#HolderIterator#
+//              ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#HolderIterator#
+//              ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#HolderIterator#`<init>`().
 //                                        ^^^^^^^^ reference java/util/Iterator#
 //                                                 ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
     private int position = 0;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/CallbackProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/CallbackProp.java
@@ -45,5 +45,5 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface CallbackProp {
-//      ^^^^^^^^^^^^ definition com/airbnb/epoxy/CallbackProp#
+//                ^^^^^^^^^^^^ definition com/airbnb/epoxy/CallbackProp#
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -110,7 +110,7 @@ import androidx.recyclerview.widget.SnapHelper;
 //                                            ^^^^ reference com/airbnb/epoxy/ModelView#Size#
 //                                                 ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelView#Size#MATCH_WIDTH_WRAP_HEIGHT.
 public class Carousel extends EpoxyRecyclerView {
-//     ^^^^^^^^ definition com/airbnb/epoxy/Carousel#
+//           ^^^^^^^^ definition com/airbnb/epoxy/Carousel#
 //                            ^^^^^^^^^^^^^^^^^ reference _root_/
   public static final int NO_VALUE_SET = -1;
 //                        ^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#NO_VALUE_SET.
@@ -122,7 +122,6 @@ public class Carousel extends EpoxyRecyclerView {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^ reference local1 7:7
 //        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#SnapHelperFactory#
 //        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#SnapHelperFactory#
-//                            ^ definition local1 2:3
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -768,7 +767,7 @@ public class Carousel extends EpoxyRecyclerView {
    * @see #setPadding(Padding)
    */
   public static class Padding {
-//              ^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#
+//                    ^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#
     public final int left;
 //                   ^^^^ definition com/airbnb/epoxy/Carousel#Padding#left.
     public final int top;
@@ -784,8 +783,8 @@ public class Carousel extends EpoxyRecyclerView {
 //                           ^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#paddingType.
 
     enum PaddingType {
-//  ^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#PaddingType#`<init>`().
-//  ^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#PaddingType#
+//       ^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#PaddingType#
+//       ^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#PaddingType#`<init>`().
       PX,
 //    ^^ definition com/airbnb/epoxy/Carousel#Padding#PaddingType#PX.
       DP,
@@ -1151,8 +1150,8 @@ public class Carousel extends EpoxyRecyclerView {
 
   /** Provide a SnapHelper implementation you want to use with a Carousel. */
   public abstract static class SnapHelperFactory {
-//                       ^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#`<init>`().
-//                       ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#
+//                             ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#
+//                             ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#`<init>`().
     /**
      * Create and return a new instance of a {@link androidx.recyclerview.widget.SnapHelper} for use
      * with a Carousel.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelper.java
@@ -11,8 +11,8 @@ import java.util.List;
  * annotation processor.
  */
 public abstract class ControllerHelper<T extends EpoxyController> {
-//              ^^^^^^ definition com/airbnb/epoxy/ControllerHelper#`<init>`().
-//              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelper#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelper#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelper#`<init>`().
 //                                               ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
   public abstract void resetAutoModels();
 //                     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelper#resetAutoModels().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
@@ -30,8 +30,8 @@ import androidx.annotation.Nullable;
  * be returned.
  */
 class ControllerHelperLookup {
-//^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#`<init>`().
-//^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#
+//    ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#
+//    ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#`<init>`().
   private static final String GENERATED_HELPER_CLASS_SUFFIX = "_EpoxyHelper";
 //                     ^^^^^^ reference java/lang/String#
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#GENERATED_HELPER_CLASS_SUFFIX.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
@@ -8,7 +8,7 @@ package com.airbnb.epoxy;
  * why it doesn't do anything.
  */
 class ControllerModelList extends ModelList {
-//^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#
+//    ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#
 //                                ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#
 
   private static final ModelListObserver OBSERVER = new ModelListObserver() {
@@ -17,7 +17,6 @@ class ControllerModelList extends ModelList {
 //                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ reference local1 12:3
 //                                                      ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ModelListObserver#
 //                                                      ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ModelListObserver#
-//                                                                          ^ definition local1 1:4
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeInserted(int positionStart, int itemCount) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
@@ -6,7 +6,7 @@ import android.util.Log;
 //                  ^^^ reference android/util/Log#
 
 class DebugTimer implements Timer {
-//^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#
+//    ^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#
 //                          ^^^^^ reference com/airbnb/epoxy/Timer#
 
   private final String tag;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -36,7 +36,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * Helper to track changes in the models list.
  */
 class DiffHelper {
-//^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#
+//    ^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#
   private ArrayList<ModelState> oldStateList = new ArrayList<>();
 //        ^^^^^^^^^ reference java/util/ArrayList#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
@@ -29,7 +29,7 @@ import androidx.collection.LongSparseArray;
  * call.
  */
 public class DiffPayload {
-//     ^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#
+//           ^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#
   private final EpoxyModel<?> singleModel;
 //              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                            ^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#singleModel.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
@@ -43,7 +43,7 @@ import androidx.recyclerview.widget.RecyclerView.Adapter;
  * Wraps the result of {@link AsyncEpoxyDiffer#submitList(List)}.
  */
 public class DiffResult {
-//     ^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#
+//           ^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#
   @NonNull final List<? extends EpoxyModel<?>> previousModels;
 // ^^^^^^^ reference androidx/annotation/NonNull#
 //               ^^^^ reference java/util/List#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
@@ -35,8 +35,8 @@ import androidx.annotation.Nullable;
 @SuppressWarnings("WeakerAccess")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
-//              ^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#`<init>`().
-//              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#`<init>`().
 //                                         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
   private final HiddenEpoxyModel hiddenModel = new HiddenEpoxyModel();
 //              ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -35,7 +35,7 @@ import androidx.annotation.MainThread;
  * Various helpers for running Epoxy operations off the main thread.
  */
 public final class EpoxyAsyncUtil {
-//           ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#
+//                 ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#
   private EpoxyAsyncUtil() {
 //        ^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#`<init>`().
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
@@ -35,14 +35,14 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyAttribute {
-//      ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#
+//                ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#
   /**
    * Options that can be included on the attribute to affect how the model's generated class is
    * created.
    */
   enum Option {
-//^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#
-//^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
+//     ^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#
+//     ^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
     /**
      * A getter is generated for this attribute by default. Add this option to prevent a getter from
      * being generated.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -112,7 +112,7 @@ import static com.airbnb.epoxy.ControllerHelperLookup.getHelperForController;
  * accurate.
  */
 public abstract class EpoxyController implements ModelCollector, StickyHeaderCallbacks {
-//              ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#
+//                    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#
 //                                               ^^^^^^^^^^^^^^ reference _root_/
 //                                                               ^^^^^^^^^^^^^^^^^^^^^ reference _root_/
 
@@ -280,7 +280,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //    ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                            ^^^^^^^ reference com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#DELAYED.
   private @interface RequestedModelBuildType {
-//         ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
+//                   ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
     int NONE = 0;
 //      ^^^^ definition com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#NONE.
     /** A request has been made to build models immediately. It is posted. */
@@ -474,7 +474,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                                             ^^^^^^^^^^^^^^^^ reference local6 49:3
 //                                                 ^^^^^^^^ reference java/lang/Runnable#
 //                                                 ^^^^^^^^ reference java/lang/Runnable#
-//                                                            ^ definition local6 1:4
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void run() {
@@ -682,7 +681,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
    * to allow changes.
    */
   interface ModelInterceptorCallback {
-//^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
+//          ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
     void onInterceptorsStarted(EpoxyController controller);
 //       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#onInterceptorsStarted().
 //                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
@@ -752,7 +751,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 
   /** A callback that is run after {@link #buildModels()} completes and before diffing is run. */
   public interface Interceptor {
-//       ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#Interceptor#
+//                 ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#Interceptor#
     /**
      * This is called immediately after {@link #buildModels()} and before diffing is run and the
      * models are set on the adapter. This is a final chance to make any changes to the the models
@@ -1423,7 +1422,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //    ^^^^^^^^^^^^^^^^^^^^^^^^ reference local58 7:7
 //        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ExceptionHandler#
 //        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ExceptionHandler#
-//                           ^ definition local58 2:3
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -1467,7 +1465,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
   }
 
   public interface ExceptionHandler {
-//       ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ExceptionHandler#
+//                 ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#ExceptionHandler#
     /**
      * This is called when recoverable exceptions happen at runtime. They can be ignored and Epoxy
      * will recover, but you can override this to be aware of when they happen.
@@ -1504,7 +1502,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                                                    ^^^^^^^^^^^^^^^^ reference local67 19:7
 //                                                        ^^^^^^^^ reference java/lang/Runnable#
 //                                                        ^^^^^^^^ reference java/lang/Runnable#
-//                                                                   ^ definition local67 1:4
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public void run() {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -56,7 +56,7 @@ import androidx.recyclerview.widget.RecyclerView;
 //                                  ^^^^^^^^^^^^ reference androidx/recyclerview/widget/RecyclerView#
 
 public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements ResultCallback {
-//           ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#
+//                 ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#
 //                                                ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
 //                                                                            ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#
   private final NotifyBlocker notifyBlocker = new NotifyBlocker();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
@@ -46,7 +46,7 @@ import androidx.annotation.LayoutRes;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyDataBindingLayouts {
-//      ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingLayouts#
+//                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingLayouts#
   /** A list of databinding layout resources that should have EpoxyModel's generated for them. */
   @LayoutRes int[] value();
 // ^^^^^^^^^ reference androidx/annotation/LayoutRes#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingPattern.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDataBindingPattern.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyDataBindingPattern {
-//      ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingPattern#
+//                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDataBindingPattern#
   /**
    * The R class used in this module (eg "com.example.app.R.class"). This is needed so Epoxy can
    * look up layout files.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
@@ -28,7 +28,7 @@ import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver;
  * optimization.
  */
 public class EpoxyDiffLogger extends AdapterDataObserver {
-//     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#
+//           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#
 //                                   ^^^^^^^^^^^^^^^^^^^ reference _root_/
   private final String tag;
 //              ^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
@@ -9,7 +9,7 @@ import android.view.View;
  * For use with {@link EpoxyModelTouchCallback}
  */
 public interface EpoxyDragCallback<T extends EpoxyModel> extends BaseEpoxyTouchCallback<T> {
-//     ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDragCallback#
+//               ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDragCallback#
 //                                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                               ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                                                                      ^ reference com/airbnb/epoxy/EpoxyDragCallback#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyHolder.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
  * pattern when binding to a model.
  */
 public abstract class EpoxyHolder {
-//              ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#
+//                    ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#
 
   public EpoxyHolder(@NonNull ViewParent parent) {
 //       ^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
@@ -57,7 +57,7 @@ import androidx.recyclerview.widget.RecyclerView.State;
  * are on the grid. Only designed to work with standard linear or grid layout managers.
  */
 public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#
 //                                             ^^^^^^^^^^^^ reference RecyclerView/
 //                                                          ^^^^^^^^^^^^^^ reference RecyclerView/ItemDecoration#
   private int pxBetweenItems;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -71,7 +71,7 @@ import static com.airbnb.epoxy.IdUtils.hashString64Bit;
  * @see EpoxyModelWithView
  */
 public abstract class EpoxyModel<T> {
-//              ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#
+//                    ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#
 
   /**
    * Counts how many of these objects are created, so that each new object can have a unique id .
@@ -657,7 +657,7 @@ public abstract class EpoxyModel<T> {
    * @see #addIf(AddPredicate, EpoxyController)
    */
   public interface AddPredicate {
-//       ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#AddPredicate#
+//                 ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#AddPredicate#
     boolean addIf();
 //          ^^^^^ definition com/airbnb/epoxy/EpoxyModel#AddPredicate#addIf().
   }
@@ -714,7 +714,6 @@ public abstract class EpoxyModel<T> {
 //                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local38 11:7
 //                                               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
 //                                               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
-//                                                                          ^ definition local38 1:4
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public void onInterceptorsStarted(EpoxyController controller) {
@@ -938,7 +937,7 @@ public abstract class EpoxyModel<T> {
   }
 
   public interface SpanSizeOverrideCallback {
-//       ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#SpanSizeOverrideCallback#
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#SpanSizeOverrideCallback#
     int getSpanSize(int totalSpanCount, int position, int itemCount);
 //      ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#SpanSizeOverrideCallback#getSpanSize().
 //                      ^^^^^^^^^^^^^^ definition local54

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelClass.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelClass.java
@@ -41,7 +41,7 @@ import androidx.annotation.LayoutRes;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface EpoxyModelClass {
-//      ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelClass#
+//                ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelClass#
   /**
    * A layout resource that should be used as the default layout for the model. If you set this you
    * don't have to implement `getDefaultLayout`; it will be generated for you.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -97,7 +97,7 @@ import androidx.annotation.Nullable;
 @SuppressWarnings("rawtypes")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
-//     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#
+//           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#
 //                                   ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelWithHolder#
 //                                                        ^^^^^^^^^^^^^^^^ reference _root_/
 
@@ -264,7 +264,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local12 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                                                    ^ definition local12 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -308,7 +307,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local20 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                                                    ^ definition local20 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -364,7 +362,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local29 15:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                                                    ^ definition local29 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -472,7 +469,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local40 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                                                    ^ definition local40 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -506,7 +502,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local47 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                                                    ^ definition local47 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -561,7 +556,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   private interface IterateModelsCallback {
-//        ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
+//                  ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
     void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex);
 //       ^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#onModel().
 //               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
@@ -39,7 +39,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * your own {@link ItemTouchHelper} if you need extra flexibility or customization.
  */
 public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
-//              ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#
+//                    ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#
 //                                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
     extends EpoxyTouchHelperCallback implements EpoxyDragCallback<T>, EpoxySwipeCallback<T> {
 //          ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelperCallback#
@@ -502,7 +502,6 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //                           ^^^^^^^^^^^^^^^^ reference local48 5:5
 //                               ^^^^^^^^ reference java/lang/Runnable#
 //                               ^^^^^^^^ reference java/lang/Runnable#
-//                                          ^ definition local48 1:4
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void run() {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -35,7 +35,7 @@ import androidx.annotation.Px;
  * instead of a specific view when binding to your model.
  */
 public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyModel<T> {
-//              ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#
+//                    ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#
 //                                                   ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyHolder#
 //                                                                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                                   ^ reference com/airbnb/epoxy/EpoxyModelWithHolder#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
@@ -35,8 +35,8 @@ import androidx.annotation.NonNull;
  * resource file.
  */
 public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
-//              ^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#
+//                    ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#
+//                    ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#`<init>`().
 //                                                 ^^^^ reference _root_/
 //                                                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                          ^ reference com/airbnb/epoxy/EpoxyModelWithView#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
@@ -19,7 +19,7 @@ import androidx.recyclerview.widget.ItemTouchHelper;
  * For use with {@link EpoxyModelTouchCallback}
  */
 public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouchCallback<T> {
-//     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxySwipeCallback#
+//               ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxySwipeCallback#
 //                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                                                                       ^ reference com/airbnb/epoxy/EpoxySwipeCallback#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -415,7 +415,6 @@ public abstract class EpoxyTouchHelper {
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#controller.
 //                                                                       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClass.
-//                                                                                         ^ definition local20 2:3
 //                                                                                         ^ definition local21 2:7
 //                                                                                         ^ definition local22 2:13
 //                                                                                           reference java/lang/ 2:2
@@ -892,7 +891,6 @@ public abstract class EpoxyTouchHelper {
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClass.
-//                                                                                   ^ definition local74 2:3
 //                                                                                   ^ definition local75 2:7
 //                                                                                   ^ definition local76 2:13
 //                                                                                     reference java/lang/ 2:2

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -63,8 +63,8 @@ import static androidx.recyclerview.widget.ItemTouchHelper.Callback.makeMovement
  * Epoxy view holders to remove some boilerplate for you.
  */
 public abstract class EpoxyTouchHelper {
-//              ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#`<init>`().
-//              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#
+//                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#`<init>`().
 
   /**
    * The entry point for setting up drag support.
@@ -85,7 +85,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class DragBuilder {
-//              ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#
+//                    ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#
 
     private final EpoxyController controller;
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
@@ -120,7 +120,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class DragBuilder2 {
-//              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#
 
     private final EpoxyController controller;
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
@@ -210,7 +210,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class DragBuilder3 {
-//              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#
 
     private final EpoxyController controller;
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
@@ -322,7 +322,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class DragBuilder4<U extends EpoxyModel> {
-//              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#
 //                                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
     private final EpoxyController controller;
@@ -543,8 +543,8 @@ public abstract class EpoxyTouchHelper {
   }
 
   public abstract static class DragCallbacks<T extends EpoxyModel>
-//                       ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#`<init>`().
-//                       ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#
+//                             ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#
+//                             ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#`<init>`().
 //                                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
       implements EpoxyDragCallback<T> {
 //               ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyDragCallback#
@@ -636,7 +636,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class SwipeBuilder {
-//              ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#
+//                    ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#
 
     private final RecyclerView recyclerView;
 //                ^^^^^^^^^^^^ reference _root_/
@@ -707,7 +707,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class SwipeBuilder2 {
-//              ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#
+//                    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#
 
     private final RecyclerView recyclerView;
 //                ^^^^^^^^^^^^ reference _root_/
@@ -810,7 +810,7 @@ public abstract class EpoxyTouchHelper {
   }
 
   public static class SwipeBuilder3<U extends EpoxyModel> {
-//              ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#
+//                    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#
 //                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
     private final RecyclerView recyclerView;
@@ -1040,8 +1040,8 @@ public abstract class EpoxyTouchHelper {
   }
 
   public abstract static class SwipeCallbacks<T extends EpoxyModel>
-//                       ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#`<init>`().
-//                       ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#
+//                             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#
+//                             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#`<init>`().
 //                                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
       implements EpoxySwipeCallback<T> {
 //               ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxySwipeCallback#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
@@ -32,8 +32,8 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
  * view holders to {@link com.airbnb.epoxy.EpoxyViewHolder} for simpler use with Epoxy.
  */
 public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback {
-//              ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#`<init>`().
 //                                                     ^^^^^^^^^^^^^^^ reference ItemTouchHelper/
 //                                                                     ^^^^^^^^ reference ItemTouchHelper/Callback#
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -52,7 +52,7 @@ import androidx.recyclerview.widget.RecyclerView;
 @SuppressWarnings("WeakerAccess")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class EpoxyViewHolder extends RecyclerView.ViewHolder {
-//     ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#
+//           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#
 //                                   ^^^^^^^^^^^^ reference RecyclerView/
 //                                                ^^^^^^^^^^ reference RecyclerView/ViewHolder#
   @SuppressWarnings("rawtypes") private EpoxyModel epoxyModel;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/GeneratedModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/GeneratedModel.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 /** Interface applied to generated models to allow the base adapter to interact with them. */
 public interface GeneratedModel<T> {
-//     ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/GeneratedModel#
+//               ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/GeneratedModel#
   /**
    * Called on the generated model immediately before the main model onBind method has been called.
    * This let's the generated model handle binding setup of its own

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
@@ -27,7 +27,7 @@ import androidx.annotation.NonNull;
  * same as the handler's thread.
  */
 class HandlerExecutor implements Executor {
-//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#
+//    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#
 //                               ^^^^^^^^ reference java/util/concurrent/Executor#
   final Handler handler;
 //      ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/HiddenEpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/HiddenEpoxyModel.java
@@ -18,8 +18,8 @@ import com.airbnb.viewmodeladapter.R;
  * view.
  */
 class HiddenEpoxyModel extends EpoxyModel<Space> {
-//^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
-//^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#
+//    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#
+//    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
 //                             ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                        ^^^^^ reference _root_/
   @Override

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/IdUtils.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/IdUtils.java
@@ -9,7 +9,7 @@ import androidx.annotation.Nullable;
  * Utilities for generating 64-bit long IDs from types such as {@link CharSequence}.
  */
 public final class IdUtils {
-//           ^^^^^^^ definition com/airbnb/epoxy/IdUtils#
+//                 ^^^^^^^ definition com/airbnb/epoxy/IdUtils#
   private IdUtils() {
 //        ^^^^^^ definition com/airbnb/epoxy/IdUtils#`<init>`().
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/IllegalEpoxyUsage.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/IllegalEpoxyUsage.java
@@ -1,7 +1,7 @@
 package com.airbnb.epoxy;
 
 public class IllegalEpoxyUsage extends RuntimeException {
-//     ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage#
+//           ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage#
 //                                     ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
   public IllegalEpoxyUsage(String message) {
 //       ^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
  * Thrown if a model is changed after it is added to an {@link com.airbnb.epoxy.EpoxyController}.
  */
 class ImmutableModelException extends RuntimeException {
-//^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#
+//    ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#
 //                                    ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
   private static final String MODEL_CANNOT_BE_CHANGED_MESSAGE =
 //                     ^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
@@ -26,8 +26,8 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 //                                               ^^^^^^^^^^ reference androidx/recyclerview/widget/RecyclerView/ViewHolder#
 
 public class ListenersUtils {
-//     ^^^^^^ definition com/airbnb/epoxy/ListenersUtils#`<init>`().
-//     ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#
+//           ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#
+//           ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#`<init>`().
 
   @Nullable
 // ^^^^^^^^ reference androidx/annotation/Nullable#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
@@ -12,7 +12,7 @@ import static com.airbnb.epoxy.EpoxyAsyncUtil.MAIN_THREAD_HANDLER;
 //                             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAsyncUtil#
 
 class MainThreadExecutor extends HandlerExecutor {
-//^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#
+//    ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#
 //                               ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#
   static final MainThreadExecutor INSTANCE = new MainThreadExecutor(false);
 //             ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
@@ -44,7 +44,7 @@ import androidx.annotation.NonNull;
  * diffing since we have a knowledge of what changed in the list.
  */
 class ModelList extends ArrayList<EpoxyModel<?>> {
-//^^^^^^^^^ definition com/airbnb/epoxy/ModelList#
+//    ^^^^^^^^^ definition com/airbnb/epoxy/ModelList#
 //                      ^^^^^^^^^ reference java/util/ArrayList#
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
@@ -62,7 +62,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   interface ModelListObserver {
-//^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#
+//          ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#
     void onItemRangeInserted(int positionStart, int itemCount);
 //       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#ModelListObserver#onItemRangeInserted().
 //                               ^^^^^^^^^^^^^ definition local1
@@ -414,8 +414,8 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
    * the parent methods so that the proper notifications are done.
    */
   private class Itr implements Iterator<EpoxyModel<?>> {
-//        ^^^ definition com/airbnb/epoxy/ModelList#Itr#
-//        ^^^^^^ definition com/airbnb/epoxy/ModelList#Itr#`<init>`().
+//              ^^^ definition com/airbnb/epoxy/ModelList#Itr#
+//              ^^^ definition com/airbnb/epoxy/ModelList#Itr#`<init>`().
 //                             ^^^^^^^^ reference java/util/Iterator#
 //                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
     int cursor;       // index of next element to return
@@ -537,7 +537,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
    * notifications are done.
    */
   private class ListItr extends Itr implements ListIterator<EpoxyModel<?>> {
-//        ^^^^^^^ definition com/airbnb/epoxy/ModelList#ListItr#
+//              ^^^^^^^ definition com/airbnb/epoxy/ModelList#ListItr#
 //                              ^^^ reference com/airbnb/epoxy/ModelList#Itr#
 //                                             ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                                                          ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -701,7 +701,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
    * the implementation to call the parent methods so that the proper notifications are done.
    */
   private static class SubList extends AbstractList<EpoxyModel<?>> {
-//               ^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#
+//                     ^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#
 //                                     ^^^^^^^^^^^^ reference java/util/AbstractList#
 //                                                  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
     private final ModelList fullList;
@@ -713,7 +713,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //              ^^^^ definition com/airbnb/epoxy/ModelList#SubList#size.
 
     private static final class SubListIterator implements ListIterator<EpoxyModel<?>> {
-//                       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#SubListIterator#
+//                             ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#SubListIterator#
 //                                                        ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                                                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
       private final SubList subList;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
@@ -48,11 +48,11 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface ModelProp {
-//      ^^^^^^^^^ definition com/airbnb/epoxy/ModelProp#
+//                ^^^^^^^^^ definition com/airbnb/epoxy/ModelProp#
 
   enum Option {
-//^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#
-//^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#`<init>`().
+//     ^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#
+//     ^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#`<init>`().
     /**
      * By default every prop's hashCode and equals method is called when determining the
      * model's state. This option can be used to exclude an prop's hashCode/equals from

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
@@ -2,8 +2,8 @@ package com.airbnb.epoxy;
 
 /** Helper to store relevant information about a model that we need to determine if it changed. */
 class ModelState {
-//^^^^^^ definition com/airbnb/epoxy/ModelState#`<init>`().
-//^^^^^^^^^^ definition com/airbnb/epoxy/ModelState#
+//    ^^^^^^^^^^ definition com/airbnb/epoxy/ModelState#
+//    ^^^^^^^^^^ definition com/airbnb/epoxy/ModelState#`<init>`().
   long id;
 //     ^^ definition com/airbnb/epoxy/ModelState#id.
   int hashCode;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
@@ -41,7 +41,7 @@ import androidx.annotation.LayoutRes;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface ModelView {
-//      ^^^^^^^^^ definition com/airbnb/epoxy/ModelView#
+//                ^^^^^^^^^ definition com/airbnb/epoxy/ModelView#
 
   /**
    * Use with {@link #autoLayout()} to declare what layout parameters should be used to size your
@@ -49,8 +49,8 @@ public @interface ModelView {
    * layout_width} and {@code layout_height}.
    */
   enum Size {
-//^^^^ definition com/airbnb/epoxy/ModelView#Size#
-//^^^^^^ definition com/airbnb/epoxy/ModelView#Size#`<init>`().
+//     ^^^^ definition com/airbnb/epoxy/ModelView#Size#
+//     ^^^^ definition com/airbnb/epoxy/ModelView#Size#`<init>`().
     NONE,
 //  ^^^^ definition com/airbnb/epoxy/ModelView#Size#NONE.
     WRAP_WIDTH_WRAP_HEIGHT,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpControllerHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpControllerHelper.java
@@ -5,8 +5,8 @@ package com.airbnb.epoxy;
  * com.airbnb.epoxy.AutoModel} usage.
  */
 class NoOpControllerHelper extends ControllerHelper<EpoxyController> {
-//^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
-//^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#
+//    ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#
+//    ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
 //                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerHelper#
 //                                                  ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NoOpTimer.java
@@ -1,8 +1,8 @@
 package com.airbnb.epoxy;
 
 class NoOpTimer implements Timer {
-//^^^^^^ definition com/airbnb/epoxy/NoOpTimer#`<init>`().
-//^^^^^^^^^ definition com/airbnb/epoxy/NoOpTimer#
+//    ^^^^^^^^^ definition com/airbnb/epoxy/NoOpTimer#
+//    ^^^^^^^^^ definition com/airbnb/epoxy/NoOpTimer#`<init>`().
 //                         ^^^^^ reference com/airbnb/epoxy/Timer#
   @Override
 // ^^^^^^^^ reference java/lang/Override#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
@@ -15,8 +15,8 @@ import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver;
  * This observer throws upon any changes done outside of diffing.
  */
 class NotifyBlocker extends AdapterDataObserver {
-//^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#`<init>`().
-//^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#
+//    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#
+//    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/NotifyBlocker#`<init>`().
 //                          ^^^^^^^^^^^^^^^^^^^ reference _root_/
 
   private boolean changesAllowed;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelBoundListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelBoundListener.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 /** Used to register an onBind callback with a generated model. */
 public interface OnModelBoundListener<T extends EpoxyModel<?>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelBoundListener#
+//               ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelBoundListener#
 //                                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
   /**
    * This will be called immediately after a model was bound, with the model and view that were

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelBuildFinishedListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelBuildFinishedListener.java
@@ -10,7 +10,7 @@ import androidx.annotation.NonNull;
  * alerted to new model changes.
  */
 public interface OnModelBuildFinishedListener {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelBuildFinishedListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelBuildFinishedListener#
   /**
    * Called after {@link EpoxyController#buildModels()} has run and changes have been notified to
    * the adapter. This will be called even if no changes existed.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelCheckedChangeListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelCheckedChangeListener.java
@@ -6,7 +6,7 @@ import android.widget.CompoundButton;
 //                    ^^^^^^^^^^^^^^ reference android/widget/CompoundButton#
 
 public interface OnModelCheckedChangeListener<T extends EpoxyModel<?>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelCheckedChangeListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelCheckedChangeListener#
 //                                                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
   /**
    * Called when the view bound to the model is checked.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelClickListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelClickListener.java
@@ -7,7 +7,7 @@ import android.view.View;
 
 /** Used to register a click listener on a generated model. */
 public interface OnModelClickListener<T extends EpoxyModel<?>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelClickListener#
+//               ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelClickListener#
 //                                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
   /**
    * Called when the view bound to the model is clicked.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelLongClickListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelLongClickListener.java
@@ -6,7 +6,7 @@ import android.view.View;
 //                  ^^^^ reference android/view/View#
 
 public interface OnModelLongClickListener<T extends EpoxyModel<?>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelLongClickListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelLongClickListener#
 //                                                  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
   /**
    * Called when the view bound to the model is clicked.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelUnboundListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelUnboundListener.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 /** Used to register an onUnbind callback with a generated model. */
 public interface OnModelUnboundListener<T extends EpoxyModel<?>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelUnboundListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelUnboundListener#
 //                                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
   /**
    * This will be called immediately after a model is unbound from a view, with the view and model

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelVisibilityChangedListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelVisibilityChangedListener.java
@@ -11,7 +11,7 @@ import androidx.annotation.Px;
 
 /** Used to register an onVisibilityChanged callback with a generated model. */
 public interface OnModelVisibilityChangedListener<T extends EpoxyModel<V>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelVisibilityChangedListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelVisibilityChangedListener#
 //                                                          ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                     ^ reference com/airbnb/epoxy/OnModelVisibilityChangedListener#[V]
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelVisibilityStateChangedListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnModelVisibilityStateChangedListener.java
@@ -9,7 +9,7 @@ import com.airbnb.epoxy.VisibilityState.Visibility;
 
 /** Used to register an onVisibilityChanged callback with a generated model. */
 public interface OnModelVisibilityStateChangedListener<T extends EpoxyModel<V>, V> {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelVisibilityStateChangedListener#
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnModelVisibilityStateChangedListener#
 //                                                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                          ^ reference com/airbnb/epoxy/OnModelVisibilityStateChangedListener#[V]
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnViewRecycled.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnViewRecycled.java
@@ -35,5 +35,5 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnViewRecycled {
-//      ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnViewRecycled#
+//                ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnViewRecycled#
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityChanged.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityChanged.java
@@ -45,5 +45,5 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnVisibilityChanged {
-//      ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnVisibilityChanged#
+//                ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnVisibilityChanged#
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityStateChanged.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/OnVisibilityStateChanged.java
@@ -47,5 +47,5 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface OnVisibilityStateChanged {
-//      ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnVisibilityStateChanged#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/OnVisibilityStateChanged#
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface PackageEpoxyConfig {
-//      ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageEpoxyConfig#
+//                ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageEpoxyConfig#
   boolean REQUIRE_HASHCODE_DEFAULT = false;
 //        ^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageEpoxyConfig#REQUIRE_HASHCODE_DEFAULT.
   boolean REQUIRE_ABSTRACT_MODELS_DEFAULT = false;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageModelViewConfig.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/PackageModelViewConfig.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface PackageModelViewConfig {
-//      ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#
+//                ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#
   /**
    * The R class used in this module (eg "com.example.app.R.class"). This is needed so Epoxy can
    * look up layout files.
@@ -130,8 +130,8 @@ public @interface PackageModelViewConfig {
    * Enable or Disable an option, or inherit the default.
    */
   enum Option {
-//^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#
-//^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#`<init>`().
+//     ^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#
+//     ^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#`<init>`().
     Default,
 //  ^^^^^^^ definition com/airbnb/epoxy/PackageModelViewConfig#Option#Default.
     Enabled,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
@@ -20,7 +20,7 @@ import androidx.annotation.PluralsRes;
 //                         ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
 
 public class QuantityStringResAttribute {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#
   @PluralsRes private final int id;
 // ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
 //                              ^^ definition com/airbnb/epoxy/QuantityStringResAttribute#id.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyAdapter.java
@@ -15,8 +15,8 @@ import java.util.List;
  * to modify the adapter from elsewhere, such as from an activity.
  */
 public class SimpleEpoxyAdapter extends EpoxyAdapter {
-//     ^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#`<init>`().
-//     ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#
+//           ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#
+//           ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyAdapter#`<init>`().
 //                                      ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#
 
   public List<EpoxyModel<?>> getModels() {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
@@ -10,8 +10,8 @@ import java.util.List;
  * models directly.
  */
 public class SimpleEpoxyController extends EpoxyController {
-//     ^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#`<init>`().
-//     ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#
+//           ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#
+//           ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyController#`<init>`().
 //                                         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
   private List<? extends EpoxyModel<?>> currentModels;
 //        ^^^^ reference java/util/List#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
@@ -25,7 +25,7 @@ import androidx.annotation.NonNull;
  * span size.
  */
 public class SimpleEpoxyModel extends EpoxyModel<View> {
-//     ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#
+//           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#
 //                                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                               ^^^^ reference _root_/
   @LayoutRes private final int layoutRes;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
@@ -24,7 +24,7 @@ import androidx.annotation.StringRes;
 //                         ^^^^^^^^^ reference androidx/annotation/StringRes#
 
 public class StringAttributeData {
-//     ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#
+//           ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#
   private final boolean hasDefault;
 //                      ^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#hasDefault.
   @Nullable private final CharSequence defaultString;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StyleBuilderCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StyleBuilderCallback.java
@@ -5,7 +5,7 @@ package com.airbnb.epoxy;
  * view is set up to be styled with the Paris library.
  */
 public interface StyleBuilderCallback<T> {
-//     ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StyleBuilderCallback#
+//               ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StyleBuilderCallback#
   void buildStyle(T builder);
 //     ^^^^^^^^^^ definition com/airbnb/epoxy/StyleBuilderCallback#buildStyle().
 //                ^ reference com/airbnb/epoxy/StyleBuilderCallback#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TextProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TextProp.java
@@ -45,7 +45,7 @@ import androidx.annotation.StringRes;
 //         ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                         ^^^^^ reference java/lang/annotation/RetentionPolicy#CLASS.
 public @interface TextProp {
-//      ^^^^^^^^ definition com/airbnb/epoxy/TextProp#
+//                ^^^^^^^^ definition com/airbnb/epoxy/TextProp#
 
   @StringRes int defaultRes() default 0;
 // ^^^^^^^^^ reference androidx/annotation/StringRes#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
@@ -1,7 +1,7 @@
 package com.airbnb.epoxy;
 
 interface Timer {
-//^^^^^ definition com/airbnb/epoxy/Timer#
+//        ^^^^^ definition com/airbnb/epoxy/Timer#
   void start(String sectionName);
 //     ^^^^^ definition com/airbnb/epoxy/Timer#start().
 //           ^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
@@ -20,7 +20,7 @@ import android.os.Handler;
  * @see Typed4EpoxyController
  */
 public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
-//              ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#
+//                    ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#
 //                                                        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 
   private T data1;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
@@ -20,7 +20,7 @@ import android.os.Handler;
  * @see Typed4EpoxyController
  */
 public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
-//              ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#
+//                    ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#
 //                                                           ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 
   private T data1;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
@@ -20,7 +20,7 @@ import android.os.Handler;
  * @see Typed3EpoxyController
  */
 public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController {
-//              ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#
+//                    ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#
 //                                                              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 
   private T data1;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
@@ -24,7 +24,7 @@ import androidx.annotation.Nullable;
  * @see Typed4EpoxyController
  */
 public abstract class TypedEpoxyController<T> extends EpoxyController {
-//              ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#
+//                    ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#
 //                                                    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
   private T currentData;
 //        ^ reference com/airbnb/epoxy/TypedEpoxyController#[T]

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 
 /** Defines an operation that makes a change to the epoxy model list. */
 class UpdateOp {
-//^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#
+//    ^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#
 
   @IntDef({ADD, REMOVE, UPDATE, MOVE})
 // ^^^^^^ reference androidx/annotation/IntDef#
@@ -40,7 +40,7 @@ class UpdateOp {
 //           ^^^^^^^^^^^^^^^ reference java/lang/annotation/RetentionPolicy#
 //                           ^^^^^^ reference java/lang/annotation/RetentionPolicy#SOURCE.
   @interface Type {
-// ^^^^ definition com/airbnb/epoxy/UpdateOp#Type#
+//           ^^^^ definition com/airbnb/epoxy/UpdateOp#Type#
   }
 
   static final int ADD = 0;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
@@ -44,8 +44,8 @@ import static com.airbnb.epoxy.UpdateOp.UPDATE;
 
 /** Helper class to collect changes in a diff, batching when possible. */
 class UpdateOpHelper {
-//^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#`<init>`().
-//^^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#
+//    ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#
+//    ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#`<init>`().
   final List<UpdateOp> opList = new ArrayList<>();
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -59,7 +59,7 @@ import androidx.collection.LongSparseArray;
 @SuppressWarnings("WeakerAccess")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
-//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#
+//    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#
 //                            ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
 //                                            ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                                                  ^^^^^^^^^^ reference _root_/
@@ -286,7 +286,7 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
    * parcelable support.
    */
   public static class ViewState extends SparseArray<Parcelable> implements Parcelable {
-//              ^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#
+//                    ^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                      ^^^^^^^^^^^ reference _root_/
 //                                                  ^^^^^^^^^^ reference _root_/
 //                                                                         ^^^^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
@@ -19,8 +19,8 @@ import androidx.annotation.VisibleForTesting;
 //                         ^^^^^^^^^^^^^^^^^ reference androidx/annotation/VisibleForTesting#
 
 class ViewTypeManager {
-//^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#`<init>`().
-//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#
+//    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#
+//    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#`<init>`().
   private static final Map<Class, Integer> VIEW_TYPE_MAP = new HashMap<>();
 //                     ^^^ reference java/util/Map#
 //                         ^^^^^ reference java/lang/Class#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
@@ -17,8 +17,8 @@ import androidx.annotation.IntDef;
 //                         ^^^^^^ reference androidx/annotation/IntDef#
 
 public final class VisibilityState {
-//           ^^^^^^ definition com/airbnb/epoxy/VisibilityState#`<init>`().
-//           ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#
+//                 ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#
+//                 ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#`<init>`().
 
   @Retention(RetentionPolicy.SOURCE)
 // ^^^^^^^^^ reference java/lang/annotation/Retention#
@@ -40,7 +40,7 @@ public final class VisibilityState {
            PARTIAL_IMPRESSION_INVISIBLE})
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/VisibilityState#PARTIAL_IMPRESSION_INVISIBLE.
   public @interface Visibility {
-//        ^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#Visibility#
+//                  ^^^^^^^^^^ definition com/airbnb/epoxy/VisibilityState#Visibility#
   }
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
@@ -21,7 +21,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * checked change.
  */
 public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#
 //                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
     implements OnCheckedChangeListener {
 //             ^^^^^^^^^^^^^^^^^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/minimized/AbstractClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/AbstractClasses.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public abstract class AbstractClasses {
-//              ^^^^^^ definition minimized/AbstractClasses#`<init>`().
-//              ^^^^^^^^^^^^^^^ definition minimized/AbstractClasses#
+//                    ^^^^^^^^^^^^^^^ definition minimized/AbstractClasses#
+//                    ^^^^^^^^^^^^^^^ definition minimized/AbstractClasses#`<init>`().
   public String defaultImplementation() {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^^^^^^^^^^^^^^^^^ definition minimized/AbstractClasses#defaultImplementation().

--- a/tests/snapshots/src/main/generated/minimized/Annotations.java
+++ b/tests/snapshots/src/main/generated/minimized/Annotations.java
@@ -44,7 +44,7 @@ import static java.lang.annotation.ElementType.*;
 //                                                                    ^^^^^^^^^ reference java/lang/annotation/ElementType#PARAMETER.
 //                                                                               ^^^^ reference java/lang/annotation/ElementType#TYPE.
 public @interface Annotations {
-//      ^^^^^^^^^^^ definition minimized/Annotations#
+//                ^^^^^^^^^^^ definition minimized/Annotations#
 
   String value() default "";
 //^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
@@ -9,8 +9,8 @@ import java.util.function.Function;
 @SuppressWarnings("ALL")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class AnonymousClasses {
-//     ^^^^^^ definition minimized/AnonymousClasses#`<init>`().
-//     ^^^^^^^^^^^^^^^^ definition minimized/AnonymousClasses#
+//           ^^^^^^^^^^^^^^^^ definition minimized/AnonymousClasses#
+//           ^^^^^^^^^^^^^^^^ definition minimized/AnonymousClasses#`<init>`().
   public static int app(int n) {
 //                  ^^^ definition minimized/AnonymousClasses#app().
 //                          ^ definition local0
@@ -27,7 +27,6 @@ public class AnonymousClasses {
 //                   ^^^^^^^ reference java/lang/Integer#
 //                            ^^^^^^^ reference java/lang/Integer#
 //                            ^^^^^^^ reference java/lang/Integer#
-//                                       ^ definition local3 1:4
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
           public Integer apply(Integer integer) {

--- a/tests/snapshots/src/main/generated/minimized/Arrays.java
+++ b/tests/snapshots/src/main/generated/minimized/Arrays.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class Arrays {
-//     ^^^^^^ definition minimized/Arrays#
-//     ^^^^^^ definition minimized/Arrays#`<init>`().
+//           ^^^^^^ definition minimized/Arrays#
+//           ^^^^^^ definition minimized/Arrays#`<init>`().
   public static String app() {
 //              ^^^^^^ reference java/lang/String#
 //                     ^^^ definition minimized/Arrays#app().

--- a/tests/snapshots/src/main/generated/minimized/ClassOf.java
+++ b/tests/snapshots/src/main/generated/minimized/ClassOf.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class ClassOf {
-//     ^^^^^^ definition minimized/ClassOf#`<init>`().
-//     ^^^^^^^ definition minimized/ClassOf#
+//           ^^^^^^^ definition minimized/ClassOf#
+//           ^^^^^^^ definition minimized/ClassOf#`<init>`().
   public static String app() {
 //              ^^^^^^ reference java/lang/String#
 //                     ^^^ definition minimized/ClassOf#app().

--- a/tests/snapshots/src/main/generated/minimized/Docstrings.java
+++ b/tests/snapshots/src/main/generated/minimized/Docstrings.java
@@ -2,8 +2,8 @@ package minimized;
 
 /** Example class docstring. */
 public class Docstrings {
-//     ^^^^^^ definition minimized/Docstrings#`<init>`().
-//     ^^^^^^^^^^ definition minimized/Docstrings#
+//           ^^^^^^^^^^ definition minimized/Docstrings#
+//           ^^^^^^^^^^ definition minimized/Docstrings#`<init>`().
 
   /** Example field docstring. */
   public static int field = 42;

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 //               ^^^^^^ reference java/util/Arrays#
 
 public enum Enums {
-//     ^^^^^ definition minimized/Enums#
+//          ^^^^^ definition minimized/Enums#
   A("A"),
 //^ definition minimized/Enums#A.
 // ^^^^^ reference minimized/Enums#`<init>`().

--- a/tests/snapshots/src/main/generated/minimized/Fields.java
+++ b/tests/snapshots/src/main/generated/minimized/Fields.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class Fields {
-//     ^^^^^^ definition minimized/Fields#
-//     ^^^^^^ definition minimized/Fields#`<init>`().
+//           ^^^^^^ definition minimized/Fields#
+//           ^^^^^^ definition minimized/Fields#`<init>`().
   private final int privateField = 0;
 //                  ^^^^^^^^^^^^ definition minimized/Fields#privateField.
   protected int protectedField = 0;
@@ -17,16 +17,16 @@ public class Fields {
 //                  ^^^^^^^^^^^^^^^^^ definition minimized/Fields#staticPublicField.
 
   public class InnerFields {
-//       ^^^^^^ definition minimized/Fields#InnerFields#`<init>`().
-//       ^^^^^^^^^^^ definition minimized/Fields#InnerFields#
+//             ^^^^^^^^^^^ definition minimized/Fields#InnerFields#
+//             ^^^^^^^^^^^ definition minimized/Fields#InnerFields#`<init>`().
     public int publicInnerField = publicField;
 //             ^^^^^^^^^^^^^^^^ definition minimized/Fields#InnerFields#publicInnerField.
 //                                ^^^^^^^^^^^ reference minimized/Fields#publicField.
   }
 
   public static class InnerStaticFields {
-//              ^^^^^^ definition minimized/Fields#InnerStaticFields#`<init>`().
-//              ^^^^^^^^^^^^^^^^^ definition minimized/Fields#InnerStaticFields#
+//                    ^^^^^^^^^^^^^^^^^ definition minimized/Fields#InnerStaticFields#
+//                    ^^^^^^^^^^^^^^^^^ definition minimized/Fields#InnerStaticFields#`<init>`().
     public int publicNonStaticInnerField = 0;
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^ definition minimized/Fields#InnerStaticFields#publicNonStaticInnerField.
     public static int publicStaticInnerField = 0;

--- a/tests/snapshots/src/main/generated/minimized/ForComprehensions.java
+++ b/tests/snapshots/src/main/generated/minimized/ForComprehensions.java
@@ -10,8 +10,8 @@ import java.util.List;
 //               ^^^^ reference java/util/List#
 
 public class ForComprehensions {
-//     ^^^^^^ definition minimized/ForComprehensions#`<init>`().
-//     ^^^^^^^^^^^^^^^^^ definition minimized/ForComprehensions#
+//           ^^^^^^^^^^^^^^^^^ definition minimized/ForComprehensions#
+//           ^^^^^^^^^^^^^^^^^ definition minimized/ForComprehensions#`<init>`().
   public static int app(int n) {
 //                  ^^^ definition minimized/ForComprehensions#app().
 //                          ^ definition local0

--- a/tests/snapshots/src/main/generated/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/InnerClasses.java
@@ -1,7 +1,7 @@
 package minimized;
 
 public class InnerClasses {
-//     ^^^^^^^^^^^^ definition minimized/InnerClasses#
+//           ^^^^^^^^^^^^ definition minimized/InnerClasses#
 
   private final int exampleField;
 //                  ^^^^^^^^^^^^ definition minimized/InnerClasses#exampleField.
@@ -16,8 +16,8 @@ public class InnerClasses {
   }
 
   public enum InnerEnum {
-//       ^^^^^^ definition minimized/InnerClasses#InnerEnum#`<init>`().
-//       ^^^^^^^^^ definition minimized/InnerClasses#InnerEnum#
+//            ^^^^^^^^^ definition minimized/InnerClasses#InnerEnum#
+//            ^^^^^^^^^ definition minimized/InnerClasses#InnerEnum#`<init>`().
     A,
 //  ^ definition minimized/InnerClasses#InnerEnum#A.
     B,
@@ -27,7 +27,7 @@ public class InnerClasses {
   }
 
   public interface InnerInterface<A, B> {
-//       ^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerInterface#
+//                 ^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerInterface#
     B apply(A a);
 //  ^ reference minimized/InnerClasses#InnerInterface#[B]
 //    ^^^^^ definition minimized/InnerClasses#InnerInterface#apply().
@@ -36,14 +36,14 @@ public class InnerClasses {
   }
 
   public static class InnerStaticClass {
-//              ^^^^^^ definition minimized/InnerClasses#InnerStaticClass#`<init>`().
-//              ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#
+//                    ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#
+//                    ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#`<init>`().
     public static void innerStaticMethod() {}
 //                     ^^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#innerStaticMethod().
   }
 
   public class InnerClass implements InnerInterface<Integer, Integer> {
-//       ^^^^^^^^^^ definition minimized/InnerClasses#InnerClass#
+//             ^^^^^^^^^^ definition minimized/InnerClasses#InnerClass#
 //                                   ^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerInterface#
 //                                                  ^^^^^^^ reference java/lang/Integer#
 //                                                           ^^^^^^^ reference java/lang/Integer#
@@ -165,7 +165,6 @@ public class InnerClasses {
 //                         ^^^^^^ reference java/lang/String#
 //                                 ^^^^^^ reference java/lang/String#
 //                                 ^^^^^^ reference java/lang/String#
-//                                           ^ definition local9 1:4
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
           public String apply(String s) {

--- a/tests/snapshots/src/main/generated/minimized/Interfaces.java
+++ b/tests/snapshots/src/main/generated/minimized/Interfaces.java
@@ -1,7 +1,7 @@
 package minimized;
 
 public interface Interfaces {
-//     ^^^^^^^^^^ definition minimized/Interfaces#
+//               ^^^^^^^^^^ definition minimized/Interfaces#
   String abstractInterfaceMethod();
 //^^^^^^ reference java/lang/String#
 //       ^^^^^^^^^^^^^^^^^^^^^^^ definition minimized/Interfaces#abstractInterfaceMethod().

--- a/tests/snapshots/src/main/generated/minimized/Methods.java
+++ b/tests/snapshots/src/main/generated/minimized/Methods.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class Methods {
-//     ^^^^^^ definition minimized/Methods#`<init>`().
-//     ^^^^^^^ definition minimized/Methods#
+//           ^^^^^^^ definition minimized/Methods#
+//           ^^^^^^^ definition minimized/Methods#`<init>`().
   private int overload(int value) {
 //            ^^^^^^^^ definition minimized/Methods#overload().
 //                         ^^^^^ definition local0

--- a/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
@@ -5,8 +5,8 @@ package minimized;
 //           ^^^^^ reference minimized/Annotations#value().
 //                            ^^^^^^ reference minimized/Annotations#format().
 public class MinimizedJavaMain {
-//     ^^^^^^ definition minimized/MinimizedJavaMain#`<init>`().
-//     ^^^^^^^^^^^^^^^^^ definition minimized/MinimizedJavaMain#
+//           ^^^^^^^^^^^^^^^^^ definition minimized/MinimizedJavaMain#
+//           ^^^^^^^^^^^^^^^^^ definition minimized/MinimizedJavaMain#`<init>`().
   public static void main(String[] args) {
 //                   ^^^^ definition minimized/MinimizedJavaMain#main().
 //                        ^^^^^^ reference java/lang/String#

--- a/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
+++ b/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class ParameterizedTypes<A, B> {
-//     ^^^^^^ definition minimized/ParameterizedTypes#`<init>`().
-//     ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#
+//           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#
+//           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#`<init>`().
   public String app(A a, B b) {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^ definition minimized/ParameterizedTypes#app().

--- a/tests/snapshots/src/main/generated/minimized/Primitives.java
+++ b/tests/snapshots/src/main/generated/minimized/Primitives.java
@@ -6,8 +6,8 @@ import java.util.Random;
 //               ^^^^^^ reference java/util/Random#
 
 public class Primitives {
-//     ^^^^^^ definition minimized/Primitives#`<init>`().
-//     ^^^^^^^^^^ definition minimized/Primitives#
+//           ^^^^^^^^^^ definition minimized/Primitives#
+//           ^^^^^^^^^^ definition minimized/Primitives#`<init>`().
   public static String app() {
 //              ^^^^^^ reference java/lang/String#
 //                     ^^^ definition minimized/Primitives#app().

--- a/tests/snapshots/src/main/generated/minimized/RawTypes.java
+++ b/tests/snapshots/src/main/generated/minimized/RawTypes.java
@@ -12,8 +12,8 @@ import java.util.List;
 @SuppressWarnings("ALL")
 //^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
 public class RawTypes {
-//     ^^^^^^ definition minimized/RawTypes#`<init>`().
-//     ^^^^^^^^ definition minimized/RawTypes#
+//           ^^^^^^^^ definition minimized/RawTypes#
+//           ^^^^^^^^ definition minimized/RawTypes#`<init>`().
   public static final List x = Collections.singletonList(42);
 //                    ^^^^ reference java/util/List#
 //                         ^ definition minimized/RawTypes#x.

--- a/tests/snapshots/src/main/generated/minimized/SubClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/SubClasses.java
@@ -1,8 +1,8 @@
 package minimized;
 
 public class SubClasses extends AbstractClasses implements Interfaces {
-//     ^^^^^^ definition minimized/SubClasses#`<init>`().
-//     ^^^^^^^^^^ definition minimized/SubClasses#
+//           ^^^^^^^^^^ definition minimized/SubClasses#
+//           ^^^^^^^^^^ definition minimized/SubClasses#`<init>`().
 //                              ^^^^^^^^^^^^^^^ reference minimized/AbstractClasses#
 //                                                         ^^^^^^^^^^ reference minimized/Interfaces#
 

--- a/tests/snapshots/src/main/generated/minimized/TypeVariables.java
+++ b/tests/snapshots/src/main/generated/minimized/TypeVariables.java
@@ -2,11 +2,11 @@ package minimized;
 
 /** Example from https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4 */
 public class TypeVariables {
-//     ^^^^^^ definition minimized/TypeVariables#`<init>`().
-//     ^^^^^^^^^^^^^ definition minimized/TypeVariables#
+//           ^^^^^^^^^^^^^ definition minimized/TypeVariables#
+//           ^^^^^^^^^^^^^ definition minimized/TypeVariables#`<init>`().
   static class C {
-//       ^ definition minimized/TypeVariables#C#
-//       ^^^^^^ definition minimized/TypeVariables#C#`<init>`().
+//             ^ definition minimized/TypeVariables#C#
+//             ^ definition minimized/TypeVariables#C#`<init>`().
     public void mCPublic() {}
 //              ^^^^^^^^ definition minimized/TypeVariables#C#mCPublic().
 
@@ -18,14 +18,14 @@ public class TypeVariables {
   }
 
   interface I {
-//^ definition minimized/TypeVariables#I#
+//          ^ definition minimized/TypeVariables#I#
     void mI();
 //       ^^ definition minimized/TypeVariables#I#mI().
   }
 
   static class CT extends C implements I {
-//       ^^ definition minimized/TypeVariables#CT#
-//       ^^^^^^ definition minimized/TypeVariables#CT#`<init>`().
+//             ^^ definition minimized/TypeVariables#CT#
+//             ^^ definition minimized/TypeVariables#CT#`<init>`().
 //                        ^ reference minimized/TypeVariables#C#
 //                                     ^ reference minimized/TypeVariables#I#
     public void mI() {}

--- a/tests/unit/src/test/scala/tests/GeneratedConstructorSuite.scala
+++ b/tests/unit/src/test/scala/tests/GeneratedConstructorSuite.scala
@@ -1,0 +1,30 @@
+package tests
+
+import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
+import munit.{FunSuite, TestOptions}
+
+import scala.meta.inputs.Input
+
+class GeneratedConstructorSuite extends FunSuite with TempDirectories {
+  val targetroot = new DirectoryFixture()
+
+  override def munitFixtures: Seq[Fixture[_]] =
+    super.munitFixtures ++ List(targetroot)
+
+  def doSomething(
+    options: TestOptions,
+    original: String,
+    fn: (TextDocument, List[String]) => Unit,
+    qualifiedClassName: String = "example.Test"
+  )(implicit loc: munit.Location): Unit = {
+    test(options) {
+      val groups = "<<([0-9a-zA-Z]+)>>".r
+      val compiler = new TestCompiler(targetroot())
+      val trimmedText = groups.replaceAllIn(original, "$1")
+      val relativePath = qualifiedClassName.replace('.', '/') + ".java"
+      val input = Input.VirtualFile(relativePath, trimmedText)
+
+
+    }
+  }
+}

--- a/tests/unit/src/test/scala/tests/GeneratedConstructorSuite.scala
+++ b/tests/unit/src/test/scala/tests/GeneratedConstructorSuite.scala
@@ -1,9 +1,10 @@
 package tests
 
-import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
-import munit.{FunSuite, TestOptions}
-
 import scala.meta.inputs.Input
+
+import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
+import munit.FunSuite
+import munit.TestOptions
 
 class GeneratedConstructorSuite extends FunSuite with TempDirectories {
   val targetroot = new DirectoryFixture()
@@ -12,10 +13,10 @@ class GeneratedConstructorSuite extends FunSuite with TempDirectories {
     super.munitFixtures ++ List(targetroot)
 
   def doSomething(
-    options: TestOptions,
-    original: String,
-    fn: (TextDocument, List[String]) => Unit,
-    qualifiedClassName: String = "example.Test"
+      options: TestOptions,
+      original: String,
+      fn: (TextDocument, List[String]) => Unit,
+      qualifiedClassName: String = "example.Test"
   )(implicit loc: munit.Location): Unit = {
     test(options) {
       val groups = "<<([0-9a-zA-Z]+)>>".r
@@ -23,7 +24,6 @@ class GeneratedConstructorSuite extends FunSuite with TempDirectories {
       val trimmedText = groups.replaceAllIn(original, "$1")
       val relativePath = qualifiedClassName.replace('.', '/') + ".java"
       val input = Input.VirtualFile(relativePath, trimmedText)
-
 
     }
   }

--- a/tests/unit/src/test/scala/tests/SnapshotCommandSuite.scala
+++ b/tests/unit/src/test/scala/tests/SnapshotCommandSuite.scala
@@ -38,8 +38,8 @@ class SnapshotCommandSuite extends MopedSuite(LsifJava.app) {
          |package main;
          |
          |public class Sample {
-         |//     ^^^^^^ definition main/Sample#
-         |//     ^^^^^^ definition main/Sample#`<init>`().
+         |//           ^^^^^^ definition main/Sample#
+         |//           ^^^^^^ definition main/Sample#`<init>`().
          |   public static void main(String[] asdf) {}
          |//                    ^^^^ definition main/Sample#main().
          |//                         ^^^^^^ reference java/lang/String#


### PR DESCRIPTION
Uses text search derived from previous com.sun.source lsif-java (Kotlin edition), which is originally derived from georgewfraser's java language server. Closes #109 

Of particular note is that the current changes cause definition occurence to [not be emitted](https://github.com/sourcegraph/lsif-java/pull/121/files#diff-1c43dc4d39a78f8bfeee7dbff8bd285a2cd2c711e57d8053586575921be9230cL325). The reference to this no longer existing definition occurrence still gets emitted, we can either follow up with a PR or fix it in this PR. 

I feel like moving parts of `SemanticdbVisitor.semanticdbRange(...)` to the `RangeFinder` class to keep more of the logic together, but I will revisit this tomorrow.