### PR TITLE
Emit SemanticDB types and signatures

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Debugging.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Debugging.java
@@ -7,6 +7,6 @@ public final class Debugging {
     if (any instanceof String) {
       any = String.format("\"%s\"", any);
     }
-    System.out.printf("%s:%s %s%n", trace.getFileName(), trace.getLineNumber(), any);
+    System.err.printf("%s:%s %s%n", trace.getFileName(), trace.getLineNumber(), any);
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Debugging.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Debugging.java
@@ -7,6 +7,6 @@ public final class Debugging {
     if (any instanceof String) {
       any = String.format("\"%s\"", any);
     }
-    System.err.printf("%s:%s %s%n", trace.getFileName(), trace.getLineNumber(), any);
+    System.out.printf("%s:%s %s%n", trace.getFileName(), trace.getLineNumber(), any);
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
@@ -30,6 +30,10 @@ public final class GlobalSymbolsCache {
     return result;
   }
 
+  public String semanticdbSymbol(Element element, LocalSymbolsCache locals) {
+    return semanticdbSymbol((Symbol) element, locals);
+  }
+
   public boolean isNone(Symbol sym) {
     return sym == null;
   }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
@@ -1,0 +1,226 @@
+package com.sourcegraph.semanticdb_javac;
+
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sourcegraph.semanticdb_javac.Semanticdb.*;
+import com.sun.tools.javac.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.type.*;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.util.SimpleTypeVisitor8;
+import java.util.ArrayList;
+
+import static com.sourcegraph.semanticdb_javac.Debugging.pprint;
+
+public final class SemanticdbSignatures {
+  private final GlobalSymbolsCache cache;
+  private final LocalSymbolsCache locals;
+
+  public SemanticdbSignatures(GlobalSymbolsCache cache, LocalSymbolsCache locals) {
+    this.cache = cache;
+    this.locals = locals;
+  }
+
+  public Signature generateSignature(Symbol sym) {
+    if (sym instanceof Symbol.ClassSymbol) {
+      return generateClassSignature((Symbol.ClassSymbol) sym);
+    } else if (sym instanceof Symbol.MethodSymbol) {
+      return generateMethodSignature((Symbol.MethodSymbol) sym);
+    } else if (sym instanceof Symbol.VarSymbol) {
+      return generateFieldSignature((Symbol.VarSymbol) sym);
+    } else if (sym instanceof Symbol.TypeVariableSymbol) {
+      return generateTypeSignature((Symbol.TypeVariableSymbol) sym);
+    }
+    return null;
+  }
+
+  private Signature generateClassSignature(Symbol.ClassSymbol sym) {
+    ClassSignature.Builder builder = ClassSignature.newBuilder();
+
+    builder.setTypeParameters(generateScope(sym.getTypeParameters()));
+
+    if (sym.getSuperclass() != Type.noType) {
+      builder.addParents(generateType(sym.getSuperclass()));
+    }
+    for (Type iType : sym.getInterfaces()) {
+      builder.addParents(generateType(iType));
+    }
+
+    Scope.Builder declarations = Scope.newBuilder();
+    for (Symbol enclosed : sym.getEnclosedElements()) {
+      declarations.addSymlinks(cache.semanticdbSymbol(enclosed, locals));
+    }
+    builder.setDeclarations(declarations);
+
+    return Signature.newBuilder().setClassSignature(builder).build();
+  }
+
+  private Signature generateMethodSignature(Symbol.MethodSymbol sym) {
+    MethodSignature.Builder builder = MethodSignature.newBuilder();
+
+    builder.setTypeParameters(generateScope(sym.getTypeParameters()));
+
+    builder.addParameterLists(generateScope(sym.params()));
+
+    Semanticdb.Type returnType = generateType(sym.getReturnType());
+    if (returnType != null) {
+      builder.setReturnType(returnType);
+    }
+
+    return Signature.newBuilder().setMethodSignature(builder).build();
+  }
+
+  private Signature generateFieldSignature(Symbol.VarSymbol sym) {
+    if (generateType(sym.type) == null) {
+      // pprint(generateType(sym.type) + " " + sym.type + " " + cache.semanticdbSymbol(sym,
+      // locals));
+    }
+    return Signature.newBuilder()
+        .setValueSignature(ValueSignature.newBuilder().setTpe(generateType(sym.type)))
+        .build();
+  }
+
+  private Signature generateTypeSignature(Symbol.TypeVariableSymbol sym) {
+    TypeSignature.Builder builder = TypeSignature.newBuilder();
+
+    pprint(sym.type.getKind() + " " + sym);
+
+    builder.setTypeParameters(generateScope(sym.getTypeParameters()));
+
+    builder.setUpperBound(generateType(sym.type.getUpperBound()));
+
+    return Signature.newBuilder().setTypeSignature(builder).build();
+  }
+
+  private <T extends Element> Scope generateScope(List<T> elements) {
+    Scope.Builder scope = Scope.newBuilder();
+    for (T typeVar : elements) {
+      String s = cache.semanticdbSymbol(typeVar, locals);
+      scope.addSymlinks(s);
+    }
+    return scope.build();
+  }
+
+  private Semanticdb.Type generateType(TypeMirror mirror) {
+    return mirror.accept(new SemanticdbTypeVisitor(cache, locals), null);
+  }
+
+  /** A TypeMirror tree visitor that constructs a recursive SemanticDB Type structure. */
+  private static class SemanticdbTypeVisitor extends SimpleTypeVisitor8<Semanticdb.Type, Void> {
+    private final GlobalSymbolsCache cache;
+    private final LocalSymbolsCache locals;
+
+    private SemanticdbTypeVisitor(GlobalSymbolsCache cache, LocalSymbolsCache locals) {
+      this.cache = cache;
+      this.locals = locals;
+    }
+
+    @Override
+    public Semanticdb.Type visitDeclared(DeclaredType t, Void unused) {
+      boolean isExistential =
+          t.getTypeArguments().stream().anyMatch((type) -> type instanceof WildcardType);
+
+      ArrayList<Semanticdb.Type> typeParams = new ArrayList<>();
+      for (TypeMirror type : t.getTypeArguments()) {
+        Semanticdb.Type visit = super.visit(type);
+        if (visit == null) {
+          pprint(type + " " + visit + " " + type.getClass());
+          continue;
+        }
+        typeParams.add(visit);
+      }
+
+      if (!isExistential) {
+        return Semanticdb.Type.newBuilder()
+            .setTypeRef(
+                TypeRef.newBuilder()
+                    .setSymbol(cache.semanticdbSymbol(t.asElement(), locals))
+                    .addAllTypeArguments(typeParams))
+            .build();
+      } else {
+        return Semanticdb.Type.newBuilder()
+            .setExistentialType(
+                ExistentialType.newBuilder()
+                    .setTpe(
+                        Semanticdb.Type.newBuilder()
+                            .setTypeRef(
+                                TypeRef.newBuilder()
+                                    .setSymbol(cache.semanticdbSymbol(t.asElement(), locals))
+                                    .addAllTypeArguments(typeParams))))
+            .build();
+      }
+    }
+
+    @Override
+    public Semanticdb.Type visitArray(ArrayType t, Void unused) {
+      return Semanticdb.Type.newBuilder()
+          .setTypeRef(
+              TypeRef.newBuilder()
+                  .setSymbol("scala/Array#")
+                  .addTypeArguments(super.visit(t.getComponentType())))
+          .build();
+    }
+
+    @Override
+    public Semanticdb.Type visitPrimitive(PrimitiveType t, Void unused) {
+      return Semanticdb.Type.newBuilder()
+          .setTypeRef(TypeRef.newBuilder().setSymbol(primitiveSymbol(t.getKind())))
+          .build();
+    }
+
+    @Override
+    public Semanticdb.Type visitTypeVariable(TypeVariable t, Void unused) {
+      return Semanticdb.Type.newBuilder()
+          .setTypeRef(
+              TypeRef.newBuilder().setSymbol(cache.semanticdbSymbol(t.asElement(), locals)).build())
+          .build();
+    }
+
+    @Override
+    public Semanticdb.Type visitIntersection(IntersectionType t, Void unused) {
+      ArrayList<Semanticdb.Type> types = new ArrayList<>();
+      for (TypeMirror type : t.getBounds()) {
+        types.add(super.visit(type));
+      }
+
+      return Semanticdb.Type.newBuilder()
+          .setIntersectionType(Semanticdb.IntersectionType.newBuilder().addAllTypes(types).build())
+          .build();
+    }
+
+    @Override
+    public Semanticdb.Type visitWildcard(WildcardType t, Void unused) {
+      new Exception().printStackTrace();
+      return Semanticdb.Type.newBuilder()
+          .setExistentialType(ExistentialType.newBuilder().build())
+          .build();
+    }
+
+    public String primitiveSymbol(TypeKind kind) {
+      switch (kind) {
+        case BOOLEAN:
+          return "scala/Boolean#";
+        case BYTE:
+          return "scala/Byte#";
+        case SHORT:
+          return "scala/Short#";
+        case INT:
+          return "scala/Int#";
+        case LONG:
+          return "scala/Long#";
+        case CHAR:
+          return "scala/Char#";
+        case FLOAT:
+          return "scala/Float#";
+        case DOUBLE:
+          return "scala/Double#";
+        case VOID:
+          return "scala/Unit#";
+        default:
+          throw new IllegalArgumentException("got " + kind.name());
+      }
+    }
+  }
+}

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static com.sourcegraph.semanticdb_javac.Debugging.pprint;
+
 /** Walks the AST of a typechecked compilation unit and generates a SemanticDB TextDocument. */
 public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
@@ -54,6 +56,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   }
 
   public Semanticdb.TextDocument buildTextDocument(CompilationUnitTree tree) {
+    // pprint(semanticdbUri());
     this.scan(tree, null); // Trigger recursive AST traversal to collect SemanticDB information.
 
     return Semanticdb.TextDocument.newBuilder()
@@ -80,6 +83,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   private void emitSymbolInformation(Symbol sym) {
     Semanticdb.SymbolInformation.Builder builder =
         Semanticdb.SymbolInformation.newBuilder().setSymbol(semanticdbSymbol(sym));
+    // .setSignature(semanticdbSignature(sym));
     Semanticdb.Documentation documentation = semanticdbDocumentation(sym);
     if (documentation != null) builder.setDocumentation(documentation);
 
@@ -178,6 +182,10 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   // =================================================
   // Utilities to generate SemanticDB data structures.
   // =================================================
+
+  private Semanticdb.Signature semanticdbSignature(Symbol sym) {
+    return new SemanticdbSignatures(globals, locals).generateSignature(sym);
+  }
 
   private String semanticdbSymbol(Symbol sym) {
     return globals.semanticdbSymbol(sym, locals);

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -56,7 +56,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   }
 
   public Semanticdb.TextDocument buildTextDocument(CompilationUnitTree tree) {
-    // pprint(semanticdbUri());
+    pprint(semanticdbUri());
     this.scan(tree, null); // Trigger recursive AST traversal to collect SemanticDB information.
 
     return Semanticdb.TextDocument.newBuilder()
@@ -83,9 +83,10 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   private void emitSymbolInformation(Symbol sym) {
     Semanticdb.SymbolInformation.Builder builder =
         Semanticdb.SymbolInformation.newBuilder().setSymbol(semanticdbSymbol(sym));
-    // .setSignature(semanticdbSignature(sym));
     Semanticdb.Documentation documentation = semanticdbDocumentation(sym);
     if (documentation != null) builder.setDocumentation(documentation);
+    Semanticdb.Signature signature = semanticdbSignature(sym);
+    if (signature != null) builder.setSignature(signature);
 
     Semanticdb.SymbolInformation info = builder.build();
 

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Optional;
 
-import static com.sourcegraph.semanticdb_javac.Debugging.pprint;
-
 /** Walks the AST of a typechecked compilation unit and generates a SemanticDB TextDocument. */
 public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
@@ -56,7 +54,6 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   }
 
   public Semanticdb.TextDocument buildTextDocument(CompilationUnitTree tree) {
-    pprint(semanticdbUri());
     this.scan(tree, null); // Trigger recursive AST traversal to collect SemanticDB information.
 
     return Semanticdb.TextDocument.newBuilder()

--- a/semanticdb-javac/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-javac/src/main/protobuf/semanticdb.proto
@@ -41,6 +41,36 @@ message Range {
   int32 end_character = 4;
 }
 
+message Signature {
+  oneof sealed_value {
+    ClassSignature class_signature = 1;
+    MethodSignature method_signature = 2;
+    TypeSignature type_signature = 3;
+    ValueSignature value_signature = 4;
+  }
+}
+
+message ClassSignature {
+  Scope type_parameters = 1;
+  repeated Type parents = 2;
+  Scope declarations = 4;
+}
+
+message MethodSignature {
+  Scope type_parameters = 1;
+  repeated Scope parameter_lists = 2;
+  Type return_type = 3;
+}
+
+message TypeSignature {
+  Scope type_parameters = 1;
+  Type upper_bound = 3;
+}
+
+message ValueSignature {
+  Type tpe = 1;
+}
+
 message SymbolInformation {
   enum Kind {
     reserved 1, 2, 4, 5, 15, 16;
@@ -86,6 +116,7 @@ message SymbolInformation {
   Kind kind = 3;
   int32 properties = 4;
   string display_name = 5;
+  Signature signature = 17;
   repeated string overridden_symbols = 19;
   Documentation documentation = 20;
 }
@@ -113,3 +144,30 @@ message SymbolOccurrence {
   Role role = 3;
 }
 
+message Scope {
+  repeated string symlinks = 1;
+}
+
+message Type {
+  reserved 1, 3, 4, 5, 6, 11, 12, 15, 16;
+  oneof sealed_value {
+    TypeRef type_ref = 2;
+    IntersectionType intersection_type = 17;
+    ExistentialType existential_type = 9;
+  }
+}
+
+message TypeRef {
+  Type prefix = 1;
+  string symbol = 2;
+  repeated Type type_arguments = 3;
+}
+message IntersectionType {
+  repeated Type types = 1;
+}
+
+message ExistentialType {
+  reserved 2;
+  Type tpe = 1;
+  Scope declarations = 3;
+}

--- a/semanticdb-javac/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-javac/src/main/protobuf/semanticdb.proto
@@ -64,6 +64,7 @@ message MethodSignature {
 
 message TypeSignature {
   Scope type_parameters = 1;
+  Type lower_bound = 2;
   Type upper_bound = 3;
 }
 
@@ -146,6 +147,7 @@ message SymbolOccurrence {
 
 message Scope {
   repeated string symlinks = 1;
+  repeated SymbolInformation hardlinks = 2;
 }
 
 message Type {
@@ -158,7 +160,6 @@ message Type {
 }
 
 message TypeRef {
-  Type prefix = 1;
   string symbol = 2;
   repeated Type type_arguments = 3;
 }

--- a/tests/minimized/src/main/java/minimized/ParameterizedTypes.java
+++ b/tests/minimized/src/main/java/minimized/ParameterizedTypes.java
@@ -1,13 +1,11 @@
 package minimized;
 
-import java.util.List;
+import java.util.Map;
 
 public class ParameterizedTypes<A, B> {
-  //Class<?> clazz;
-
   public String app(A a, B b) {
     return a.toString() + b;
   }
 
-  public List<?> doStuff() { return null; }
+  public Map<? extends String, ?> doStuff() { return null; }
 }

--- a/tests/minimized/src/main/java/minimized/ParameterizedTypes.java
+++ b/tests/minimized/src/main/java/minimized/ParameterizedTypes.java
@@ -1,7 +1,13 @@
 package minimized;
 
+import java.util.List;
+
 public class ParameterizedTypes<A, B> {
+  //Class<?> clazz;
+
   public String app(A a, B b) {
     return a.toString() + b;
   }
+
+  public List<?> doStuff() { return null; }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
@@ -21,8 +21,8 @@ class ControllerModelList extends ModelList {
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeInserted(int positionStart, int itemCount) {
 //              ^^^^^^^^^^^^^^^^^^^ definition local2
-//                                      ^^^^^^^^^^^^^ definition local3
-//                                                         ^^^^^^^^^ definition local4
+//                                      ^^^^^^^^^^^^^ definition local4
+//                                                         ^^^^^^^^^ definition local5
       throw new IllegalStateException(
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:75
 //              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
@@ -32,7 +32,7 @@ class ControllerModelList extends ModelList {
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeRemoved(int positionStart, int itemCount) {
-//              ^^^^^^^^^^^^^^^^^^ definition local5
+//              ^^^^^^^^^^^^^^^^^^ definition local3
 //                                     ^^^^^^^^^^^^^ definition local6
 //                                                        ^^^^^^^^^ definition local7
       throw new IllegalStateException(

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -114,24 +114,24 @@ class DiffHelper {
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeChanged(int positionStart, int itemCount) {
 //              ^^^^^^^^^^^^^^^^^^ definition local4
-//                                     ^^^^^^^^^^^^^ definition local5
-//                                                        ^^^^^^^^^ definition local6
+//                                     ^^^^^^^^^^^^^ definition local8
+//                                                        ^^^^^^^^^ definition local9
       for (int i = positionStart; i < positionStart + itemCount; i++) {
-//             ^ definition local7
-//                 ^^^^^^^^^^^^^ reference local5
-//                                ^ reference local7
-//                                    ^^^^^^^^^^^^^ reference local5
-//                                                    ^^^^^^^^^ reference local6
-//                                                               ^ reference local7
+//             ^ definition local10
+//                 ^^^^^^^^^^^^^ reference local8
+//                                ^ reference local10
+//                                    ^^^^^^^^^^^^^ reference local8
+//                                                    ^^^^^^^^^ reference local9
+//                                                               ^ reference local10
         currentStateList.get(i).hashCode = adapter.getCurrentModels().get(i).hashCode();
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                       ^^^ reference java/util/ArrayList#get().
-//                           ^ reference local7
+//                           ^ reference local10
 //                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#hashCode.
 //                                         ^^^^^^^ reference com/airbnb/epoxy/DiffHelper#adapter.
 //                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                                                    ^^^ reference java/util/List#get().
-//                                                                        ^ reference local7
+//                                                                        ^ reference local10
 //                                                                           ^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hashCode().
       }
     }
@@ -139,93 +139,93 @@ class DiffHelper {
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeInserted(int positionStart, int itemCount) {
-//              ^^^^^^^^^^^^^^^^^^^ definition local8
-//                                      ^^^^^^^^^^^^^ definition local9
-//                                                         ^^^^^^^^^ definition local10
+//              ^^^^^^^^^^^^^^^^^^^ definition local5
+//                                      ^^^^^^^^^^^^^ definition local11
+//                                                         ^^^^^^^^^ definition local12
       if (itemCount == 0) {
-//        ^^^^^^^^^ reference local10
+//        ^^^^^^^^^ reference local12
         // no-op
         return;
       }
 
       if (itemCount == 1 || positionStart == currentStateList.size()) {
-//        ^^^^^^^^^ reference local10
-//                          ^^^^^^^^^^^^^ reference local9
+//        ^^^^^^^^^ reference local12
+//                          ^^^^^^^^^^^^^ reference local11
 //                                           ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                                                            ^^^^ reference java/util/ArrayList#size().
         for (int i = positionStart; i < positionStart + itemCount; i++) {
-//               ^ definition local11
-//                   ^^^^^^^^^^^^^ reference local9
-//                                  ^ reference local11
-//                                      ^^^^^^^^^^^^^ reference local9
-//                                                      ^^^^^^^^^ reference local10
-//                                                                 ^ reference local11
+//               ^ definition local13
+//                   ^^^^^^^^^^^^^ reference local11
+//                                  ^ reference local13
+//                                      ^^^^^^^^^^^^^ reference local11
+//                                                      ^^^^^^^^^ reference local12
+//                                                                 ^ reference local13
           currentStateList.add(i, createStateForPosition(i));
 //        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                         ^^^ reference java/util/ArrayList#add(+2).
-//                             ^ reference local11
+//                             ^ reference local13
 //                                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#createStateForPosition().
-//                                                       ^ reference local11
+//                                                       ^ reference local13
         }
       } else {
         // Add in a batch since multiple insertions to the middle of the list are slow
         List<ModelState> newModels = new ArrayList<>(itemCount);
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                       ^^^^^^^^^ definition local12
+//                       ^^^^^^^^^ definition local14
 //                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
 //                                       ^^^^^^^^^ reference java/util/ArrayList#
-//                                                   ^^^^^^^^^ reference local10
+//                                                   ^^^^^^^^^ reference local12
         for (int i = positionStart; i < positionStart + itemCount; i++) {
-//               ^ definition local13
-//                   ^^^^^^^^^^^^^ reference local9
-//                                  ^ reference local13
-//                                      ^^^^^^^^^^^^^ reference local9
-//                                                      ^^^^^^^^^ reference local10
-//                                                                 ^ reference local13
+//               ^ definition local15
+//                   ^^^^^^^^^^^^^ reference local11
+//                                  ^ reference local15
+//                                      ^^^^^^^^^^^^^ reference local11
+//                                                      ^^^^^^^^^ reference local12
+//                                                                 ^ reference local15
           newModels.add(createStateForPosition(i));
-//        ^^^^^^^^^ reference local12
+//        ^^^^^^^^^ reference local14
 //                  ^^^ reference java/util/List#add().
 //                      ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#createStateForPosition().
-//                                             ^ reference local13
+//                                             ^ reference local15
         }
 
         currentStateList.addAll(positionStart, newModels);
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                       ^^^^^^ reference java/util/ArrayList#addAll(+1).
-//                              ^^^^^^^^^^^^^ reference local9
-//                                             ^^^^^^^^^ reference local12
+//                              ^^^^^^^^^^^^^ reference local11
+//                                             ^^^^^^^^^ reference local14
       }
 
       // Update positions of affected items
       int size = currentStateList.size();
-//        ^^^^ definition local14
+//        ^^^^ definition local16
 //               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                                ^^^^ reference java/util/ArrayList#size().
       for (int i = positionStart + itemCount; i < size; i++) {
-//             ^ definition local15
-//                 ^^^^^^^^^^^^^ reference local9
-//                                 ^^^^^^^^^ reference local10
-//                                            ^ reference local15
-//                                                ^^^^ reference local14
-//                                                      ^ reference local15
+//             ^ definition local17
+//                 ^^^^^^^^^^^^^ reference local11
+//                                 ^^^^^^^^^ reference local12
+//                                            ^ reference local17
+//                                                ^^^^ reference local16
+//                                                      ^ reference local17
         currentStateList.get(i).position += itemCount;
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                       ^^^ reference java/util/ArrayList#get().
-//                           ^ reference local15
+//                           ^ reference local17
 //                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                          ^^^^^^^^^ reference local10
+//                                          ^^^^^^^^^ reference local12
       }
     }
 
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeRemoved(int positionStart, int itemCount) {
-//              ^^^^^^^^^^^^^^^^^^ definition local16
-//                                     ^^^^^^^^^^^^^ definition local17
-//                                                        ^^^^^^^^^ definition local18
+//              ^^^^^^^^^^^^^^^^^^ definition local6
+//                                     ^^^^^^^^^^^^^ definition local18
+//                                                        ^^^^^^^^^ definition local19
       if (itemCount == 0) {
-//        ^^^^^^^^^ reference local18
+//        ^^^^^^^^^ reference local19
         // no-op
         return;
       }
@@ -233,51 +233,51 @@ class DiffHelper {
       List<ModelState> modelsToRemove =
 //    ^^^^ reference java/util/List#
 //         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                     ^^^^^^^^^^^^^^ definition local19
+//                     ^^^^^^^^^^^^^^ definition local20
           currentStateList.subList(positionStart, positionStart + itemCount);
 //        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                         ^^^^^^^ reference java/util/ArrayList#subList().
-//                                 ^^^^^^^^^^^^^ reference local17
-//                                                ^^^^^^^^^^^^^ reference local17
-//                                                                ^^^^^^^^^ reference local18
+//                                 ^^^^^^^^^^^^^ reference local18
+//                                                ^^^^^^^^^^^^^ reference local18
+//                                                                ^^^^^^^^^ reference local19
       for (ModelState model : modelsToRemove) {
 //         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
-//                    ^^^^^ definition local20
-//                            ^^^^^^^^^^^^^^ reference local19
+//                    ^^^^^ definition local21
+//                            ^^^^^^^^^^^^^^ reference local20
         currentStateMap.remove(model.id);
 //      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateMap.
 //                      ^^^^^^ reference java/util/Map#remove().
-//                             ^^^^^ reference local20
+//                             ^^^^^ reference local21
 //                                   ^^ reference com/airbnb/epoxy/ModelState#id.
       }
       modelsToRemove.clear();
-//    ^^^^^^^^^^^^^^ reference local19
+//    ^^^^^^^^^^^^^^ reference local20
 //                   ^^^^^ reference java/util/List#clear().
 
       // Update positions of affected items
       int size = currentStateList.size();
-//        ^^^^ definition local21
+//        ^^^^ definition local22
 //               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                                ^^^^ reference java/util/ArrayList#size().
       for (int i = positionStart; i < size; i++) {
-//             ^ definition local22
-//                 ^^^^^^^^^^^^^ reference local17
-//                                ^ reference local22
-//                                    ^^^^ reference local21
-//                                          ^ reference local22
+//             ^ definition local23
+//                 ^^^^^^^^^^^^^ reference local18
+//                                ^ reference local23
+//                                    ^^^^ reference local22
+//                                          ^ reference local23
         currentStateList.get(i).position -= itemCount;
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#currentStateList.
 //                       ^^^ reference java/util/ArrayList#get().
-//                           ^ reference local22
+//                           ^ reference local23
 //                              ^^^^^^^^ reference com/airbnb/epoxy/ModelState#position.
-//                                          ^^^^^^^^^ reference local18
+//                                          ^^^^^^^^^ reference local19
       }
     }
 
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
-//              ^^^^^^^^^^^^^^^^ definition local23
+//              ^^^^^^^^^^^^^^^^ definition local7
 //                                   ^^^^^^^^^^^^ definition local24
 //                                                     ^^^^^^^^^^ definition local25
 //                                                                     ^^^^^^^^^ definition local26

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -591,35 +591,35 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
         public boolean areItemsTheSame(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
 //                     ^^^^^^^^^^^^^^^ definition local36
 //                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                   ^^^^^^^ definition local37
+//                                                   ^^^^^^^ definition local39
 //                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                                          ^^^^^^^ definition local38
+//                                                                          ^^^^^^^ definition local40
           return oldItem.id() == newItem.id();
-//               ^^^^^^^ reference local37
+//               ^^^^^^^ reference local39
 //                       ^^ reference com/airbnb/epoxy/EpoxyModel#id().
-//                               ^^^^^^^ reference local38
+//                               ^^^^^^^ reference local40
 //                                       ^^ reference com/airbnb/epoxy/EpoxyModel#id().
         }
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public boolean areContentsTheSame(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
-//                     ^^^^^^^^^^^^^^^^^^ definition local39
+//                     ^^^^^^^^^^^^^^^^^^ definition local37
 //                                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                      ^^^^^^^ definition local40
+//                                                      ^^^^^^^ definition local41
 //                                                               ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                                             ^^^^^^^ definition local41
+//                                                                             ^^^^^^^ definition local42
           return oldItem.equals(newItem);
-//               ^^^^^^^ reference local40
+//               ^^^^^^^ reference local41
 //                       ^^^^^^ reference com/airbnb/epoxy/EpoxyModel#equals().
-//                              ^^^^^^^ reference local41
+//                              ^^^^^^^ reference local42
         }
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public Object getChangePayload(EpoxyModel<?> oldItem, EpoxyModel<?> newItem) {
 //             ^^^^^^ reference java/lang/Object#
-//                    ^^^^^^^^^^^^^^^^ definition local42
+//                    ^^^^^^^^^^^^^^^^ definition local38
 //                                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                   ^^^^^^^ definition local43
 //                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -720,7 +720,7 @@ public abstract class EpoxyModel<T> {
         public void onInterceptorsStarted(EpoxyController controller) {
 //                  ^^^^^^^^^^^^^^^^^^^^^ definition local39
 //                                        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
-//                                                        ^^^^^^^^^^ definition local40
+//                                                        ^^^^^^^^^^ definition local41
           currentlyInInterceptors = true;
 //        ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#currentlyInInterceptors.
         }
@@ -728,7 +728,7 @@ public abstract class EpoxyModel<T> {
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public void onInterceptorsFinished(EpoxyController controller) {
-//                  ^^^^^^^^^^^^^^^^^^^^^^ definition local41
+//                  ^^^^^^^^^^^^^^^^^^^^^^ definition local40
 //                                         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                                         ^^^^^^^^^^ definition local42
           hashCodeWhenAdded = EpoxyModel.this.hashCode();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -416,8 +416,8 @@ public abstract class EpoxyTouchHelper {
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#controller.
 //                                                                       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClass.
-//                                                                                         ^ definition local21 2:7
-//                                                                                         ^ definition local22 2:13
+//                                                                                         ^ definition local27 2:7
+//                                                                                         ^ definition local28 2:13
 //                                                                                           reference java/lang/ 2:2
 //                                                                                           reference com/airbnb/epoxy/ 2:3
 //                                                                                           reference java/lang/Class# 2:3
@@ -427,10 +427,10 @@ public abstract class EpoxyTouchHelper {
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public int getMovementFlagsForModel(U model, int adapterPosition) {
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^ definition local23
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^ definition local21
 //                                              ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
-//                                                ^^^^^ definition local24
-//                                                           ^^^^^^^^^^^^^^^ definition local25
+//                                                ^^^^^ definition local29
+//                                                           ^^^^^^^^^^^^^^^ definition local30
               return movementFlags;
 //                   ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#movementFlags.
             }
@@ -438,88 +438,88 @@ public abstract class EpoxyTouchHelper {
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             protected boolean isTouchableModel(EpoxyModel<?> model) {
-//                            ^^^^^^^^^^^^^^^^ definition local26
+//                            ^^^^^^^^^^^^^^^^ definition local22
 //                                             ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                           ^^^^^ definition local27
+//                                                           ^^^^^ definition local31
               boolean isTargetType = targetModelClasses.size() == 1
-//                    ^^^^^^^^^^^^ definition local28
+//                    ^^^^^^^^^^^^ definition local32
 //                                   ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClasses.
 //                                                      ^^^^ reference java/util/List#size().
                   ? super.isTouchableModel(model)
-//                  ^^^^^ reference local29
+//                  ^^^^^ reference local33
 //                        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
-//                                         ^^^^^ reference local27
+//                                         ^^^^^ reference local31
                   : targetModelClasses.contains(model.getClass());
 //                  ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClasses.
 //                                     ^^^^^^^^ reference java/util/List#contains().
-//                                              ^^^^^ reference local27
+//                                              ^^^^^ reference local31
 //                                                    ^^^^^^^^ reference java/lang/Object#getClass().
 
               //noinspection unchecked
               return isTargetType && callbacks.isDragEnabledForModel((U) model);
-//                   ^^^^^^^^^^^^ reference local28
+//                   ^^^^^^^^^^^^ reference local32
 //                                   ^^^^^^^^^ reference local17
 //                                             ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#isDragEnabledForModel().
 //                                                                    ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
-//                                                                       ^^^^^ reference local27
+//                                                                       ^^^^^ reference local31
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onDragStarted(U model, View itemView, int adapterPosition) {
-//                      ^^^^^^^^^^^^^ definition local30
+//                      ^^^^^^^^^^^^^ definition local23
 //                                    ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
-//                                      ^^^^^ definition local31
+//                                      ^^^^^ definition local34
 //                                             ^^^^ reference _root_/
-//                                                  ^^^^^^^^ definition local32
-//                                                                ^^^^^^^^^^^^^^^ definition local33
+//                                                  ^^^^^^^^ definition local35
+//                                                                ^^^^^^^^^^^^^^^ definition local36
               callbacks.onDragStarted(model, itemView, adapterPosition);
 //            ^^^^^^^^^ reference local17
 //                      ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragStarted().
-//                                    ^^^^^ reference local31
-//                                           ^^^^^^^^ reference local32
-//                                                     ^^^^^^^^^^^^^^^ reference local33
+//                                    ^^^^^ reference local34
+//                                           ^^^^^^^^ reference local35
+//                                                     ^^^^^^^^^^^^^^^ reference local36
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onDragReleased(U model, View itemView) {
-//                      ^^^^^^^^^^^^^^ definition local34
+//                      ^^^^^^^^^^^^^^ definition local24
 //                                     ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
-//                                       ^^^^^ definition local35
+//                                       ^^^^^ definition local37
 //                                              ^^^^ reference _root_/
-//                                                   ^^^^^^^^ definition local36
+//                                                   ^^^^^^^^ definition local38
               callbacks.onDragReleased(model, itemView);
 //            ^^^^^^^^^ reference local17
 //                      ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragReleased().
-//                                     ^^^^^ reference local35
-//                                            ^^^^^^^^ reference local36
+//                                     ^^^^^ reference local37
+//                                            ^^^^^^^^ reference local38
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onModelMoved(int fromPosition, int toPosition, U modelBeingMoved,
-//                      ^^^^^^^^^^^^ definition local37
-//                                       ^^^^^^^^^^^^ definition local38
-//                                                         ^^^^^^^^^^ definition local39
+//                      ^^^^^^^^^^^^ definition local25
+//                                       ^^^^^^^^^^^^ definition local39
+//                                                         ^^^^^^^^^^ definition local40
 //                                                                     ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
-//                                                                       ^^^^^^^^^^^^^^^ definition local40
+//                                                                       ^^^^^^^^^^^^^^^ definition local41
                 View itemView) {
 //              ^^^^ reference _root_/
-//                   ^^^^^^^^ definition local41
+//                   ^^^^^^^^ definition local42
               callbacks.onModelMoved(fromPosition, toPosition, modelBeingMoved, itemView);
 //            ^^^^^^^^^ reference local17
 //                      ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onModelMoved().
-//                                   ^^^^^^^^^^^^ reference local38
-//                                                 ^^^^^^^^^^ reference local39
-//                                                             ^^^^^^^^^^^^^^^ reference local40
-//                                                                              ^^^^^^^^ reference local41
+//                                   ^^^^^^^^^^^^ reference local39
+//                                                 ^^^^^^^^^^ reference local40
+//                                                             ^^^^^^^^^^^^^^^ reference local41
+//                                                                              ^^^^^^^^ reference local42
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void clearView(U model, View itemView) {
-//                      ^^^^^^^^^ definition local42
+//                      ^^^^^^^^^ definition local26
 //                                ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                  ^^^^^ definition local43
 //                                         ^^^^ reference _root_/
@@ -894,8 +894,8 @@ public abstract class EpoxyTouchHelper {
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClass.
-//                                                                                   ^ definition local75 2:7
-//                                                                                   ^ definition local76 2:13
+//                                                                                   ^ definition local82 2:7
+//                                                                                   ^ definition local83 2:13
 //                                                                                     reference java/lang/ 2:2
 //                                                                                     reference com/airbnb/epoxy/ 2:3
 //                                                                                     reference java/lang/Class# 2:3
@@ -905,10 +905,10 @@ public abstract class EpoxyTouchHelper {
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public int getMovementFlagsForModel(U model, int adapterPosition) {
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^ definition local77
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^ definition local75
 //                                              ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                                ^^^^^ definition local78
-//                                                           ^^^^^^^^^^^^^^^ definition local79
+//                                                ^^^^^ definition local84
+//                                                           ^^^^^^^^^^^^^^^ definition local85
               return movementFlags;
 //                   ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#movementFlags.
             }
@@ -916,108 +916,108 @@ public abstract class EpoxyTouchHelper {
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             protected boolean isTouchableModel(EpoxyModel<?> model) {
-//                            ^^^^^^^^^^^^^^^^ definition local80
+//                            ^^^^^^^^^^^^^^^^ definition local76
 //                                             ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
-//                                                           ^^^^^ definition local81
+//                                                           ^^^^^ definition local86
               boolean isTargetType = targetModelClasses.size() == 1
-//                    ^^^^^^^^^^^^ definition local82
+//                    ^^^^^^^^^^^^ definition local87
 //                                   ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClasses.
 //                                                      ^^^^ reference java/util/List#size().
                   ? super.isTouchableModel(model)
-//                  ^^^^^ reference local83
+//                  ^^^^^ reference local88
 //                        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
-//                                         ^^^^^ reference local81
+//                                         ^^^^^ reference local86
                   : targetModelClasses.contains(model.getClass());
 //                  ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClasses.
 //                                     ^^^^^^^^ reference java/util/List#contains().
-//                                              ^^^^^ reference local81
+//                                              ^^^^^ reference local86
 //                                                    ^^^^^^^^ reference java/lang/Object#getClass().
 
               //noinspection unchecked
               return isTargetType && callbacks.isSwipeEnabledForModel((U) model);
-//                   ^^^^^^^^^^^^ reference local82
+//                   ^^^^^^^^^^^^ reference local87
 //                                   ^^^^^^^^^ reference local71
 //                                             ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#isSwipeEnabledForModel().
 //                                                                     ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                                                        ^^^^^ reference local81
+//                                                                        ^^^^^ reference local86
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onSwipeStarted(U model, View itemView, int adapterPosition) {
-//                      ^^^^^^^^^^^^^^ definition local84
+//                      ^^^^^^^^^^^^^^ definition local77
 //                                     ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                       ^^^^^ definition local85
+//                                       ^^^^^ definition local89
 //                                              ^^^^ reference _root_/
-//                                                   ^^^^^^^^ definition local86
-//                                                                 ^^^^^^^^^^^^^^^ definition local87
+//                                                   ^^^^^^^^ definition local90
+//                                                                 ^^^^^^^^^^^^^^^ definition local91
               callbacks.onSwipeStarted(model, itemView, adapterPosition);
 //            ^^^^^^^^^ reference local71
 //                      ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeStarted().
-//                                     ^^^^^ reference local85
-//                                            ^^^^^^^^ reference local86
-//                                                      ^^^^^^^^^^^^^^^ reference local87
+//                                     ^^^^^ reference local89
+//                                            ^^^^^^^^ reference local90
+//                                                      ^^^^^^^^^^^^^^^ reference local91
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onSwipeProgressChanged(U model, View itemView, float swipeProgress,
-//                      ^^^^^^^^^^^^^^^^^^^^^^ definition local88
+//                      ^^^^^^^^^^^^^^^^^^^^^^ definition local78
 //                                             ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                               ^^^^^ definition local89
+//                                               ^^^^^ definition local92
 //                                                      ^^^^ reference _root_/
-//                                                           ^^^^^^^^ definition local90
-//                                                                           ^^^^^^^^^^^^^ definition local91
+//                                                           ^^^^^^^^ definition local93
+//                                                                           ^^^^^^^^^^^^^ definition local94
                 Canvas canvas) {
 //              ^^^^^^ reference _root_/
-//                     ^^^^^^ definition local92
+//                     ^^^^^^ definition local95
               callbacks.onSwipeProgressChanged(model, itemView, swipeProgress, canvas);
 //            ^^^^^^^^^ reference local71
 //                      ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeProgressChanged().
-//                                             ^^^^^ reference local89
-//                                                    ^^^^^^^^ reference local90
-//                                                              ^^^^^^^^^^^^^ reference local91
-//                                                                             ^^^^^^ reference local92
+//                                             ^^^^^ reference local92
+//                                                    ^^^^^^^^ reference local93
+//                                                              ^^^^^^^^^^^^^ reference local94
+//                                                                             ^^^^^^ reference local95
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onSwipeCompleted(U model, View itemView, int position, int direction) {
-//                      ^^^^^^^^^^^^^^^^ definition local93
+//                      ^^^^^^^^^^^^^^^^ definition local79
 //                                       ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                         ^^^^^ definition local94
+//                                         ^^^^^ definition local96
 //                                                ^^^^ reference _root_/
-//                                                     ^^^^^^^^ definition local95
-//                                                                   ^^^^^^^^ definition local96
-//                                                                                 ^^^^^^^^^ definition local97
+//                                                     ^^^^^^^^ definition local97
+//                                                                   ^^^^^^^^ definition local98
+//                                                                                 ^^^^^^^^^ definition local99
               callbacks.onSwipeCompleted(model, itemView, position, direction);
 //            ^^^^^^^^^ reference local71
 //                      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeCompleted().
-//                                       ^^^^^ reference local94
-//                                              ^^^^^^^^ reference local95
-//                                                        ^^^^^^^^ reference local96
-//                                                                  ^^^^^^^^^ reference local97
+//                                       ^^^^^ reference local96
+//                                              ^^^^^^^^ reference local97
+//                                                        ^^^^^^^^ reference local98
+//                                                                  ^^^^^^^^^ reference local99
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void onSwipeReleased(U model, View itemView) {
-//                      ^^^^^^^^^^^^^^^ definition local98
+//                      ^^^^^^^^^^^^^^^ definition local80
 //                                      ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
-//                                        ^^^^^ definition local99
+//                                        ^^^^^ definition local100
 //                                               ^^^^ reference _root_/
-//                                                    ^^^^^^^^ definition local100
+//                                                    ^^^^^^^^ definition local101
               callbacks.onSwipeReleased(model, itemView);
 //            ^^^^^^^^^ reference local71
 //                      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeReleased().
-//                                      ^^^^^ reference local99
-//                                             ^^^^^^^^ reference local100
+//                                      ^^^^^ reference local100
+//                                             ^^^^^^^^ reference local101
             }
 
             @Override
 //           ^^^^^^^^ reference java/lang/Override#
             public void clearView(U model, View itemView) {
-//                      ^^^^^^^^^ definition local101
+//                      ^^^^^^^^^ definition local81
 //                                ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                  ^^^^^ definition local102
 //                                         ^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -127,15 +127,15 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
     public ViewHolderState[] newArray(int size) {
 //         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                           ^^^^^^^^ definition local6
-//                                        ^^^^ definition local7
+//                                        ^^^^ definition local8
       return new ViewHolderState[size];
 //               ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
-//                               ^^^^ reference local7
+//                               ^^^^ reference local8
     }
 
     public ViewHolderState createFromParcel(Parcel source) {
 //         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
-//                         ^^^^^^^^^^^^^^^^ definition local8
+//                         ^^^^^^^^^^^^^^^^ definition local7
 //                                          ^^^^^^ reference _root_/
 //                                                 ^^^^^^ definition local9
       int size = source.readInt();
@@ -459,51 +459,51 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                         ^^^^^^^^^^^^^^^^ definition local38
 //                                          ^^^^^^ reference _root_/
-//                                                 ^^^^^^ definition local39
+//                                                 ^^^^^^ definition local41
 //                                                         ^^^^^^^^^^^ reference java/lang/ClassLoader#
-//                                                                     ^^^^^^ definition local40
+//                                                                     ^^^^^^ definition local42
             int size = source.readInt();
-//              ^^^^ definition local41
-//                     ^^^^^^ reference local39
+//              ^^^^ definition local43
+//                     ^^^^^^ reference local41
 //                            ^^^^^^^ reference readInt#
             int[] keys = new int[size];
-//                ^^^^ definition local42
-//                               ^^^^ reference local41
+//                ^^^^ definition local44
+//                               ^^^^ reference local43
             source.readIntArray(keys);
-//          ^^^^^^ reference local39
+//          ^^^^^^ reference local41
 //                 ^^^^^^^^^^^^ reference readIntArray#
-//                              ^^^^ reference local42
+//                              ^^^^ reference local44
             Parcelable[] values = source.readParcelableArray(loader);
 //          ^^^^^^^^^^ reference _root_/
-//                       ^^^^^^ definition local43
-//                                ^^^^^^ reference local39
+//                       ^^^^^^ definition local45
+//                                ^^^^^^ reference local41
 //                                       ^^^^^^^^^^^^^^^^^^^ reference readParcelableArray#
-//                                                           ^^^^^^ reference local40
+//                                                           ^^^^^^ reference local42
             return new ViewState(size, keys, values);
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1).
 //                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
-//                               ^^^^ reference local41
-//                                     ^^^^ reference local42
-//                                           ^^^^^^ reference local43
+//                               ^^^^ reference local43
+//                                     ^^^^ reference local44
+//                                           ^^^^^^ reference local45
           }
 
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
           public ViewState createFromParcel(Parcel source) {
 //               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
-//                         ^^^^^^^^^^^^^^^^ definition local44
+//                         ^^^^^^^^^^^^^^^^ definition local39
 //                                          ^^^^^^ reference _root_/
-//                                                 ^^^^^^ definition local45
+//                                                 ^^^^^^ definition local46
             return createFromParcel(source, null);
 //                 ^^^^^^^^^^^^^^^^ reference local38
-//                                  ^^^^^^ reference local45
+//                                  ^^^^^^ reference local46
           }
 
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
           public ViewState[] newArray(int size) {
 //               ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
-//                           ^^^^^^^^ definition local46
+//                           ^^^^^^^^ definition local40
 //                                        ^^^^ definition local47
             return new ViewState[size];
 //                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#

--- a/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
+++ b/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
@@ -1,10 +1,17 @@
 package minimized;
 
+import java.util.List;
+//     ^^^^ reference java/
+//          ^^^^ reference java/util/
+//               ^^^^ reference java/util/List#
+
 public class ParameterizedTypes<A, B> {
 //           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#
 //           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#`<init>`().
 //                              ^ definition minimized/ParameterizedTypes#[A]
 //                                 ^ definition minimized/ParameterizedTypes#[B]
+  //Class<?> clazz;
+
   public String app(A a, B b) {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^ definition minimized/ParameterizedTypes#app().
@@ -17,4 +24,8 @@ public class ParameterizedTypes<A, B> {
 //           ^^^^^^^^ reference java/lang/Object#toString().
 //                        ^ reference local1
   }
+
+  public List<?> doStuff() { return null; }
+//       ^^^^ reference java/util/List#
+//               ^^^^^^^ definition minimized/ParameterizedTypes#doStuff().
 }

--- a/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
+++ b/tests/snapshots/src/main/generated/minimized/ParameterizedTypes.java
@@ -1,17 +1,15 @@
 package minimized;
 
-import java.util.List;
+import java.util.Map;
 //     ^^^^ reference java/
 //          ^^^^ reference java/util/
-//               ^^^^ reference java/util/List#
+//               ^^^ reference java/util/Map#
 
 public class ParameterizedTypes<A, B> {
 //           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#
 //           ^^^^^^^^^^^^^^^^^^ definition minimized/ParameterizedTypes#`<init>`().
 //                              ^ definition minimized/ParameterizedTypes#[A]
 //                                 ^ definition minimized/ParameterizedTypes#[B]
-  //Class<?> clazz;
-
   public String app(A a, B b) {
 //       ^^^^^^ reference java/lang/String#
 //              ^^^ definition minimized/ParameterizedTypes#app().
@@ -25,7 +23,8 @@ public class ParameterizedTypes<A, B> {
 //                        ^ reference local1
   }
 
-  public List<?> doStuff() { return null; }
-//       ^^^^ reference java/util/List#
-//               ^^^^^^^ definition minimized/ParameterizedTypes#doStuff().
+  public Map<? extends String, ?> doStuff() { return null; }
+//       ^^^ reference java/util/Map#
+//                     ^^^^^^ reference java/lang/String#
+//                                ^^^^^^^ definition minimized/ParameterizedTypes#doStuff().
 }


### PR DESCRIPTION
Emit [Type](https://scalameta.org/docs/semanticdb/specification.html#type-2) and [Signature](https://scalameta.org/docs/semanticdb/specification.html#signature-2) messages for symbol occurrences. 
With this information, we can reconstruct accurate hover signatures when converting from SemanticDB to LSIF.

---

**Footnotes**

Wildcard (existential) types proved most difficult to decipher. My work here is a combination of [scalameta Javacp.scala file](https://sourcegraph.com/github.com/scalameta/scalameta/-/blob/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/Javacp.scala#L453), the semanticdb spec ("Hardlinking comes in handy in situations when an advanced type such as ... `ExistentialType`") and this one table entry from the semanticdb spec (in which the params are the opposite way around): 
![image](https://user-images.githubusercontent.com/18282288/112159230-d3f64780-8be0-11eb-9f09-97088ac57f35.png)

As wildcard params dont have a symbol emitting for them, I create a hardlink as opposed to a symlink in the declarations field of the existential type. In a mixed wildcard and non-wildcard scenario, the declarations ordering must be derived from the `ExistentialType.tpe.type_arguments` field, as in the case of `Triplet<?, String, ? extends Integer>`, the ordering of declarations would be `symlink: "String", hardlinks: "local_wildcard", hardlinks: "local_wildcard"+upper_bound: "java/lang/Integer#"`. The relative ordering of symlinks to symlinks and hardlinks to hardlinks is preserved, just not symlinks to hardlinks and vice versa, so there should be no problem there. 

I had to do some guessing as to the behaviour when theres multiple wildcard type params for a given type (as is the case with e.g. `Map<?, ?>`), which isn't covered in the semanticdb spec, but this seems fairly sane.

<details>
<summary>Decoded Protobuf</summary>

Link to Java source for below: https://github.com/sourcegraph/lsif-java/pull/126/files#diff-3f725eecc09c1818a18120a2d471018890dd664200b233dcbee8c14c650824aeR10

```clojure
  symbols {
    symbol: "minimized/ParameterizedTypes#doStuff()."
    signature {
      method_signature {
        type_parameters {
        }
        parameter_lists {
        }
        return_type {
          existential_type {
            tpe {
              type_ref {
                symbol: "java/util/Map#"
                type_arguments {
                  type_ref {
                    symbol: "local_wildcard"
                  }
                }
                type_arguments {
                  type_ref {
                    symbol: "local_wildcard"
                  }
                }
              }
            }
            declarations {
              hardlinks {
                symbol: "local_wildcard"
                signature {
                  type_signature {
                    type_parameters {
                    }
                    upper_bound {
                      type_ref {
                        symbol: "java/lang/String#"
                      }
                    }
                  }
                }
              }
              hardlinks {
                symbol: "local_wildcard"
                signature {
                  type_signature {
                    type_parameters {
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
```

</details>