### PR TITLE
fix range building for all constructors

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -30,6 +30,9 @@ public class RangeFinder {
     int endPos = (int) trees.getSourcePositions().getEndPosition(root, path.getLeaf());
     // false for anonymous classes
     if (name.length() != 0) {
+      // for declared constructors with no modifiers, findNameIn will return -1 as the name will
+      // not start with a space, the first char is the start of the name
+      if (source.charAt(startPos) != ' ') startPos -= 1;
       startPos = findNameIn(name, startPos, source);
       endPos = startPos + name.length();
     }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -30,9 +30,6 @@ public class RangeFinder {
     int endPos = (int) trees.getSourcePositions().getEndPosition(root, path.getLeaf());
     // false for anonymous classes
     if (name.length() != 0) {
-      // for declared constructors with no modifiers, findNameIn will return -1 as the name will
-      // not start with a space, the first char is the start of the name
-      if (source.charAt(startPos) != ' ') startPos -= 1;
       startPos = findNameIn(name, startPos, source);
       endPos = startPos + name.length();
     }
@@ -54,9 +51,9 @@ public class RangeFinder {
   private static int findNameIn(CharSequence name, int start, String source) {
     if (source.equals("")) return -1;
 
-    int offset = source.indexOf(" " + name, start);
+    int offset = source.indexOf(name.toString(), start);
     if (offset > -1) {
-      return offset + 1;
+      return offset ;
     }
     return -1;
   }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -156,7 +156,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     if (node instanceof JCTree.JCMethodDecl) {
       JCTree.JCMethodDecl meth = (JCTree.JCMethodDecl) node;
       CompilerRange range = CompilerRange.FROM_POINT_TO_SYMBOL_NAME;
-      if ((meth.sym.flags() & Flags.GENERATEDCONSTR) != 0L) {
+      if (meth.sym.name.toString().equals("<init>")) {
         range = CompilerRange.FROM_TEXT_SEARCH;
       }
       emitSymbolOccurrence(meth.sym, meth, Role.DEFINITION, range);

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -157,7 +157,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
       JCTree.JCMethodDecl meth = (JCTree.JCMethodDecl) node;
       CompilerRange range = CompilerRange.FROM_POINT_TO_SYMBOL_NAME;
       if (meth.sym.name.toString().equals("<init>")) {
-        range = CompilerRange.FROM_TEXT_SEARCH;
+        range = CompilerRange.FROM_POINT_WITH_TEXT_SEARCH;
       }
       emitSymbolOccurrence(meth.sym, meth, Role.DEFINITION, range);
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
@@ -30,7 +30,7 @@ public abstract class AsyncEpoxyController extends EpoxyController {
    * A new instance that does model building and diffing asynchronously.
    */
   public AsyncEpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(). public AsyncEpoxyController()
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(). public AsyncEpoxyController()
     this(true);
 //  ^^^^ reference com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+1).
   }
@@ -40,7 +40,7 @@ public abstract class AsyncEpoxyController extends EpoxyController {
    *                    both on the main thread.
    */
   public AsyncEpoxyController(boolean enableAsync) {
-//       ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+1). public AsyncEpoxyController(boolean enableAsync)
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+1). public AsyncEpoxyController(boolean enableAsync)
 //                                    ^^^^^^^^^^^ definition local0 boolean enableAsync
     this(enableAsync, enableAsync);
 //  ^^^^ reference com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+2).
@@ -52,7 +52,7 @@ public abstract class AsyncEpoxyController extends EpoxyController {
    * Individually control whether model building and diffing are done async or on the main thread.
    */
   public AsyncEpoxyController(boolean enableAsyncModelBuilding, boolean enableAsyncDiffing) {
-//       ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+2). public AsyncEpoxyController(boolean enableAsyncModelBuilding, boolean enableAsyncDiffing)
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#`<init>`(+2). public AsyncEpoxyController(boolean enableAsyncModelBuilding, boolean enableAsyncDiffing)
 //                                    ^^^^^^^^^^^^^^^^^^^^^^^^ definition local1 boolean enableAsyncModelBuilding
 //                                                                      ^^^^^^^^^^^^^^^^^^ definition local2 boolean enableAsyncDiffing
     super(getHandler(enableAsyncModelBuilding), getHandler(enableAsyncDiffing));

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -78,7 +78,7 @@ class AsyncEpoxyDiffer {
 //                                                        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
 
   AsyncEpoxyDiffer(
-//^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`(). AsyncEpoxyDiffer(unresolved_type handler, ResultCallback resultCallback, unresolved_type diffCallback)
+//^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`(). AsyncEpoxyDiffer(unresolved_type handler, ResultCallback resultCallback, unresolved_type diffCallback)
       @NonNull Handler handler,
 //     ^^^^^^^ reference androidx/annotation/NonNull#
 //             ^^^^^^^ reference _root_/
@@ -523,7 +523,7 @@ class AsyncEpoxyDiffer {
 //                                            ^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#diffCallback. private final unresolved_type diffCallback
 
     DiffCallback(List<? extends EpoxyModel<?>> oldList, List<? extends EpoxyModel<?>> newList,
-//  ^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#`<init>`(). DiffCallback(List<? extends EpoxyModel<?>> oldList, List<? extends EpoxyModel<?>> newList, unresolved_type diffCallback)
+//  ^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#`<init>`(). DiffCallback(List<? extends EpoxyModel<?>> oldList, List<? extends EpoxyModel<?>> newList, unresolved_type diffCallback)
 //               ^^^^ reference java/util/List#
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                             ^^^^^^^ definition local28 List<? extends EpoxyModel<?>> oldList

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -135,7 +135,7 @@ public abstract class BaseEpoxyAdapter
   };
 
   public BaseEpoxyAdapter() {
-//       ^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#`<init>`(). public BaseEpoxyAdapter()
+//       ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#`<init>`(). public BaseEpoxyAdapter()
     // Defaults to stable ids since view models generate unique ids. Set this to false in the
     // subclass if you don't want to support it
     setHasStableIds(true);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -150,7 +150,7 @@ public class Carousel extends EpoxyRecyclerView {
 //              ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#numViewsToShowOnScreen. private float numViewsToShowOnScreen
 
   public Carousel(Context context) {
-//       ^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(). public Carousel(unresolved_type context)
+//       ^^^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(). public Carousel(unresolved_type context)
 //                ^^^^^^^ reference _root_/
 //                        ^^^^^^^ definition local4 unresolved_type context
     super(context);
@@ -158,7 +158,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   public Carousel(Context context, @Nullable AttributeSet attrs) {
-//       ^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(+1). public Carousel(unresolved_type context, unresolved_type attrs)
+//       ^^^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(+1). public Carousel(unresolved_type context, unresolved_type attrs)
 //                ^^^^^^^ reference _root_/
 //                        ^^^^^^^ definition local5 unresolved_type context
 //                                  ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -170,7 +170,7 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   public Carousel(Context context, @Nullable AttributeSet attrs, int defStyle) {
-//       ^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(+2). public Carousel(unresolved_type context, unresolved_type attrs, int defStyle)
+//       ^^^^^^^^ definition com/airbnb/epoxy/Carousel#`<init>`(+2). public Carousel(unresolved_type context, unresolved_type attrs, int defStyle)
 //                ^^^^^^^ reference _root_/
 //                        ^^^^^^^ definition local7 unresolved_type context
 //                                  ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -948,7 +948,7 @@ public class Carousel extends EpoxyRecyclerView {
      *     via an item decoration.
      */
     public Padding(@Px int paddingPx, @Px int itemSpacingPx) {
-//         ^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(). public Padding(int paddingPx, int itemSpacingPx)
+//         ^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(). public Padding(int paddingPx, int itemSpacingPx)
 //                  ^^ reference androidx/annotation/Px#
 //                         ^^^^^^^^^ definition local52 int paddingPx
 //                                     ^^ reference androidx/annotation/Px#
@@ -973,7 +973,7 @@ public class Carousel extends EpoxyRecyclerView {
      *     via an item decoration.
      */
     public Padding(
-//         ^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(+1). public Padding(int leftPx, int topPx, int rightPx, int bottomPx, int itemSpacingPx)
+//         ^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(+1). public Padding(int leftPx, int topPx, int rightPx, int bottomPx, int itemSpacingPx)
         @Px int leftPx, @Px int topPx, @Px int rightPx, @Px int bottomPx, @Px int itemSpacingPx) {
 //       ^^ reference androidx/annotation/Px#
 //              ^^^^^^ definition local54 int leftPx
@@ -1006,7 +1006,7 @@ public class Carousel extends EpoxyRecyclerView {
      * @param paddingType Unit / Type of the given paddings/ itemspacing.
      */
     private Padding(
-//          ^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(+2). private Padding(int left, int top, int right, int bottom, int itemSpacing, PaddingType paddingType)
+//          ^^^^^^^ definition com/airbnb/epoxy/Carousel#Padding#`<init>`(+2). private Padding(int left, int top, int right, int bottom, int itemSpacing, PaddingType paddingType)
         int left, int top, int right, int bottom, int itemSpacing, PaddingType paddingType) {
 //          ^^^^ definition local59 int left
 //                    ^^^ definition local60 int top

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
@@ -43,7 +43,7 @@ class ControllerModelList extends ModelList {
   };
 
   ControllerModelList(int expectedModelCount) {
-//^^^^^^ definition com/airbnb/epoxy/ControllerModelList#`<init>`(). ControllerModelList(int expectedModelCount)
+//^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#`<init>`(). ControllerModelList(int expectedModelCount)
 //                        ^^^^^^^^^^^^^^^^^^ definition local8 int expectedModelCount
     super(expectedModelCount);
 //  ^^^^^ reference com/airbnb/epoxy/ModelList#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
@@ -19,7 +19,7 @@ class DebugTimer implements Timer {
 //               ^^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#sectionName. private String sectionName
 
   DebugTimer(String tag) {
-//^^^^^^ definition com/airbnb/epoxy/DebugTimer#`<init>`(). DebugTimer(String tag)
+//^^^^^^^^^^ definition com/airbnb/epoxy/DebugTimer#`<init>`(). DebugTimer(String tag)
 //           ^^^^^^ reference java/lang/String#
 //                  ^^^ definition local0 String tag
     this.tag = tag;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -73,7 +73,7 @@ class DiffHelper {
 
 
   DiffHelper(BaseEpoxyAdapter adapter, boolean immutableModels) {
-//^^^^^^ definition com/airbnb/epoxy/DiffHelper#`<init>`(). DiffHelper(BaseEpoxyAdapter adapter, boolean immutableModels)
+//^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#`<init>`(). DiffHelper(BaseEpoxyAdapter adapter, boolean immutableModels)
 //           ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
 //                            ^^^^^^^ definition local0 BaseEpoxyAdapter adapter
 //                                             ^^^^^^^^^^^^^^^ definition local1 boolean immutableModels

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
@@ -39,7 +39,7 @@ public class DiffPayload {
 //                                             ^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#modelsById. private final LongSparseArray<EpoxyModel<?>> modelsById
 
   DiffPayload(List<? extends EpoxyModel<?>> models) {
-//^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`(). DiffPayload(List<? extends EpoxyModel<?>> models)
+//^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`(). DiffPayload(List<? extends EpoxyModel<?>> models)
 //            ^^^^ reference java/util/List#
 //                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                          ^^^^^^ definition local0 List<? extends EpoxyModel<?>> models
@@ -88,7 +88,7 @@ public class DiffPayload {
   }
 
   public DiffPayload(EpoxyModel<?> changedItem) {
-//       ^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`(+1). public DiffPayload(EpoxyModel<?> changedItem)
+//       ^^^^^^^^^^^ definition com/airbnb/epoxy/DiffPayload#`<init>`(+1). public DiffPayload(EpoxyModel<?> changedItem)
 //                   ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                 ^^^^^^^^^^^ definition local3 EpoxyModel<?> changedItem
     this(Collections.singletonList(changedItem));

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
@@ -154,7 +154,7 @@ public class DiffResult {
   }
 
   private DiffResult(
-//        ^^^^^^ definition com/airbnb/epoxy/DiffResult#`<init>`(). private DiffResult(List<? extends EpoxyModel<?>> previousModels, List<? extends EpoxyModel<?>> newModels, unresolved_type differResult)
+//        ^^^^^^^^^^ definition com/airbnb/epoxy/DiffResult#`<init>`(). private DiffResult(List<? extends EpoxyModel<?>> previousModels, List<? extends EpoxyModel<?>> newModels, unresolved_type differResult)
       @NonNull List<? extends EpoxyModel<?>> previousModels,
 //     ^^^^^^^ reference androidx/annotation/NonNull#
 //             ^^^^ reference java/util/List#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -37,7 +37,7 @@ import androidx.annotation.MainThread;
 public final class EpoxyAsyncUtil {
 //                 ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil# public final class EpoxyAsyncUtil
   private EpoxyAsyncUtil() {
-//        ^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#`<init>`(). private EpoxyAsyncUtil()
+//        ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#`<init>`(). private EpoxyAsyncUtil()
   }
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -224,7 +224,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
   //////////////////////////////////////////////////////////////////////////////////////////
 
   public EpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyController#`<init>`(). public EpoxyController()
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#`<init>`(). public EpoxyController()
     this(defaultModelBuildingHandler, defaultDiffingHandler);
 //  ^^^^ reference com/airbnb/epoxy/EpoxyController#`<init>`(+1).
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#defaultModelBuildingHandler.
@@ -232,7 +232,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
   }
 
   public EpoxyController(Handler modelBuildingHandler, Handler diffingHandler) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyController#`<init>`(+1). public EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#`<init>`(+1). public EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
 //                       ^^^^^^^ reference _root_/
 //                               ^^^^^^^^^^^^^^^^^^^^ definition local0 unresolved_type modelBuildingHandler
 //                                                     ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -80,7 +80,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                                                           ^^^^^^^^^ reference java/util/ArrayList#
 
   EpoxyControllerAdapter(@NonNull EpoxyController epoxyController, Handler diffingHandler) {
-//^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`(). EpoxyControllerAdapter(EpoxyController epoxyController, unresolved_type diffingHandler)
+//^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`(). EpoxyControllerAdapter(EpoxyController epoxyController, unresolved_type diffingHandler)
 //                        ^^^^^^^ reference androidx/annotation/NonNull#
 //                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                                ^^^^^^^^^^^^^^^ definition local0 EpoxyController epoxyController

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDiffLogger.java
@@ -35,7 +35,7 @@ public class EpoxyDiffLogger extends AdapterDataObserver {
 //                     ^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#tag. private final String tag
 
   public EpoxyDiffLogger(String tag) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#`<init>`(). public EpoxyDiffLogger(String tag)
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyDiffLogger#`<init>`(). public EpoxyDiffLogger(String tag)
 //                       ^^^^^^ reference java/lang/String#
 //                              ^^^ definition local0 String tag
     this.tag = tag;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyHolder.java
@@ -22,7 +22,7 @@ public abstract class EpoxyHolder {
 //                    ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyHolder# public abstract class EpoxyHolder
 
   public EpoxyHolder(@NonNull ViewParent parent) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#`<init>`(). public EpoxyHolder(unresolved_type parent)
+//       ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#`<init>`(). public EpoxyHolder(unresolved_type parent)
 //                    ^^^^^^^ reference androidx/annotation/NonNull#
 //                            ^^^^^^^^^^ reference _root_/
 //                                       ^^^^^^ definition local0 unresolved_type parent
@@ -31,7 +31,7 @@ public abstract class EpoxyHolder {
   }
 
   public EpoxyHolder() {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#`<init>`(+1). public EpoxyHolder()
+//       ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyHolder#`<init>`(+1). public EpoxyHolder()
   }
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
@@ -83,13 +83,13 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
 //                ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#isInLastRow. private boolean isInLastRow
 
   public EpoxyItemSpacingDecorator() {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#`<init>`(). public EpoxyItemSpacingDecorator()
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#`<init>`(). public EpoxyItemSpacingDecorator()
     this(0);
 //  ^^^^ reference com/airbnb/epoxy/EpoxyItemSpacingDecorator#`<init>`(+1).
   }
 
   public EpoxyItemSpacingDecorator(@Px int pxBetweenItems) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#`<init>`(+1). public EpoxyItemSpacingDecorator(int pxBetweenItems)
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyItemSpacingDecorator#`<init>`(+1). public EpoxyItemSpacingDecorator(int pxBetweenItems)
 //                                  ^^ reference androidx/annotation/Px#
 //                                         ^^^^^^^^^^^^^^ definition local0 int pxBetweenItems
     setPxBetweenItems(pxBetweenItems);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -128,7 +128,7 @@ public abstract class EpoxyModel<T> {
 //                                           ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#spanSizeOverride. private SpanSizeOverrideCallback spanSizeOverride
 
   protected EpoxyModel(long id) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#`<init>`(). protected EpoxyModel(long id)
+//          ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#`<init>`(). protected EpoxyModel(long id)
 //                          ^^ definition local0 long id
     id(id);
 //  ^^ reference com/airbnb/epoxy/EpoxyModel#id(+1).
@@ -136,7 +136,7 @@ public abstract class EpoxyModel<T> {
   }
 
   public EpoxyModel() {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModel#`<init>`(+1). public EpoxyModel()
+//       ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#`<init>`(+1). public EpoxyModel()
     this(idCounter--);
 //  ^^^^ reference com/airbnb/epoxy/EpoxyModel#`<init>`().
 //       ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#idCounter.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -120,7 +120,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    * @param models    The models that will be used to bind the views in the given layout.
    */
   public EpoxyModelGroup(@LayoutRes int layoutRes, Collection<? extends EpoxyModel<?>> models) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(). public EpoxyModelGroup(int layoutRes, Collection<? extends EpoxyModel<?>> models)
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(). public EpoxyModelGroup(int layoutRes, Collection<? extends EpoxyModel<?>> models)
 //                        ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                      ^^^^^^^^^ definition local0 int layoutRes
 //                                                 ^^^^^^^^^^ reference java/util/Collection#
@@ -139,7 +139,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    * @param models    The models that will be used to bind the views in the given layout.
    */
   public EpoxyModelGroup(@LayoutRes int layoutRes, EpoxyModel<?>... models) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+1). public EpoxyModelGroup(int layoutRes, EpoxyModel<?>[] models)
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+1). public EpoxyModelGroup(int layoutRes, EpoxyModel<?>[] models)
 //                        ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                      ^^^^^^^^^ definition local2 int layoutRes
 //                                                 ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -159,7 +159,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    * @param models    The models that will be used to bind the views in the given layout.
    */
   private EpoxyModelGroup(@LayoutRes int layoutRes, List<EpoxyModel<?>> models) {
-//        ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+2). private EpoxyModelGroup(int layoutRes, List<EpoxyModel<?>> models)
+//        ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+2). private EpoxyModelGroup(int layoutRes, List<EpoxyModel<?>> models)
 //                         ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                       ^^^^^^^^^ definition local4 int layoutRes
 //                                                  ^^^^ reference java/util/List#
@@ -210,7 +210,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    * Constructor use for DSL
    */
   protected EpoxyModelGroup() {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+3). protected EpoxyModelGroup()
+//          ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+3). protected EpoxyModelGroup()
     models = new ArrayList<>();
 //  ^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#models.
 //           ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
@@ -223,7 +223,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
    * Constructor use for DSL
    */
   protected EpoxyModelGroup(@LayoutRes int layoutRes) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+4). protected EpoxyModelGroup(int layoutRes)
+//          ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+4). protected EpoxyModelGroup(int layoutRes)
 //                           ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                         ^^^^^^^^^ definition local8 int layoutRes
     this();

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
@@ -68,7 +68,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //                        ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#holderBeingSwiped. private EpoxyViewHolder holderBeingSwiped
 
   public EpoxyModelTouchCallback(@Nullable EpoxyController controller, Class<T> targetModelClass) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#`<init>`(). public EpoxyModelTouchCallback(EpoxyController controller, Class<T> targetModelClass)
+//       ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelTouchCallback#`<init>`(). public EpoxyModelTouchCallback(EpoxyController controller, Class<T> targetModelClass)
 //                                ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                                         ^^^^^^^^^^ definition local0 EpoxyController controller

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -42,11 +42,11 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
 //                                                                                   ^ reference com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 
   public EpoxyModelWithHolder() {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#`<init>`(). public EpoxyModelWithHolder()
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#`<init>`(). public EpoxyModelWithHolder()
   }
 
   public EpoxyModelWithHolder(long id) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#`<init>`(+1). public EpoxyModelWithHolder(long id)
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithHolder#`<init>`(+1). public EpoxyModelWithHolder(long id)
 //                                 ^^ definition local0 long id
     super(id);
 //  ^^^^^ reference com/airbnb/epoxy/EpoxyModel#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -92,7 +92,7 @@ public abstract class EpoxyTouchHelper {
 //                                ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#controller. private final EpoxyController controller
 
     private DragBuilder(EpoxyController controller) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#`<init>`(). private DragBuilder(EpoxyController controller)
+//          ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#`<init>`(). private DragBuilder(EpoxyController controller)
 //                      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                      ^^^^^^^^^^ definition local1 EpoxyController controller
       this.controller = controller;
@@ -130,7 +130,7 @@ public abstract class EpoxyTouchHelper {
 //                             ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#recyclerView. private final unresolved_type recyclerView
 
     private DragBuilder2(EpoxyController controller, RecyclerView recyclerView) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#`<init>`(). private DragBuilder2(EpoxyController controller, unresolved_type recyclerView)
+//          ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#`<init>`(). private DragBuilder2(EpoxyController controller, unresolved_type recyclerView)
 //                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                       ^^^^^^^^^^ definition local3 EpoxyController controller
 //                                                   ^^^^^^^^^^^^ reference _root_/
@@ -222,7 +222,7 @@ public abstract class EpoxyTouchHelper {
 //                    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#movementFlags. private final int movementFlags
 
     private DragBuilder3(EpoxyController controller, RecyclerView recyclerView, int movementFlags) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#`<init>`(). private DragBuilder3(EpoxyController controller, unresolved_type recyclerView, int movementFlags)
+//          ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#`<init>`(). private DragBuilder3(EpoxyController controller, unresolved_type recyclerView, int movementFlags)
 //                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                       ^^^^^^^^^^ definition local6 EpoxyController controller
 //                                                   ^^^^^^^^^^^^ reference _root_/
@@ -346,7 +346,7 @@ public abstract class EpoxyTouchHelper {
 //                                                  ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClasses. private final List<Class<? extends EpoxyModel>> targetModelClasses
 
     private DragBuilder4(EpoxyController controller,
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`(). private DragBuilder4(EpoxyController controller, unresolved_type recyclerView, int movementFlags, Class<U> targetModelClass, List<Class<? extends EpoxyModel>> targetModelClasses)
+//          ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`(). private DragBuilder4(EpoxyController controller, unresolved_type recyclerView, int movementFlags, Class<U> targetModelClass, List<Class<? extends EpoxyModel>> targetModelClasses)
 //                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                       ^^^^^^^^^^ definition local12 EpoxyController controller
         RecyclerView recyclerView, int movementFlags,
@@ -645,7 +645,7 @@ public abstract class EpoxyTouchHelper {
 //                             ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#recyclerView. private final unresolved_type recyclerView
 
     private SwipeBuilder(RecyclerView recyclerView) {
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#`<init>`(). private SwipeBuilder(unresolved_type recyclerView)
+//          ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#`<init>`(). private SwipeBuilder(unresolved_type recyclerView)
 //                       ^^^^^^^^^^^^ reference _root_/
 //                                    ^^^^^^^^^^^^ definition local60 unresolved_type recyclerView
       this.recyclerView = recyclerView;
@@ -718,7 +718,7 @@ public abstract class EpoxyTouchHelper {
 //                    ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#movementFlags. private final int movementFlags
 
     private SwipeBuilder2(RecyclerView recyclerView,
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#`<init>`(). private SwipeBuilder2(unresolved_type recyclerView, int movementFlags)
+//          ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#`<init>`(). private SwipeBuilder2(unresolved_type recyclerView, int movementFlags)
 //                        ^^^^^^^^^^^^ reference _root_/
 //                                     ^^^^^^^^^^^^ definition local62 unresolved_type recyclerView
         int movementFlags) {
@@ -833,7 +833,7 @@ public abstract class EpoxyTouchHelper {
 //                                                  ^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClasses. private final List<Class<? extends EpoxyModel>> targetModelClasses
 
     private SwipeBuilder3(
-//          ^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`(). private SwipeBuilder3(unresolved_type recyclerView, int movementFlags, Class<U> targetModelClass, List<Class<? extends EpoxyModel>> targetModelClasses)
+//          ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`(). private SwipeBuilder3(unresolved_type recyclerView, int movementFlags, Class<U> targetModelClass, List<Class<? extends EpoxyModel>> targetModelClasses)
         RecyclerView recyclerView, int movementFlags,
 //      ^^^^^^^^^^^^ reference _root_/
 //                   ^^^^^^^^^^^^ definition local67 unresolved_type recyclerView

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -78,7 +78,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
 //                   ^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#parent. private unresolved_type parent
 
   public EpoxyViewHolder(ViewParent parent, View view, boolean saveInitialState) {
-//       ^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#`<init>`(). public EpoxyViewHolder(unresolved_type parent, unresolved_type view, boolean saveInitialState)
+//       ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyViewHolder#`<init>`(). public EpoxyViewHolder(unresolved_type parent, unresolved_type view, boolean saveInitialState)
 //                       ^^^^^^^^^^ reference _root_/
 //                                  ^^^^^^ definition local0 unresolved_type parent
 //                                          ^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/HandlerExecutor.java
@@ -34,7 +34,7 @@ class HandlerExecutor implements Executor {
 //              ^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#handler. final unresolved_type handler
 
   HandlerExecutor(Handler handler) {
-//^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#`<init>`(). HandlerExecutor(unresolved_type handler)
+//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/HandlerExecutor#`<init>`(). HandlerExecutor(unresolved_type handler)
 //                ^^^^^^^ reference _root_/
 //                        ^^^^^^^ definition local0 unresolved_type handler
     this.handler = handler;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/IdUtils.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/IdUtils.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
 public final class IdUtils {
 //                 ^^^^^^^ definition com/airbnb/epoxy/IdUtils# public final class IdUtils
   private IdUtils() {
-//        ^^^^^^ definition com/airbnb/epoxy/IdUtils#`<init>`(). private IdUtils()
+//        ^^^^^^^ definition com/airbnb/epoxy/IdUtils#`<init>`(). private IdUtils()
   }
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/IllegalEpoxyUsage.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/IllegalEpoxyUsage.java
@@ -4,7 +4,7 @@ public class IllegalEpoxyUsage extends RuntimeException {
 //           ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage# public class IllegalEpoxyUsage extends RuntimeException
 //                                     ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
   public IllegalEpoxyUsage(String message) {
-//       ^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). public IllegalEpoxyUsage(String message)
+//       ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). public IllegalEpoxyUsage(String message)
 //                         ^^^^^^ reference java/lang/String#
 //                                ^^^^^^^ definition local0 String message
     super(message);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
@@ -23,7 +23,7 @@ class ImmutableModelException extends RuntimeException {
           + " call `requestModelBuild` instead to recreate all models.";
 
   ImmutableModelException(EpoxyModel model, int modelPosition) {
-//^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(). ImmutableModelException(EpoxyModel model, int modelPosition)
+//^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(). ImmutableModelException(EpoxyModel model, int modelPosition)
 //                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                   ^^^^^ definition local0 EpoxyModel model
 //                                              ^^^^^^^^^^^^^ definition local1 int modelPosition
@@ -34,7 +34,7 @@ class ImmutableModelException extends RuntimeException {
   }
 
   ImmutableModelException(EpoxyModel model,
-//^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(+1). ImmutableModelException(EpoxyModel model, String descriptionOfWhenChangeHappened, int modelPosition)
+//^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ImmutableModelException#`<init>`(+1). ImmutableModelException(EpoxyModel model, String descriptionOfWhenChangeHappened, int modelPosition)
 //                        ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                   ^^^^^ definition local2 EpoxyModel model
       String descriptionOfWhenChangeHappened, int modelPosition) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
@@ -26,7 +26,7 @@ class MainThreadExecutor extends HandlerExecutor {
 //                                                     ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
 
   MainThreadExecutor(boolean async) {
-//^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#`<init>`(). MainThreadExecutor(boolean async)
+//^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#`<init>`(). MainThreadExecutor(boolean async)
 //                           ^^^^^ definition local0 boolean async
     super(async ? AYSNC_MAIN_THREAD_HANDLER : MAIN_THREAD_HANDLER);
 //  ^^^^^ reference com/airbnb/epoxy/HandlerExecutor#`<init>`().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
@@ -49,7 +49,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 
   ModelList(int expectedModelCount) {
-//^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(). ModelList(int expectedModelCount)
+//^^^^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(). ModelList(int expectedModelCount)
 //              ^^^^^^^^^^^^^^^^^^ definition local0 int expectedModelCount
     super(expectedModelCount);
 //  ^^^^^ reference java/util/ArrayList#`<init>`().
@@ -57,7 +57,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
   }
 
   ModelList() {
-//^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(+1). ModelList()
+//^^^^^^^^^ definition com/airbnb/epoxy/ModelList#`<init>`(+1). ModelList()
 
   }
 
@@ -542,7 +542,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                             ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                                                          ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
     ListItr(int index) {
-//  ^^^^^^ definition com/airbnb/epoxy/ModelList#ListItr#`<init>`(). ListItr(int index)
+//  ^^^^^^^ definition com/airbnb/epoxy/ModelList#ListItr#`<init>`(). ListItr(int index)
 //              ^^^^^ definition local33 int index
       cursor = index;
 //    ^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#cursor.
@@ -729,7 +729,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                ^^^ definition com/airbnb/epoxy/ModelList#SubList#SubListIterator#end. private int end
 
       SubListIterator(ListIterator<EpoxyModel<?>> it, SubList list, int offset, int length) {
-//    ^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#SubListIterator#`<init>`(). SubListIterator(ListIterator<EpoxyModel<?>> it, SubList list, int offset, int length)
+//    ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#SubListIterator#`<init>`(). SubListIterator(ListIterator<EpoxyModel<?>> it, SubList list, int offset, int length)
 //                    ^^^^^^^^^^^^ reference java/util/ListIterator#
 //                                 ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                ^^ definition local42 ListIterator<EpoxyModel<?>> it
@@ -863,7 +863,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
     }
 
     SubList(ModelList list, int start, int end) {
-//  ^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#`<init>`(). SubList(ModelList list, int start, int end)
+//  ^^^^^^^ definition com/airbnb/epoxy/ModelList#SubList#`<init>`(). SubList(ModelList list, int start, int end)
 //          ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#
 //                    ^^^^ definition local49 ModelList list
 //                              ^^^^^ definition local50 int start

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/QuantityStringResAttribute.java
@@ -32,7 +32,7 @@ public class QuantityStringResAttribute {
 //                                 ^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#formatArgs. private final Object[] formatArgs
 
   public QuantityStringResAttribute(@PluralsRes int id, int quantity,
-//       ^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#`<init>`(). public QuantityStringResAttribute(int id, int quantity, Object[] formatArgs)
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#`<init>`(). public QuantityStringResAttribute(int id, int quantity, Object[] formatArgs)
 //                                   ^^^^^^^^^^ reference androidx/annotation/PluralsRes#
 //                                                  ^^ definition local0 int id
 //                                                          ^^^^^^^^ definition local1 int quantity
@@ -55,7 +55,7 @@ public class QuantityStringResAttribute {
   }
 
   public QuantityStringResAttribute(int id, int quantity) {
-//       ^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#`<init>`(+1). public QuantityStringResAttribute(int id, int quantity)
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/QuantityStringResAttribute#`<init>`(+1). public QuantityStringResAttribute(int id, int quantity)
 //                                      ^^ definition local3 int id
 //                                              ^^^^^^^^ definition local4 int quantity
     this(id, quantity, null);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyModel.java
@@ -39,7 +39,7 @@ public class SimpleEpoxyModel extends EpoxyModel<View> {
 //            ^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#spanCount. private int spanCount
 
   public SimpleEpoxyModel(@LayoutRes int layoutRes) {
-//       ^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#`<init>`(). public SimpleEpoxyModel(int layoutRes)
+//       ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/SimpleEpoxyModel#`<init>`(). public SimpleEpoxyModel(int layoutRes)
 //                         ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                       ^^^^^^^^^ definition local0 int layoutRes
     this.layoutRes = layoutRes;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
@@ -53,7 +53,7 @@ public class StringAttributeData {
 //                           ^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#formatArgs. private Object[] formatArgs
 
   public StringAttributeData() {
-//       ^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(). public StringAttributeData()
+//       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(). public StringAttributeData()
     hasDefault = false;
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/StringAttributeData#hasDefault.
     defaultString = null;
@@ -63,7 +63,7 @@ public class StringAttributeData {
   }
 
   public StringAttributeData(@Nullable CharSequence defaultString) {
-//       ^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(+1). public StringAttributeData(CharSequence defaultString)
+//       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(+1). public StringAttributeData(CharSequence defaultString)
 //                            ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                     ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                                  ^^^^^^^^^^^^^ definition local0 CharSequence defaultString
@@ -81,7 +81,7 @@ public class StringAttributeData {
   }
 
   public StringAttributeData(@StringRes int defaultStringRes) {
-//       ^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(+2). public StringAttributeData(int defaultStringRes)
+//       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/StringAttributeData#`<init>`(+2). public StringAttributeData(int defaultStringRes)
 //                            ^^^^^^^^^ reference androidx/annotation/StringRes#
 //                                          ^^^^^^^^^^^^^^^^ definition local1 int defaultStringRes
     hasDefault = true;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
@@ -35,11 +35,11 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#allowModelBuildRequests. private boolean allowModelBuildRequests
 
   public Typed2EpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#`<init>`(). public Typed2EpoxyController()
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#`<init>`(). public Typed2EpoxyController()
   }
 
   public Typed2EpoxyController(Handler modelBuildingHandler, Handler diffingHandler) {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#`<init>`(+1). public Typed2EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed2EpoxyController#`<init>`(+1). public Typed2EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
 //                             ^^^^^^^ reference _root_/
 //                                     ^^^^^^^^^^^^^^^^^^^^ definition local0 unresolved_type modelBuildingHandler
 //                                                           ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
@@ -39,11 +39,11 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#allowModelBuildRequests. private boolean allowModelBuildRequests
 
   public Typed3EpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#`<init>`(). public Typed3EpoxyController()
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#`<init>`(). public Typed3EpoxyController()
   }
 
   public Typed3EpoxyController(Handler modelBuildingHandler, Handler diffingHandler) {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#`<init>`(+1). public Typed3EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed3EpoxyController#`<init>`(+1). public Typed3EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
 //                             ^^^^^^^ reference _root_/
 //                                     ^^^^^^^^^^^^^^^^^^^^ definition local0 unresolved_type modelBuildingHandler
 //                                                           ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
@@ -43,11 +43,11 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#allowModelBuildRequests. private boolean allowModelBuildRequests
 
   public Typed4EpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#`<init>`(). public Typed4EpoxyController()
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#`<init>`(). public Typed4EpoxyController()
   }
 
   public Typed4EpoxyController(Handler modelBuildingHandler, Handler diffingHandler) {
-//       ^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#`<init>`(+1). public Typed4EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
+//       ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Typed4EpoxyController#`<init>`(+1). public Typed4EpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
 //                             ^^^^^^^ reference _root_/
 //                                     ^^^^^^^^^^^^^^^^^^^^ definition local0 unresolved_type modelBuildingHandler
 //                                                           ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
@@ -34,11 +34,11 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#allowModelBuildRequests. private boolean allowModelBuildRequests
 
   public TypedEpoxyController() {
-//       ^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#`<init>`(). public TypedEpoxyController()
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#`<init>`(). public TypedEpoxyController()
   }
 
   public TypedEpoxyController(Handler modelBuildingHandler, Handler diffingHandler) {
-//       ^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#`<init>`(+1). public TypedEpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
+//       ^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/TypedEpoxyController#`<init>`(+1). public TypedEpoxyController(unresolved_type modelBuildingHandler, unresolved_type diffingHandler)
 //                            ^^^^^^^ reference _root_/
 //                                    ^^^^^^^^^^^^^^^^^^^^ definition local0 unresolved_type modelBuildingHandler
 //                                                          ^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -66,7 +66,7 @@ class UpdateOp {
 //                         ^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#payloads. ArrayList<EpoxyModel<?>> payloads
 
   private UpdateOp() {
-//        ^^^^^^ definition com/airbnb/epoxy/UpdateOp#`<init>`(). private UpdateOp()
+//        ^^^^^^^^ definition com/airbnb/epoxy/UpdateOp#`<init>`(). private UpdateOp()
   }
 
   static UpdateOp instance(@Type int type, int positionStart, int itemCount,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -64,11 +64,11 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                                            ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                                                  ^^^^^^^^^^ reference _root_/
   ViewHolderState() {
-//^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`(). ViewHolderState()
+//^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`(). ViewHolderState()
   }
 
   private ViewHolderState(int size) {
-//        ^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`(+1). private ViewHolderState(int size)
+//        ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#`<init>`(+1). private ViewHolderState(int size)
 //                            ^^^^ definition local0 int size
     super(size);
 //  ^^^^^ reference androidx/collection/LongSparseArray#`<init>`(+1).
@@ -292,11 +292,11 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                                                                         ^^^^^^^^^^ reference _root_/
 
     ViewState() {
-//  ^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(). ViewState()
+//  ^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(). ViewState()
     }
 
     private ViewState(int size, int[] keys, Parcelable[] values) {
-//          ^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1). private ViewState(int size, int[] keys, unresolved_type[] values)
+//          ^^^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1). private ViewState(int size, int[] keys, unresolved_type[] values)
 //                        ^^^^ definition local22 int size
 //                                    ^^^^ definition local23 int[] keys
 //                                          ^^^^^^^^^^ reference _root_/

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
@@ -35,7 +35,7 @@ public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
 //                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#originalCheckedChangeListener. private final OnModelCheckedChangeListener<T, V> originalCheckedChangeListener
 
   public WrappedEpoxyModelCheckedChangeListener(
-//       ^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#`<init>`(). public WrappedEpoxyModelCheckedChangeListener(OnModelCheckedChangeListener<T, V> checkedListener)
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#`<init>`(). public WrappedEpoxyModelCheckedChangeListener(OnModelCheckedChangeListener<T, V> checkedListener)
       OnModelCheckedChangeListener<T, V> checkedListener
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/OnModelCheckedChangeListener#
 //                                 ^ reference com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener#[T]

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -22,7 +22,7 @@ enum Enums {
 //              ^^^^^ definition minimized/Enums#value. public String value
 
   Enums(String value, int a) {
-//^^^^^^ definition minimized/Enums#`<init>`(). private Enums(String value, int a)
+//^^^^^ definition minimized/Enums#`<init>`(). private Enums(String value, int a)
 //      ^^^^^^ reference java/lang/String#
 //             ^^^^^ definition local0 String value
 //                        ^ definition local1 int a

--- a/tests/snapshots/src/main/generated/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/InnerClasses.java
@@ -7,7 +7,7 @@ public class InnerClasses {
 //                  ^^^^^^^^^^^^ definition minimized/InnerClasses#exampleField. private final int exampleField
 
   public InnerClasses(int exampleField) {
-//       ^^^^^^ definition minimized/InnerClasses#`<init>`(). public InnerClasses(int exampleField)
+//       ^^^^^^^^^^^^ definition minimized/InnerClasses#`<init>`(). public InnerClasses(int exampleField)
 //                        ^^^^^^^^^^^^ definition local0 int exampleField
     this.exampleField = exampleField;
 //  ^^^^ reference minimized/InnerClasses#
@@ -53,7 +53,7 @@ public class InnerClasses {
 //                    ^^^^^ definition minimized/InnerClasses#InnerClass#field. private final int field
 
     public InnerClass(int field) {
-//         ^^^^^^ definition minimized/InnerClasses#InnerClass#`<init>`(). public InnerClass(int field)
+//         ^^^^^^^^^^ definition minimized/InnerClasses#InnerClass#`<init>`(). public InnerClass(int field)
 //                        ^^^^^ definition local2 int field
       this.field = field;
 //    ^^^^ reference minimized/InnerClasses#InnerClass#


### PR DESCRIPTION
Previously, only generated constructors were delegated to using text search to find the range encompassing the constructor name (aka the class name, which shares the same range as the generated default constructor).
For this reason, non-generated constructors were not hitting the code-path that checks if the `name == "<init>"`, aka it was a constructor, which followed with logic to build a range based on the owning class's name, causing the range to be built based on the synthetic `<init>` name.

This PR fixes this bug by delegating _all_ constructors to the aforementioned text search codepath. It does it slightly differently by using text search from point, as constructors' preferred/point position starts from the name, avoiding the problem outlined [here](https://github.com/sourcegraph/lsif-java/pull/151#discussion_r613316106).

This allows for a minor simplification in the `RangeFinder` class, as we no longer have to prepend the search name with a space. This was only required for constructors which may have the constructor name at the start of the line (after whitespace).