### PR TITLE
fix textDocument/reference -> textDocument/references

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
@@ -83,7 +83,7 @@ public class LsifWriter implements AutoCloseable {
 
   public int emitReferenceResult(int resultSet) {
     int referenceResult = emitObject(lsifVertex("referenceResult"));
-    emitEdge("textDocument/reference", resultSet, referenceResult);
+    emitEdge("textDocument/references", resultSet, referenceResult);
     return referenceResult;
   }
 


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsif/0.5.0/specification/#references

<img src="https://user-images.githubusercontent.com/18282288/114201119-c6b1ba80-994d-11eb-9a7e-057ffe88e83f.png" width=150 height=150/>
