### PR TITLE
add emitting of type parameters in method signatures

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -126,6 +126,17 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
         range = CompilerRange.FROM_TEXT_SEARCH;
       }
       emitSymbolOccurrence(meth.sym, meth, Role.DEFINITION, range);
+
+      List<JCTree.JCTypeParameter> typeParameters = meth.getTypeParameters();
+      int i = 0;
+      for (Symbol.TypeVariableSymbol typeSym : meth.sym.getTypeParameters()) {
+        emitSymbolOccurrence(
+            typeSym,
+            typeParameters.get(i),
+            Role.DEFINITION,
+            CompilerRange.FROM_POINT_TO_SYMBOL_NAME);
+        i++;
+      }
     }
     return super.visitMethod(node, unused);
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -247,6 +247,7 @@ public abstract class EpoxyTouchHelper {
      * draggable type.
      */
     public <U extends EpoxyModel> DragBuilder4<U> withTarget(Class<U> targetModelClass) {
+//          ^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#withTarget().[U]
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#
 //                                             ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#withTarget().[U]
@@ -737,6 +738,7 @@ public abstract class EpoxyTouchHelper {
      * swipable type.
      */
     public <U extends EpoxyModel> SwipeBuilder3<U> withTarget(Class<U> targetModelClass) {
+//          ^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#withTarget().[U]
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#
 //                                              ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#withTarget().[U]

--- a/tests/snapshots/src/main/generated/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/InnerClasses.java
@@ -85,6 +85,8 @@ public class InnerClasses {
   }
 
   private static <A, B> B runInnerInterface(InnerInterface<A, B> fn, A a) {
+//                ^ definition minimized/InnerClasses#runInnerInterface().[A]
+//                   ^ definition minimized/InnerClasses#runInnerInterface().[B]
 //                      ^ reference minimized/InnerClasses#runInnerInterface().[B]
 //                        ^^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#runInnerInterface().
 //                                          ^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerInterface#

--- a/tests/snapshots/src/main/generated/minimized/TypeVariables.java
+++ b/tests/snapshots/src/main/generated/minimized/TypeVariables.java
@@ -33,6 +33,7 @@ public class TypeVariables {
   }
 
   public static <T extends C & I> void app(T t) {
+//               ^ definition minimized/TypeVariables#app().[T]
 //                         ^ reference minimized/TypeVariables#C#
 //                             ^ reference minimized/TypeVariables#I#
 //                                     ^^^ definition minimized/TypeVariables#app().


### PR DESCRIPTION
Using same method as for [class signatures](https://github.com/sourcegraph/lsif-java/blob/nsc/method-typeparams/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java#L106-L116), this PR adds the emitting of symbol occurrences for  type parameters in method signatures.

Closes #128 