### PR TITLE
fix ctor range via textsearch & dont emit ref to class in ctro call

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -53,7 +53,7 @@ public class RangeFinder {
 
     int offset = source.indexOf(name.toString(), start);
     if (offset > -1) {
-      return offset ;
+      return offset;
     }
     return -1;
   }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -221,9 +221,14 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   public Void visitNewClass(NewClassTree node, Void unused) {
     if (node instanceof JCTree.JCNewClass) {
       JCTree.JCNewClass cls = (JCTree.JCNewClass) node;
-      emitSymbolOccurrence(cls.constructor, cls, Role.REFERENCE, CompilerRange.FROM_START_TO_END);
+      emitSymbolOccurrence(cls.constructor, cls, Role.REFERENCE, CompilerRange.FROM_TEXT_SEARCH);
     }
-    return super.visitNewClass(node, unused);
+
+    // to avoid emitting a reference to the class itself, we manually scan everything
+    // except the identifier
+    scan(node.getTypeArguments(), unused);
+    scan(node.getArguments(), unused);
+    return scan(node.getClassBody(), unused);
   }
 
   // =================================================

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -74,8 +74,7 @@ class AsyncEpoxyDiffer {
   private final GenerationTracker generationTracker = new GenerationTracker();
 //              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
 //                                ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#generationTracker. private final GenerationTracker generationTracker
-//                                                    ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#`<init>`().
-//                                                        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#
+//                                                        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#GenerationTracker#`<init>`().
 
   AsyncEpoxyDiffer(
 //^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`(). AsyncEpoxyDiffer(unresolved_type handler, ResultCallback resultCallback, unresolved_type diffCallback)
@@ -96,8 +95,7 @@ class AsyncEpoxyDiffer {
     this.executor = new HandlerExecutor(handler);
 //  ^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#
 //       ^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#executor.
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#`<init>`().
-//                      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#
+//                      ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#`<init>`().
 //                                      ^^^^^^^ reference local1
     this.resultCallback = resultCallback;
 //  ^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#
@@ -310,8 +308,7 @@ class AsyncEpoxyDiffer {
     final DiffCallback wrappedCallback = new DiffCallback(previousList, newList, diffCallback);
 //        ^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#
 //                     ^^^^^^^^^^^^^^^ definition local11 final DiffCallback wrappedCallback
-//                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#`<init>`().
-//                                           ^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#
+//                                           ^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#DiffCallback#`<init>`().
 //                                                        ^^^^^^^^^^^^ reference local9
 //                                                                      ^^^^^^^ reference local7
 //                                                                               ^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#diffCallback.
@@ -320,7 +317,6 @@ class AsyncEpoxyDiffer {
 //  ^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#executor.
 //           ^^^^^^^ reference java/util/concurrent/Executor#execute().
 //                   ^^^^^^^^^^^^^^^^ reference local13 6:5
-//                       ^^^^^^^^ reference java/lang/Runnable#
 //                       ^^^^^^^^ reference java/lang/Runnable#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
@@ -368,7 +364,6 @@ class AsyncEpoxyDiffer {
 //                     ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#ASYNC_INSTANCE.
 //                                    ^^^^^^^ reference com/airbnb/epoxy/HandlerExecutor#execute().
 //                                            ^^^^^^^^^^^^^^^^ reference local20 8:5
-//                                                ^^^^^^^^ reference java/lang/Runnable#
 //                                                ^^^^^^^^ reference java/lang/Runnable#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -78,8 +78,7 @@ public abstract class BaseEpoxyAdapter
   private final ViewTypeManager viewTypeManager = new ViewTypeManager();
 //              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#
 //                              ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#viewTypeManager. private final ViewTypeManager viewTypeManager
-//                                                ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#`<init>`().
-//                                                    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#
+//                                                    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewTypeManager#`<init>`().
   /**
    * Keeps track of view holders that are currently bound so we can save their state in {@link
    * #onSaveInstanceState(Bundle)}.
@@ -87,19 +86,15 @@ public abstract class BaseEpoxyAdapter
   private final BoundViewHolders boundViewHolders = new BoundViewHolders();
 //              ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#
 //                               ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders. private final BoundViewHolders boundViewHolders
-//                                                  ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#`<init>`().
-//                                                      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#
+//                                                      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#`<init>`().
   private ViewHolderState viewHolderState = new ViewHolderState();
 //        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                        ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState. private ViewHolderState viewHolderState
-//                                          ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#`<init>`().
-//                                              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                                              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#`<init>`().
 
   private final SpanSizeLookup spanSizeLookup = new SpanSizeLookup() {
 //              ^^^^^^^^^^^^^^ reference _root_/
 //                             ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#spanSizeLookup. private final unresolved_type spanSizeLookup
-//                                              ^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 19:3
-//                                                  ^^^^^^^^^^^^^^ reference _root_/
 //                                                  ^^^^^^^^^^^^^^ reference _root_/
 
     @Override
@@ -227,8 +222,7 @@ public abstract class BaseEpoxyAdapter
 //                    ^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#buildView().
 //                              ^^^^^^ reference local7
     return new EpoxyViewHolder(parent, view, model.shouldSaveViewState());
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#`<init>`().
-//             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
+//             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#`<init>`().
 //                             ^^^^^^ reference local7
 //                                     ^^^^ reference local10
 //                                           ^^^^^ reference local9
@@ -540,8 +534,7 @@ public abstract class BaseEpoxyAdapter
 //                      ^^^^ reference androidx/collection/LongSparseArray#size().
 //                                     ^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#hasStableIds#
       throw new IllegalStateException("Must have stable ids when saving view holder state");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     outState.putParcelable(SAVED_STATE_ARG_VIEW_HOLDERS, viewHolderState);
@@ -562,8 +555,7 @@ public abstract class BaseEpoxyAdapter
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders.
 //                       ^^^^ reference com/airbnb/epoxy/BoundViewHolders#size().
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:52
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "State cannot be restored once views have been bound. It should be done before adding "
               + "the adapter to the recycler view.");
     }
@@ -578,8 +570,7 @@ public abstract class BaseEpoxyAdapter
       if (viewHolderState == null) {
 //        ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#viewHolderState.
         throw new IllegalStateException(
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:89
-//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
             "Tried to restore instance state, but onSaveInstanceState was never called.");
       }
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BoundViewHolders.java
@@ -31,8 +31,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
 //              ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
 //                              ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                                               ^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#holders. private final LongSparseArray<EpoxyViewHolder> holders
-//                                                         ^^^^^^^^^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#`<init>`().
-//                                                             ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
+//                                                             ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#`<init>`().
 
   @Nullable
 // ^^^^^^^^ reference androidx/annotation/Nullable#
@@ -85,8 +84,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
 //                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#
 //                                 ^^^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#iterator(). @Override public Iterator<EpoxyViewHolder> iterator()
     return new HolderIterator();
-//         ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#HolderIterator#`<init>`().
-//             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#HolderIterator#
+//             ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#HolderIterator#`<init>`().
   }
 
   @Nullable
@@ -129,8 +127,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
       if (!hasNext()) {
 //         ^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#HolderIterator#hasNext().
         throw new NoSuchElementException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#
+//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
       }
       return holders.valueAt(position++);
 //           ^^^^^^^ reference com/airbnb/epoxy/BoundViewHolders#holders.
@@ -143,8 +140,7 @@ public class BoundViewHolders implements Iterable<EpoxyViewHolder> {
     public void remove() {
 //              ^^^^^^ definition com/airbnb/epoxy/BoundViewHolders#HolderIterator#remove(). @Override public void remove()
       throw new UnsupportedOperationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`().
     }
   }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -121,7 +121,6 @@ public class Carousel extends EpoxyRecyclerView {
       new SnapHelperFactory() {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^ reference local1 7:7
 //        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#SnapHelperFactory#
-//        ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#SnapHelperFactory#
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -133,8 +132,7 @@ public class Carousel extends EpoxyRecyclerView {
 //                                        ^^^^^^^ reference _root_/
 //                                                ^^^^^^^ definition local3 unresolved_type context
           return new LinearSnapHelper();
-//               ^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//                   ^^^^^^^^^^^^^^^^ reference _root_/
+//                   ^^^^^^^^^^^^^^^^ reference `<init>`#
         }
       };
 
@@ -339,8 +337,7 @@ public class Carousel extends EpoxyRecyclerView {
     if (numItemsToPrefetch < 0) {
 //      ^^^^^^^^^^^^^^^^^^ reference local15
       throw new IllegalStateException("numItemsToPrefetch must be greater than 0");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     // Use the linearlayoutmanager default of 2 if the user did not specify one
@@ -806,14 +803,16 @@ public class Carousel extends EpoxyRecyclerView {
 //                                                            ^^^^^^^^ reference androidx/annotation/DimenRes#
 //                                                                         ^^^^^^^^^^^^^^ definition local39 @DimenRes int itemSpacingRes
       return new Padding(
-//           ^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2). 1:95
-//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#
+//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
           paddingRes, paddingRes, paddingRes, paddingRes, itemSpacingRes, PaddingType.RESOURCE);
 //        ^^^^^^^^^^ reference local38
 //                    ^^^^^^^^^^ reference local38
 //                                ^^^^^^^^^^ reference local38
 //                                            ^^^^^^^^^^ reference local38
 //                                                        ^^^^^^^^^^^^^^ reference local39
+//                                                                        ^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#PaddingType#`<init>`().
+//                                                                        ^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#PaddingType#`<init>`().
+//                                                                        ^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#PaddingType#`<init>`().
 //                                                                        ^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#PaddingType#
 //                                                                                    ^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#PaddingType#RESOURCE.
     }
@@ -845,8 +844,7 @@ public class Carousel extends EpoxyRecyclerView {
 //       ^^^^^^^^ reference androidx/annotation/DimenRes#
 //                    ^^^^^^^^^^^^^^ definition local44 @DimenRes int itemSpacingRes
       return new Padding(
-//           ^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2). 1:85
-//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#
+//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
           leftRes, topRes, rightRes, bottomRes, itemSpacingRes, PaddingType.RESOURCE);
 //        ^^^^^^^ reference local40
 //                 ^^^^^^ reference local41
@@ -878,8 +876,7 @@ public class Carousel extends EpoxyRecyclerView {
 //                                  ^^ reference androidx/annotation/Dimension#DP.
 //                                          ^^^^^^^^^^^^^ definition local46 @Dimension(unit = Dimension.DP) int itemSpacingDp
       return new Padding(paddingDp, paddingDp, paddingDp, paddingDp, itemSpacingDp, PaddingType.DP);
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
-//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#
+//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
 //                       ^^^^^^^^^ reference local45
 //                                  ^^^^^^^^^ reference local45
 //                                             ^^^^^^^^^ reference local45
@@ -931,8 +928,7 @@ public class Carousel extends EpoxyRecyclerView {
 //                                  ^^ reference androidx/annotation/Dimension#DP.
 //                                          ^^^^^^^^^^^^^ definition local51 @Dimension(unit = Dimension.DP) int itemSpacingDp
       return new Padding(leftDp, topDp, rightDp, bottomDp, itemSpacingDp, PaddingType.DP);
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
-//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#
+//               ^^^^^^^ reference com/airbnb/epoxy/Carousel#Padding#`<init>`(+2).
 //                       ^^^^^^ reference local47
 //                               ^^^^^ reference local48
 //                                      ^^^^^^^ reference local49

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelperLookup.java
@@ -40,13 +40,11 @@ class ControllerHelperLookup {
 //                         ^^^^^ reference java/lang/Class#
 //                                   ^^^^^^^^^^^ reference java/lang/reflect/Constructor#
 //                                                   ^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#BINDINGS. private static final Map<Class<?>, Constructor<?>> BINDINGS
-//                                                              ^^^^^^^^^^^^^^^^^^^^^ reference java/util/LinkedHashMap#`<init>`(+2).
-//                                                                  ^^^^^^^^^^^^^ reference java/util/LinkedHashMap#
+//                                                                  ^^^^^^^^^^^^^ reference java/util/LinkedHashMap#`<init>`(+2).
   private static final NoOpControllerHelper NO_OP_CONTROLLER_HELPER = new NoOpControllerHelper();
 //                     ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NoOpControllerHelper#
 //                                          ^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ControllerHelperLookup#NO_OP_CONTROLLER_HELPER. private static final NoOpControllerHelper NO_OP_CONTROLLER_HELPER
-//                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
-//                                                                        ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NoOpControllerHelper#
+//                                                                        ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NoOpControllerHelper#`<init>`().
 
   static ControllerHelper getHelperForController(EpoxyController controller) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerHelper#
@@ -75,16 +73,14 @@ class ControllerHelperLookup {
 //           ^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalAccessException#
 //                                  ^ definition local2 IllegalAccessException e
       throw new RuntimeException("Unable to invoke " + constructor, e);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
-//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
+//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
 //                                                     ^^^^^^^^^^^ reference local1
 //                                                                  ^ reference local2
     } catch (InstantiationException e) {
 //           ^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/InstantiationException#
 //                                  ^ definition local3 InstantiationException e
       throw new RuntimeException("Unable to invoke " + constructor, e);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
-//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
+//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
 //                                                     ^^^^^^^^^^^ reference local1
 //                                                                  ^ reference local3
     } catch (InvocationTargetException e) {
@@ -110,8 +106,7 @@ class ControllerHelperLookup {
 //                    ^^^^^ reference local5
       }
       throw new RuntimeException("Unable to get Epoxy helper class.", cause);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
-//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
+//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
 //                                                                    ^^^^^ reference local5
     }
   }
@@ -177,8 +172,7 @@ class ControllerHelperLookup {
 //           ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/NoSuchMethodException#
 //                                 ^ definition local11 NoSuchMethodException e
       throw new RuntimeException("Unable to find Epoxy Helper constructor for " + clsName, e);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
-//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
+//              ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+2).
 //                                                                                ^^^^^^^ reference local8
 //                                                                                         ^ reference local11
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerModelList.java
@@ -16,7 +16,6 @@ class ControllerModelList extends ModelList {
 //                                       ^^^^^^^^ definition com/airbnb/epoxy/ControllerModelList#OBSERVER. private static final ModelListObserver OBSERVER
 //                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ reference local1 12:3
 //                                                      ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ModelListObserver#
-//                                                      ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ModelListObserver#
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onItemRangeInserted(int positionStart, int itemCount) {
@@ -24,8 +23,7 @@ class ControllerModelList extends ModelList {
 //                                      ^^^^^^^^^^^^^ definition local4 int positionStart
 //                                                         ^^^^^^^^^ definition local5 int itemCount
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:75
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "Models cannot be changed once they are added to the controller");
     }
 
@@ -36,8 +34,7 @@ class ControllerModelList extends ModelList {
 //                                     ^^^^^^^^^^^^^ definition local6 int positionStart
 //                                                        ^^^^^^^^^ definition local7 int itemCount
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:75
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "Models cannot be changed once they are added to the controller");
     }
   };

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DebugTimer.java
@@ -47,8 +47,7 @@ class DebugTimer implements Timer {
     if (startTime != -1) {
 //      ^^^^^^^^^ reference com/airbnb/epoxy/DebugTimer#startTime.
       throw new IllegalStateException("Timer was already started");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     startTime = System.nanoTime();
@@ -68,8 +67,7 @@ class DebugTimer implements Timer {
     if (startTime == -1) {
 //      ^^^^^^^^^ reference com/airbnb/epoxy/DebugTimer#startTime.
       throw new IllegalStateException("Timer was not started");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     float durationMs = (System.nanoTime() - startTime) / 1000000f;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffHelper.java
@@ -41,8 +41,7 @@ class DiffHelper {
 //        ^^^^^^^^^ reference java/util/ArrayList#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                              ^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#oldStateList. private ArrayList<ModelState> oldStateList
-//                                             ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                                 ^^^^^^^^^ reference java/util/ArrayList#
+//                                                 ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
   // Using a HashMap instead of a LongSparseArray to
   // have faster look up times at the expense of memory
   private Map<Long, ModelState> oldStateMap = new HashMap<>();
@@ -50,21 +49,18 @@ class DiffHelper {
 //            ^^^^ reference java/lang/Long#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                              ^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#oldStateMap. private Map<Long, ModelState> oldStateMap
-//                                            ^^^^^^^^^^^^^^^ reference java/util/HashMap#`<init>`(+2).
-//                                                ^^^^^^^ reference java/util/HashMap#
+//                                                ^^^^^^^ reference java/util/HashMap#`<init>`(+2).
   private ArrayList<ModelState> currentStateList = new ArrayList<>();
 //        ^^^^^^^^^ reference java/util/ArrayList#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                              ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#currentStateList. private ArrayList<ModelState> currentStateList
-//                                                 ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                                     ^^^^^^^^^ reference java/util/ArrayList#
+//                                                     ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
   private Map<Long, ModelState> currentStateMap = new HashMap<>();
 //        ^^^ reference java/util/Map#
 //            ^^^^ reference java/lang/Long#
 //                  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                              ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#currentStateMap. private Map<Long, ModelState> currentStateMap
-//                                                ^^^^^^^^^^^^^^^ reference java/util/HashMap#`<init>`(+2).
-//                                                    ^^^^^^^ reference java/util/HashMap#
+//                                                    ^^^^^^^ reference java/util/HashMap#`<init>`(+2).
   private final BaseEpoxyAdapter adapter;
 //              ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#
 //                               ^^^^^^^ definition com/airbnb/epoxy/DiffHelper#adapter. private final BaseEpoxyAdapter adapter
@@ -95,18 +91,14 @@ class DiffHelper {
 //              ^^^^^^^^^^^^ reference RecyclerView/
 //                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
 //                                               ^^^^^^^^ definition com/airbnb/epoxy/DiffHelper#observer. private final unresolved_type observer
-//                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 91:3
 //                                                              ^^^^^^^^^^^^ reference RecyclerView/
-//                                                              ^^^^^^^^^^^^ reference RecyclerView/
-//                                                                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
 //                                                                           ^^^^^^^^^^^^^^^^^^^ reference RecyclerView/AdapterDataObserver#
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void onChanged() {
 //              ^^^^^^^^^ definition local3 @Override public void onChanged()
       throw new UnsupportedOperationException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1). 1:99
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1).
           "Diffing is enabled. You should use notifyModelsChanged instead of notifyDataSetChanged");
     }
 
@@ -173,8 +165,7 @@ class DiffHelper {
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //                       ^^^^^^^^^ definition local14 List<ModelState> newModels
-//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
-//                                       ^^^^^^^^^ reference java/util/ArrayList#
+//                                       ^^^^^^^^^ reference java/util/ArrayList#`<init>`().
 //                                                   ^^^^^^^^^ reference local12
         for (int i = positionStart; i < positionStart + itemCount; i++) {
 //               ^ definition local15 int i
@@ -291,8 +282,7 @@ class DiffHelper {
       if (itemCount != 1) {
 //        ^^^^^^^^^ reference local26
         throw new IllegalArgumentException("Moving more than 1 item at a time is not "
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1). 1:63
-//                ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
             + "supported. Number of items moved: " + itemCount);
 //                                                   ^^^^^^^^^ reference local26
       }
@@ -356,8 +346,7 @@ class DiffHelper {
     UpdateOpHelper updateOpHelper = new UpdateOpHelper();
 //  ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
 //                 ^^^^^^^^^^^^^^ definition local30 UpdateOpHelper updateOpHelper
-//                                  ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#`<init>`().
-//                                      ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#
+//                                      ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOpHelper#`<init>`().
 
     buildDiff(updateOpHelper);
 //  ^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#buildDiff().
@@ -438,8 +427,7 @@ class DiffHelper {
 //                                                           ^^ reference local32
 //                                                              ^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#itemCount.
                 new DiffPayload(op.payloads));
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`().
-//                  ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#
+//                  ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`().
 //                              ^^ reference local32
 //                                 ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
           } else {
@@ -454,8 +442,7 @@ class DiffHelper {
           break;
         default:
           throw new IllegalArgumentException("Unknown type: " + op.type);
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
 //                                                              ^^ reference local32
 //                                                                 ^^^^ reference com/airbnb/epoxy/UpdateOp#type.
       }
@@ -641,8 +628,7 @@ class DiffHelper {
 //                                                             ^^^ reference java/util/List#get().
 //                                                                 ^^^^^^^^^^^^^^^^ reference local44
       throw new IllegalStateException("Two models have the same ID. ID's must be unique!"
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:76
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           + " Model at position " + position + ": " + model
 //                                  ^^^^^^^^ reference local40
 //                                                    ^^^^^ reference local41

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffPayload.java
@@ -47,8 +47,7 @@ public class DiffPayload {
 //      ^^^^^^ reference local0
 //             ^^^^^^^ reference java/util/List#isEmpty().
       throw new IllegalStateException("Models must not be empty");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     int modelCount = models.size();
@@ -70,8 +69,7 @@ public class DiffPayload {
 //    ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#singleModel.
       modelsById = new LongSparseArray<>(modelCount);
 //    ^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#modelsById.
-//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#`<init>`(+1).
-//                     ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#
+//                     ^^^^^^^^^^^^^^^ reference androidx/collection/LongSparseArray#`<init>`(+1).
 //                                       ^^^^^^^^^^ reference local1
       for (EpoxyModel<?> model : models) {
 //         ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/DiffResult.java
@@ -82,8 +82,7 @@ public class DiffResult {
 //                         ^^^^^^^^^ reference java/util/Collections#emptyList().
     }
     return new DiffResult(models, models, null);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
-//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#
+//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
 //                        ^^^^^^ reference local0
 //                                ^^^^^^ reference local0
   }
@@ -98,8 +97,7 @@ public class DiffResult {
 //                                                                  ^^^^^^^^^ definition local1 @NonNull List<? extends EpoxyModel<?>> newModels
     //noinspection unchecked
     return new DiffResult(Collections.EMPTY_LIST, newModels, null);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
-//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#
+//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
 //                        ^^^^^^^^^^^ reference java/util/Collections#
 //                                    ^^^^^^^^^^ reference java/util/Collections#EMPTY_LIST.
 //                                                ^^^^^^^^^ reference local1
@@ -115,8 +113,7 @@ public class DiffResult {
 //                                                               ^^^^^^^^^^^^^^ definition local2 @NonNull List<? extends EpoxyModel<?>> previousModels
     //noinspection unchecked
     return new DiffResult(previousModels, Collections.EMPTY_LIST, null);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
-//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#
+//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
 //                        ^^^^^^^^^^^^^^ reference local2
 //                                        ^^^^^^^^^^^ reference java/util/Collections#
 //                                                    ^^^^^^^^^^ reference java/util/Collections#EMPTY_LIST.
@@ -146,8 +143,7 @@ public class DiffResult {
 //                                 ^^^^^^^^^^^^ definition local5 @NonNull unresolved_type differResult
   ) {
     return new DiffResult(previousModels, newModels, differResult);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
-//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#
+//             ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#`<init>`().
 //                        ^^^^^^^^^^^^^^ reference local3
 //                                        ^^^^^^^^^ reference local4
 //                                                   ^^^^^^^^^^^^ reference local5
@@ -191,8 +187,7 @@ public class DiffResult {
 //                               ^^^^^^^ definition local9 unresolved_type adapter
     dispatchTo(new AdapterListUpdateCallback(adapter));
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/DiffResult#dispatchTo().
-//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//                 ^^^^^^^^^^^^^^^^^^^^^^^^^ reference _root_/
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
 //                                           ^^^^^^^ reference local9
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
@@ -41,8 +41,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
   private final HiddenEpoxyModel hiddenModel = new HiddenEpoxyModel();
 //              ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#
 //                               ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#hiddenModel. private final HiddenEpoxyModel hiddenModel
-//                                             ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
-//                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#
+//                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
 
   /**
    * Subclasses should modify this list as necessary with the models they want to show. Subclasses
@@ -52,8 +51,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //                ^^^^ reference java/util/List#
 //                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                    ^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#models. protected final List<EpoxyModel<?>> models
-//                                             ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#`<init>`(+1).
-//                                                 ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#
+//                                                 ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#`<init>`(+1).
   private DiffHelper diffHelper;
 //        ^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#
 //                   ^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAdapter#diffHelper. private DiffHelper diffHelper
@@ -79,29 +77,25 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
     if (diffHelper != null) {
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#diffHelper.
       throw new IllegalStateException("Diffing was already enabled");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     if (!models.isEmpty()) {
 //       ^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#models.
 //              ^^^^^^^ reference java/util/List#isEmpty().
       throw new IllegalStateException("You must enable diffing before modifying models");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     if (!hasStableIds()) {
 //       ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#hasStableIds#
       throw new IllegalStateException("You must have stable ids to use diffing");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     diffHelper = new DiffHelper(this, false);
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#diffHelper.
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#`<init>`().
-//                   ^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#
+//                   ^^^^^^^^^^ reference com/airbnb/epoxy/DiffHelper#`<init>`().
 //                              ^^^^ reference com/airbnb/epoxy/EpoxyAdapter#
   }
 
@@ -142,8 +136,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
     if (diffHelper == null) {
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyAdapter#diffHelper.
       throw new IllegalStateException("You must enable diffing before notifying models changed");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     diffHelper.notifyModelChanges();
@@ -301,8 +294,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
     if (targetIndex == -1) {
 //      ^^^^^^^^^^^ reference local15
       throw new IllegalStateException("Model is not added: " + modelToInsertBefore);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
 //                                                             ^^^^^^^^^^^^^^^^^^^ reference local14
     }
 
@@ -338,8 +330,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
     if (modelIndex == -1) {
 //      ^^^^^^^^^^ reference local18
       throw new IllegalStateException("Model is not added: " + modelToInsertAfter);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
 //                                                             ^^^^^^^^^^^^^^^^^^ reference local17
     }
 
@@ -650,8 +641,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
     if (index == -1) {
 //      ^^^^^ reference local42
       throw new IllegalStateException("Model is not added: " + model);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
 //                                                             ^^^^^ reference local41
     }
     return models.subList(index + 1, models.size());

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -107,8 +107,7 @@ public final class EpoxyAsyncUtil {
     if (!async) {
 //       ^^^^^ reference local1
       return new Handler(looper);
-//           ^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//               ^^^^^^^ reference _root_/
+//               ^^^^^^^ reference `<init>`#
 //                       ^^^^^^ reference local0
     }
 
@@ -149,8 +148,7 @@ public final class EpoxyAsyncUtil {
     }
 
     return new Handler(looper);
-//         ^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//             ^^^^^^^ reference _root_/
+//             ^^^^^^^ reference `<init>`#
 //                     ^^^^^^ reference local0
   }
 
@@ -165,8 +163,7 @@ public final class EpoxyAsyncUtil {
     HandlerThread handlerThread = new HandlerThread(threadName);
 //  ^^^^^^^^^^^^^ reference _root_/
 //                ^^^^^^^^^^^^^ definition local4 unresolved_type handlerThread
-//                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//                                    ^^^^^^^^^^^^^ reference _root_/
+//                                    ^^^^^^^^^^^^^ reference `<init>`#
 //                                                  ^^^^^^^^^^ reference local3
     handlerThread.start();
 //  ^^^^^^^^^^^^^ reference local4

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAttribute.java
@@ -85,6 +85,9 @@ public @interface EpoxyAttribute {
      * If you use this it is your responsibility to ensure that the object assigned to the attribute
      * at runtime correctly implements hashCode/equals. If you don't want the attribute to
      * contribute to model state you should use {@link Option#DoNotHash} instead.
+//                                                     ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
+//                                                     ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
+//                                                     ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
      */
     IgnoreRequireHashCode,
 //  ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#Option#IgnoreRequireHashCode. Option.IgnoreRequireHashCode /* ordinal 3 */
@@ -97,6 +100,8 @@ public @interface EpoxyAttribute {
   }
 
   /** Specify any {@link Option} values that should be used when generating the model class. */
+//                       ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
+//                       ^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#`<init>`().
   Option[] value() default {};
 //^^^^^^ reference com/airbnb/epoxy/EpoxyAttribute#Option#
 //         ^^^^^ definition com/airbnb/epoxy/EpoxyAttribute#value(). public abstract Option[] value()

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -128,8 +128,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
   private static final Timer NO_OP_TIMER = new NoOpTimer();
 //                     ^^^^^ reference com/airbnb/epoxy/Timer#
 //                           ^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#NO_OP_TIMER. private static final Timer NO_OP_TIMER
-//                                         ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NoOpTimer#`<init>`().
-//                                             ^^^^^^^^^ reference com/airbnb/epoxy/NoOpTimer#
+//                                             ^^^^^^^^^ reference com/airbnb/epoxy/NoOpTimer#`<init>`().
 
   public static Handler defaultModelBuildingHandler = MainThreadExecutor.INSTANCE.handler;
 //              ^^^^^^^ reference _root_/
@@ -168,8 +167,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //              ^^^^ reference java/util/List#
 //                   ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#Interceptor#
 //                                ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#interceptors. private final List<Interceptor> interceptors
-//                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/concurrent/CopyOnWriteArrayList#`<init>`().
-//                                                   ^^^^^^^^^^^^^^^^^^^^ reference java/util/concurrent/CopyOnWriteArrayList#
+//                                                   ^^^^^^^^^^^^^^^^^^^^ reference java/util/concurrent/CopyOnWriteArrayList#`<init>`().
 
   // Volatile because -> write only on main thread, read from builder thread
   private volatile boolean filterDuplicates = filterDuplicatesDefault;
@@ -239,8 +237,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                                                             ^^^^^^^^^^^^^^ definition local1 unresolved_type diffingHandler
     adapter = new EpoxyControllerAdapter(this, diffingHandler);
 //  ^^^^^^^ reference com/airbnb/epoxy/EpoxyController#adapter.
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#
+//                ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`().
 //                                       ^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                             ^^^^^^^^^^^^^^ reference local1
     modelBuildHandler = modelBuildingHandler;
@@ -309,8 +306,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     if (isBuildingModels()) {
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage("Cannot call `requestModelBuild` from inside `buildModels`");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
     }
 
     // If it is the first time building models then we do it right away, otherwise we post the call.
@@ -407,8 +403,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     if (isBuildingModels()) {
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 1:77
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "Cannot call `requestDelayedModelBuild` from inside `buildModels`");
     }
 
@@ -473,7 +468,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                       ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#buildModelsRunnable. private final Runnable buildModelsRunnable
 //                                             ^^^^^^^^^^^^^^^^ reference local6 49:3
 //                                                 ^^^^^^^^ reference java/lang/Runnable#
-//                                                 ^^^^^^^^ reference java/lang/Runnable#
     @Override
 //   ^^^^^^^^ reference java/lang/Override#
     public void run() {
@@ -495,8 +489,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 
       modelsBeingBuilt = new ControllerModelList(getExpectedModelCount());
 //    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelsBeingBuilt.
-//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerModelList#`<init>`().
-//                           ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerModelList#
+//                           ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ControllerModelList#`<init>`().
 //                                               ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#getExpectedModelCount().
 
       timer.start("Models built");
@@ -666,8 +659,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelInterceptorCallbacks.
       modelInterceptorCallbacks = new ArrayList<>();
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#modelInterceptorCallbacks.
-//                                ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                    ^^^^^^^^^ reference java/util/ArrayList#
+//                                    ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
     }
 
     modelInterceptorCallbacks.add(callback);
@@ -823,8 +815,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage("Can only call this when inside the `buildModels` method");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
     }
   }
 
@@ -833,8 +824,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     if (isBuildingModels()) {
 //      ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage("Cannot call this from inside `buildModels`");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
     }
   }
 
@@ -923,8 +913,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //      ^^^^^^^^^^ reference local31
 //                 ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hasDefaultId().
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 2:68
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "You must set an id on a model before adding it. Use the @AutoModel annotation if you "
               + "want an id to be automatically generated for you.");
     }
@@ -933,8 +922,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //       ^^^^^^^^^^ reference local31
 //                  ^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#isShown().
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 2:33
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "You cannot hide a model in an EpoxyController. Use `addIf` to conditionally add a "
               + "model instead.");
     }
@@ -1032,8 +1020,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //  ^^^ reference java/util/Set#
 //      ^^^^ reference java/lang/Long#
 //            ^^^^^^^^ definition local35 Set<Long> modelIds
-//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/HashSet#`<init>`(+3).
-//                           ^^^^^^^ reference java/util/HashSet#
+//                           ^^^^^^^ reference java/util/HashSet#`<init>`(+3).
 //                                     ^^^^^^ reference local34
 //                                            ^^^^ reference java/util/List#size().
 
@@ -1086,8 +1073,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
         onExceptionSwallowed(
 //      ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#onExceptionSwallowed().
             new IllegalEpoxyUsage("Two models have the same ID. ID's must be unique!"
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 2:81
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
                 + "\nOriginal has position " + indexOfOriginal + ":\n" + originalModel
 //                                             ^^^^^^^^^^^^^^^ reference local39
 //                                                                       ^^^^^^^^^^^^^ reference local40
@@ -1136,8 +1122,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
     }
 
     throw new IllegalArgumentException("No duplicates in list");
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//            ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//            ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
   }
 
   /**
@@ -1200,16 +1185,14 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //      ^^^^^^^ reference local48
       timer = new DebugTimer(getClass().getSimpleName());
 //    ^^^^^ reference com/airbnb/epoxy/EpoxyController#timer.
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DebugTimer#`<init>`().
-//                ^^^^^^^^^^ reference com/airbnb/epoxy/DebugTimer#
+//                ^^^^^^^^^^ reference com/airbnb/epoxy/DebugTimer#`<init>`().
 //                           ^^^^^^^^ reference java/lang/Object#getClass().
 //                                      ^^^^^^^^^^^^^ reference java/lang/Class#getSimpleName().
       if (debugObserver == null) {
 //        ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#debugObserver.
         debugObserver = new EpoxyDiffLogger(getClass().getSimpleName());
 //      ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#debugObserver.
-//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyDiffLogger#`<init>`().
-//                          ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyDiffLogger#
+//                          ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyDiffLogger#`<init>`().
 //                                          ^^^^^^^^ reference java/lang/Object#getClass().
 //                                                     ^^^^^^^^^^^^^ reference java/lang/Class#getSimpleName().
       }
@@ -1421,7 +1404,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
       new ExceptionHandler() {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^ reference local58 7:7
 //        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ExceptionHandler#
-//        ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ExceptionHandler#
 
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -1501,7 +1483,6 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                                        ^^^^^^^^^^^ reference postDelayed#
 //                                                    ^^^^^^^^^^^^^^^^ reference local67 19:7
 //                                                        ^^^^^^^^ reference java/lang/Runnable#
-//                                                        ^^^^^^^^ reference java/lang/Runnable#
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
         public void run() {
@@ -1512,8 +1493,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //            ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#recyclerViewAttachCount.
             onExceptionSwallowed(new IllegalStateException(
 //          ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#onExceptionSwallowed().
-//                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 10:91
-//                                   ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//                                   ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
                 "This EpoxyController had its adapter added to more than one ReyclerView. Epoxy "
                     + "does not support attaching an adapter to multiple RecyclerViews because "
                     + "saved state will not work properly. If you did not intend to attach your "

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -62,8 +62,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   private final NotifyBlocker notifyBlocker = new NotifyBlocker();
 //              ^^^^^^^^^^^^^ reference com/airbnb/epoxy/NotifyBlocker#
 //                            ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#notifyBlocker. private final NotifyBlocker notifyBlocker
-//                                            ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NotifyBlocker#`<init>`().
-//                                                ^^^^^^^^^^^^^ reference com/airbnb/epoxy/NotifyBlocker#
+//                                                ^^^^^^^^^^^^^ reference com/airbnb/epoxy/NotifyBlocker#`<init>`().
   private final AsyncEpoxyDiffer differ;
 //              ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#
 //                               ^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#differ. private final AsyncEpoxyDiffer differ
@@ -76,8 +75,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //              ^^^^ reference java/util/List#
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/OnModelBuildFinishedListener#
 //                                                 ^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#modelBuildListeners. private final List<OnModelBuildFinishedListener> modelBuildListeners
-//                                                                       ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                                                           ^^^^^^^^^ reference java/util/ArrayList#
+//                                                                           ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
 
   EpoxyControllerAdapter(@NonNull EpoxyController epoxyController, Handler diffingHandler) {
 //^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#`<init>`(). EpoxyControllerAdapter(EpoxyController epoxyController, unresolved_type diffingHandler)
@@ -92,8 +90,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                         ^^^^^^^^^^^^^^^ reference local0
     differ = new AsyncEpoxyDiffer(
 //  ^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#differ.
-//           ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`(). 4:5
-//               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#
+//               ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/AsyncEpoxyDiffer#`<init>`().
         diffingHandler,
 //      ^^^^^^^^^^^^^^ reference local1
         this,
@@ -499,8 +496,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //  ^^^^^^^^^ reference java/util/ArrayList#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                           ^^^^^^^^^^^ definition local30 ArrayList<EpoxyModel<?>> updatedList
-//                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
-//                                             ^^^^^^^^^ reference java/util/ArrayList#
+//                                             ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
 //                                                         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
 
     updatedList.add(toPosition, updatedList.remove(fromPosition));
@@ -546,8 +542,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //  ^^^^^^^^^ reference java/util/ArrayList#
 //            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                           ^^^^^^^^^^^ definition local33 ArrayList<EpoxyModel<?>> updatedList
-//                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
-//                                             ^^^^^^^^^ reference java/util/ArrayList#
+//                                             ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
 //                                                         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
 
     notifyBlocker.allowChanges();
@@ -581,10 +576,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                  ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                 ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyControllerAdapter#ITEM_CALLBACK. private static final unresolved_type ITEM_CALLBACK
       new ItemCallback<EpoxyModel<?>>() {
-//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 15:7
 //        ^^^^^^^^^^^^ reference _root_/
-//        ^^^^^^^^^^^^ reference _root_/
-//                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                     ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -625,8 +617,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
 //                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                          ^^^^^^^ definition local44 EpoxyModel<?> newItem
           return new DiffPayload(oldItem);
-//               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`(+1).
-//                   ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#
+//                   ^^^^^^^^^^^ reference com/airbnb/epoxy/DiffPayload#`<init>`(+1).
 //                               ^^^^^^^ reference local43
         }
       };

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -346,8 +346,7 @@ public abstract class EpoxyModel<T> {
 //                                                                  ^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                       ^^ reference com/airbnb/epoxy/EpoxyModel#id.
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 1:79
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "Cannot change a model's id after it has been added to the adapter.");
     }
 
@@ -675,8 +674,7 @@ public abstract class EpoxyModel<T> {
     if (controller == null) {
 //      ^^^^^^^^^^ reference local36
       throw new IllegalArgumentException("Controller cannot be null");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
     }
 
     if (controller.isModelAddedMultipleTimes(this)) {
@@ -684,8 +682,7 @@ public abstract class EpoxyModel<T> {
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isModelAddedMultipleTimes().
 //                                           ^^^^ reference com/airbnb/epoxy/EpoxyModel#
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 2:68
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "This model was already added to the controller at position "
               + controller.getFirstIndexOfModelInBuildingList(this));
 //              ^^^^^^^^^^ reference local36
@@ -713,7 +710,6 @@ public abstract class EpoxyModel<T> {
 //    ^^^^^^^^^^ reference local36
 //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#addAfterInterceptorCallback().
 //                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local38 11:7
-//                                               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
 //                                               ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#ModelInterceptorCallback#
         @Override
 //       ^^^^^^^^ reference java/lang/Override#
@@ -768,8 +764,7 @@ public abstract class EpoxyModel<T> {
 //      ^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#isDebugValidationEnabled().
 //                                     ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#currentlyInInterceptors.
       throw new ImmutableModelException(this,
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#`<init>`(). 1:52
-//              ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#`<init>`().
 //                                      ^^^^ reference com/airbnb/epoxy/EpoxyModel#
           getPosition(firstControllerAddedTo, this));
 //        ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#getPosition().
@@ -837,8 +832,7 @@ public abstract class EpoxyModel<T> {
 //         ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hashCodeWhenAdded.
 //                              ^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#hashCode().
       throw new ImmutableModelException(this, descriptionOfChange, modelPosition);
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ImmutableModelException#`<init>`(+1).
 //                                      ^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                            ^^^^^^^^^^^^^^^^^^^ reference local45
 //                                                                 ^^^^^^^^^^^^^ reference local46

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -129,8 +129,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
     this(layoutRes, new ArrayList<>(models));
 //  ^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+2).
 //       ^^^^^^^^^ reference local0
-//                  ^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
-//                      ^^^^^^^^^ reference java/util/ArrayList#
+//                      ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
 //                                  ^^^^^^ reference local1
   }
 
@@ -147,8 +146,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
     this(layoutRes, new ArrayList<>(Arrays.asList(models)));
 //  ^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+2).
 //       ^^^^^^^^^ reference local2
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
-//                      ^^^^^^^^^ reference java/util/ArrayList#
+//                      ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+2).
 //                                  ^^^^^^ reference java/util/Arrays#
 //                                         ^^^^^^ reference java/util/Arrays#asList().
 //                                                ^^^^^^ reference local3
@@ -169,8 +167,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //      ^^^^^^ reference local5
 //             ^^^^^^^ reference java/util/List#isEmpty().
       throw new IllegalArgumentException("Models cannot be empty");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
     }
 
     this.models = models;
@@ -213,8 +210,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //          ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#`<init>`(+3). protected EpoxyModelGroup()
     models = new ArrayList<>();
 //  ^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#models.
-//           ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//               ^^^^^^^^^ reference java/util/ArrayList#
+//               ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
     shouldSaveViewStateDefault = false;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewStateDefault.
   }
@@ -263,7 +259,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                ^^^^^^ reference local10
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local12 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -305,7 +300,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //  ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#iterateModels().
 //                ^^^^^^ reference local17
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local20 6:5
-//                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
@@ -360,7 +354,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //  ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#iterateModels().
 //                ^^^^^^ reference local25
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local29 15:5
-//                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
@@ -468,7 +461,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                ^^^^^^ reference local38
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local40 6:5
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
-//                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
@@ -500,7 +492,6 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //  ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#iterateModels().
 //                ^^^^^^ reference local45
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local47 6:5
-//                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
 //                            ^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelGroup#IterateModelsCallback#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
@@ -588,8 +579,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   protected final int getDefaultLayout() {
 //                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#getDefaultLayout(). @Override protected final int getDefaultLayout()
     throw new UnsupportedOperationException(
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1). 1:74
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1).
         "You should set a layout with layout(...) instead of using this.");
   }
 
@@ -651,8 +641,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 //                                                          ^^^^^^^^^^ reference _root_/
 //                                                                     ^^^^^^ definition local65 @NonNull unresolved_type parent
     return new ModelGroupHolder(parent);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`#
-//             ^^^^^^^^^^^^^^^^ reference _root_/
+//             ^^^^^^^^^^^^^^^^ reference `<init>`#
 //                              ^^^^^^ reference local65
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelTouchCallback.java
@@ -171,8 +171,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
     if (controller == null) {
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#controller.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:84
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "A controller must be provided in the constructor if dragging is enabled");
     }
 
@@ -199,8 +198,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
 //                        ^^^^^ reference local15
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:80
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "A model was dragged that is not a valid target: " + model.getClass());
 //                                                             ^^^^^ reference local15
 //                                                                   ^^^^^^^^ reference java/lang/Object#getClass().
@@ -257,8 +255,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
 //                        ^^^^^ reference local22
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:79
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "A model was swiped that is not a valid target: " + model.getClass());
 //                                                            ^^^^^ reference local22
 //                                                                  ^^^^^^^^ reference java/lang/Object#getClass().
@@ -312,8 +309,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
 //                          ^^^^^ reference local31
         throw new IllegalStateException(
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:83
-//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
             "A model was selected that is not a valid target: " + model.getClass());
 //                                                                ^^^^^ reference local31
 //                                                                      ^^^^^^^^ reference java/lang/Object#getClass().
@@ -502,7 +498,6 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //               ^^^^^^^^^^^ reference postDelayed#
 //                           ^^^^^^^^^^^^^^^^ reference local48 5:5
 //                               ^^^^^^^^ reference java/lang/Runnable#
-//                               ^^^^^^^^ reference java/lang/Runnable#
       @Override
 //     ^^^^^^^^ reference java/lang/Override#
       public void run() {
@@ -561,8 +556,7 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#isTouchableModel().
 //                        ^^^^^ reference local59
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:81
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "A model was selected that is not a valid target: " + model.getClass());
 //                                                              ^^^^^ reference local59
 //                                                                    ^^^^^^^^ reference java/lang/Object#getClass().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithView.java
@@ -75,8 +75,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
   protected final int getDefaultLayout() {
 //                    ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelWithView#getDefaultLayout(). @Override protected final int getDefaultLayout()
     throw new UnsupportedOperationException(
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1). 1:83
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1).
         "Layout resources are unsupported. Views must be created with `buildView`");
   }
 
@@ -89,8 +88,7 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
 //                             ^^^^^^^^^ reference androidx/annotation/LayoutRes#
 //                                           ^^^^^^^^^ definition local1 @LayoutRes int layoutRes
     throw new UnsupportedOperationException(
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1). 1:83
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/UnsupportedOperationException#`<init>`(+1).
         "Layout resources are unsupported. Views must be created with `buildView`");
   }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -79,8 +79,7 @@ public abstract class EpoxyTouchHelper {
 //                                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#
 //                                                       ^^^^^^^^^^ definition local0 EpoxyController controller
     return new DragBuilder(controller);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#`<init>`().
-//             ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#
+//             ^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#`<init>`().
 //                         ^^^^^^^^^^ reference local0
   }
 
@@ -112,8 +111,7 @@ public abstract class EpoxyTouchHelper {
 //                                       ^^^^^^^^^^^^ reference _root_/
 //                                                    ^^^^^^^^^^^^ definition local2 unresolved_type recyclerView
       return new DragBuilder2(controller, recyclerView);
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#`<init>`().
-//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#
+//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#`<init>`().
 //                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder#controller.
 //                                        ^^^^^^^^^^^^ reference local2
     }
@@ -200,8 +198,7 @@ public abstract class EpoxyTouchHelper {
 //                      ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#withDirections(). public DragBuilder3 withDirections(int directionFlags)
 //                                         ^^^^^^^^^^^^^^ definition local5 int directionFlags
       return new DragBuilder3(controller, recyclerView, makeMovementFlags(directionFlags, 0));
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#`<init>`().
-//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#
+//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#`<init>`().
 //                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#controller.
 //                                        ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#recyclerView.
 //                                                      ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder2#makeMovementFlags#
@@ -260,16 +257,14 @@ public abstract class EpoxyTouchHelper {
 //         ^^^^^ reference java/lang/Class#
 //                         ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                      ^^^^^^^^^^^^^ definition local10 List<Class<? extends EpoxyModel>> targetClasses
-//                                                      ^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
-//                                                          ^^^^^^^^^ reference java/util/ArrayList#
+//                                                          ^^^^^^^^^ reference java/util/ArrayList#`<init>`().
       targetClasses.add(targetModelClass);
 //    ^^^^^^^^^^^^^ reference local10
 //                  ^^^ reference java/util/List#add().
 //                      ^^^^^^^^^^^^^^^^ reference local9
 
       return new DragBuilder4<>(controller, recyclerView, movementFlags, targetModelClass,
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`(). 1:24
-//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#
+//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`().
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#controller.
 //                                          ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#recyclerView.
 //                                                        ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#movementFlags.
@@ -292,8 +287,7 @@ public abstract class EpoxyTouchHelper {
 //                                                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                                                             ^^^^^^^^^^^^^^^^^^ definition local11 Class<? extends EpoxyModel>[] targetModelClasses
       return new DragBuilder4<>(controller, recyclerView, movementFlags, EpoxyModel.class,
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`(). 1:44
-//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#
+//               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#`<init>`().
 //                              ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#controller.
 //                                          ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#recyclerView.
 //                                                        ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder3#movementFlags.
@@ -408,12 +402,9 @@ public abstract class EpoxyTouchHelper {
 //    ^^^^^^^^^^^^^^^ reference _root_/
 //                    ^^^^^^^^^^^^^^^ definition local18 unresolved_type itemTouchHelper
           new ItemTouchHelper(new EpoxyModelTouchCallback<U>(controller, targetModelClass) {
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`# 37:12
-//            ^^^^^^^^^^^^^^^ reference _root_/
+//            ^^^^^^^^^^^^^^^ reference `<init>`#
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local20 37:11
 //                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#
-//                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#
-//                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                                           ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#controller.
 //                                                                       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#targetModelClass.
@@ -632,8 +623,7 @@ public abstract class EpoxyTouchHelper {
 //                                       ^^^^^^^^^^^^ reference _root_/
 //                                                    ^^^^^^^^^^^^ definition local59 unresolved_type recyclerView
     return new SwipeBuilder(recyclerView);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#`<init>`().
-//             ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#
+//             ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#`<init>`().
 //                          ^^^^^^^^^^^^ reference local59
   }
 
@@ -700,8 +690,7 @@ public abstract class EpoxyTouchHelper {
 //                       ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#withDirections(). public SwipeBuilder2 withDirections(int directionFlags)
 //                                          ^^^^^^^^^^^^^^ definition local61 int directionFlags
       return new SwipeBuilder2(recyclerView, makeMovementFlags(0, directionFlags));
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#`<init>`().
-//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#
+//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#`<init>`().
 //                             ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#recyclerView.
 //                                           ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder#makeMovementFlags#
 //                                                                ^^^^^^^^^^^^^^ reference local61
@@ -751,16 +740,14 @@ public abstract class EpoxyTouchHelper {
 //         ^^^^^ reference java/lang/Class#
 //                         ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                      ^^^^^^^^^^^^^ definition local65 List<Class<? extends EpoxyModel>> targetClasses
-//                                                      ^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
-//                                                          ^^^^^^^^^ reference java/util/ArrayList#
+//                                                          ^^^^^^^^^ reference java/util/ArrayList#`<init>`().
       targetClasses.add(targetModelClass);
 //    ^^^^^^^^^^^^^ reference local65
 //                  ^^^ reference java/util/List#add().
 //                      ^^^^^^^^^^^^^^^^ reference local64
 
       return new SwipeBuilder3<>(recyclerView, movementFlags, targetModelClass,
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`(). 1:24
-//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#
+//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`().
 //                               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#recyclerView.
 //                                             ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#movementFlags.
 //                                                            ^^^^^^^^^^^^^^^^ reference local64
@@ -783,8 +770,7 @@ public abstract class EpoxyTouchHelper {
 //                      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                     ^^^^^^^^^^^^^^^^^^ definition local66 Class<? extends EpoxyModel>[] targetModelClasses
       return new SwipeBuilder3<>(recyclerView, movementFlags, EpoxyModel.class,
-//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`(). 1:44
-//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#
+//               ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#`<init>`().
 //                               ^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#recyclerView.
 //                                             ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder2#movementFlags.
 //                                                            ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
@@ -888,12 +874,9 @@ public abstract class EpoxyTouchHelper {
 //    ^^^^^^^^^^^^^^^ reference _root_/
 //                    ^^^^^^^^^^^^^^^ definition local72 unresolved_type itemTouchHelper
           new ItemTouchHelper(new EpoxyModelTouchCallback<U>(null, targetModelClass) {
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<init>`# 42:12
-//            ^^^^^^^^^^^^^^^ reference _root_/
+//            ^^^^^^^^^^^^^^^ reference `<init>`#
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local74 42:11
 //                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#
-//                                ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModelTouchCallback#
-//                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                        ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                                 ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#targetModelClass.
 //                                                                                   ^ definition local82 2:7 EpoxyController controller

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -98,8 +98,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
       // state from a previously bound model.
       initialViewState = new ViewState();
 //    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#initialViewState.
-//                       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`().
-//                           ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                           ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`().
       initialViewState.save(itemView);
 //    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#initialViewState.
 //                     ^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#save().
@@ -319,8 +318,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     if (epoxyModel == null) {
 //      ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyViewHolder#epoxyModel.
       throw new IllegalStateException("This holder is not currently bound.");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ImmutableModelException.java
@@ -61,8 +61,7 @@ class ImmutableModelException extends RuntimeException {
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local6 String descriptionOfWhenChangeHappened
 //                                                ^^^^^^^^^^^^^ definition local7 int modelPosition
     return new StringBuilder(descriptionOfWhenChangeHappened)
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/StringBuilder#`<init>`(+2).
-//             ^^^^^^^^^^^^^ reference java/lang/StringBuilder#
+//             ^^^^^^^^^^^^^ reference java/lang/StringBuilder#`<init>`(+2).
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local6
         .append(" Position: ")
 //       ^^^^^^ reference java/lang/StringBuilder#append(+1).

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/MainThreadExecutor.java
@@ -17,13 +17,11 @@ class MainThreadExecutor extends HandlerExecutor {
   static final MainThreadExecutor INSTANCE = new MainThreadExecutor(false);
 //             ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
 //                                ^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#INSTANCE. static final MainThreadExecutor INSTANCE
-//                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#`<init>`().
-//                                               ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
+//                                               ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#`<init>`().
   static final MainThreadExecutor ASYNC_INSTANCE = new MainThreadExecutor(true);
 //             ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
 //                                ^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#ASYNC_INSTANCE. static final MainThreadExecutor ASYNC_INSTANCE
-//                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#`<init>`().
-//                                                     ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#
+//                                                     ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/MainThreadExecutor#`<init>`().
 
   MainThreadExecutor(boolean async) {
 //^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/MainThreadExecutor#`<init>`(). MainThreadExecutor(boolean async)

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelList.java
@@ -84,8 +84,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
     if (notificationsPaused) {
 //      ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notificationsPaused.
       throw new IllegalStateException("Notifications already paused");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
     notificationsPaused = true;
 //  ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notificationsPaused.
@@ -96,8 +95,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
     if (!notificationsPaused) {
 //       ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notificationsPaused.
       throw new IllegalStateException("Notifications already resumed");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
     notificationsPaused = false;
 //  ^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#notificationsPaused.
@@ -403,8 +401,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                               ^^^^^^^^ definition com/airbnb/epoxy/ModelList#iterator(). @NonNull @Override public Iterator<EpoxyModel<?>> iterator()
     return new Itr();
-//         ^^^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#`<init>`().
-//             ^^^ reference com/airbnb/epoxy/ModelList#Itr#
+//             ^^^ reference com/airbnb/epoxy/ModelList#Itr#`<init>`().
   }
 
   /**
@@ -461,8 +458,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
       if (lastRet < 0) {
 //        ^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#lastRet.
         throw new IllegalStateException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`().
       }
       checkForComodification();
 //    ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#checkForComodification().
@@ -485,8 +481,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
 //                                       ^^ definition local31 IndexOutOfBoundsException ex
         throw new ConcurrentModificationException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
       }
     }
 
@@ -496,8 +491,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //        ^^^^^^^^ reference java/util/AbstractList#modCount.
 //                    ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#expectedModCount.
         throw new ConcurrentModificationException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
       }
     }
   }
@@ -511,8 +505,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                    ^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyModel#
 //                                   ^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#listIterator(). @NonNull @Override public ListIterator<EpoxyModel<?>> listIterator()
     return new ListItr(0);
-//         ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#`<init>`().
-//             ^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#
+//             ^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#`<init>`().
   }
 
   @NonNull
@@ -525,8 +518,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                   ^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelList#listIterator(+1). @NonNull @Override public ListIterator<EpoxyModel<?>> listIterator(int index)
 //                                                    ^^^^^ definition local32 int index
     return new ListItr(index);
-//         ^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#`<init>`().
-//             ^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#
+//             ^^^^^^^ reference com/airbnb/epoxy/ModelList#ListItr#`<init>`().
 //                     ^^^^^ reference local32
   }
 
@@ -580,8 +572,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
       if (i < 0) {
 //        ^ reference local34
         throw new NoSuchElementException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#
+//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
       }
 
       cursor = i;
@@ -604,8 +595,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
       if (lastRet < 0) {
 //        ^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#lastRet.
         throw new IllegalStateException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//                ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`().
       }
       checkForComodification();
 //    ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#Itr#checkForComodification().
@@ -621,8 +611,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
 //                                       ^^ definition local36 IndexOutOfBoundsException ex
         throw new ConcurrentModificationException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
       }
     }
 
@@ -655,8 +644,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
 //                                       ^^ definition local39 IndexOutOfBoundsException ex
         throw new ConcurrentModificationException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
       }
     }
   }
@@ -679,19 +667,16 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //        ^^^^^ reference local40
 //                 ^^^ reference local41
         return new SubList(this, start, end);
-//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#`<init>`().
-//                 ^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#
+//                 ^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#`<init>`().
 //                         ^^^^ reference com/airbnb/epoxy/ModelList#
 //                               ^^^^^ reference local40
 //                                      ^^^ reference local41
       }
       throw new IllegalArgumentException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`().
     }
     throw new IndexOutOfBoundsException();
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
   }
 
   /**
@@ -795,8 +780,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                        ^^^^ reference java/util/ListIterator#next().
         }
         throw new NoSuchElementException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#
+//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
       }
 
       public int nextIndex() {
@@ -819,8 +803,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                        ^^^^^^^^ reference java/util/ListIterator#previous().
         }
         throw new NoSuchElementException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#
+//                ^^^^^^^^^^^^^^^^^^^^^^ reference java/util/NoSuchElementException#`<init>`().
       }
 
       public int previousIndex() {
@@ -913,13 +896,11 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                            ^^^^^^^^ reference java/util/AbstractList#modCount.
         } else {
           throw new IndexOutOfBoundsException();
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
         }
       } else {
         throw new ConcurrentModificationException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
       }
     }
 
@@ -961,12 +942,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //               ^^^^^^ reference local56
         }
         throw new IndexOutOfBoundsException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @Override
@@ -1003,8 +982,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //             ^^^^^^ reference local58
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @Override
@@ -1028,12 +1006,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                       ^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#offset.
         }
         throw new IndexOutOfBoundsException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @NonNull
@@ -1066,8 +1042,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                           ^^^^^^^^ reference local60
 //                                       ^^^^ reference com/airbnb/epoxy/ModelList#SubList#size.
           return new SubListIterator(fullList.listIterator(location + offset), this, offset, size);
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#SubListIterator#`<init>`().
-//                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#SubListIterator#
+//                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#SubListIterator#`<init>`().
 //                                   ^^^^^^^^ reference com/airbnb/epoxy/ModelList#SubList#fullList.
 //                                            ^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelList#listIterator(+1).
 //                                                         ^^^^^^^^ reference local60
@@ -1077,12 +1052,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                                                                           ^^^^ reference com/airbnb/epoxy/ModelList#SubList#size.
         }
         throw new IndexOutOfBoundsException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @Override
@@ -1116,12 +1089,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //               ^^^^^^ reference local62
         }
         throw new IndexOutOfBoundsException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @Override
@@ -1154,8 +1125,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                            ^^^^^^^^ reference java/util/AbstractList#modCount.
         } else {
           throw new ConcurrentModificationException();
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
         }
       }
     }
@@ -1184,12 +1154,10 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //                                               ^^^^^^ reference local66
         }
         throw new IndexOutOfBoundsException();
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#`<init>`().
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     @Override
@@ -1204,8 +1172,7 @@ class ModelList extends ArrayList<EpoxyModel<?>> {
 //             ^^^^ reference com/airbnb/epoxy/ModelList#SubList#size.
       }
       throw new ConcurrentModificationException();
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/util/ConcurrentModificationException#`<init>`().
     }
 
     void sizeChanged(boolean increment) {

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelProp.java
@@ -83,6 +83,7 @@ public @interface ModelProp {
      * If you use this it is your responsibility to ensure that the object assigned to the prop
      * at runtime correctly implements hashCode/equals. If you don't want the prop to
      * contribute to model state you should use {@link Option#DoNotHash} instead.
+//                                                     ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#`<init>`().
      */
     IgnoreRequireHashCode,
 //  ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ModelProp#Option#IgnoreRequireHashCode. Option.IgnoreRequireHashCode /* ordinal 1 */
@@ -102,6 +103,9 @@ public @interface ModelProp {
   }
 
   /** Specify any {@link Option} values that should be used when generating the model class. */
+//                       ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#`<init>`().
+//                       ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#`<init>`().
+//                       ^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#`<init>`().
   Option[] options() default {};
 //^^^^^^ reference com/airbnb/epoxy/ModelProp#Option#
 //         ^^^^^^^ definition com/airbnb/epoxy/ModelProp#options(). public abstract Option[] options()

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelState.java
@@ -44,8 +44,7 @@ class ModelState {
     ModelState state = new ModelState();
 //  ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
 //             ^^^^^ definition local3 ModelState state
-//                     ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#`<init>`().
-//                         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//                         ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#`<init>`().
 
     state.lastMoveOp = 0;
 //  ^^^^^ reference local3
@@ -90,14 +89,12 @@ class ModelState {
     if (pair != null) {
 //      ^^^^ reference com/airbnb/epoxy/ModelState#pair.
       throw new IllegalStateException("Already paired.");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
     }
 
     pair = new ModelState();
 //  ^^^^ reference com/airbnb/epoxy/ModelState#pair.
-//         ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#`<init>`().
-//             ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#
+//             ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#`<init>`().
     pair.lastMoveOp = 0;
 //  ^^^^ reference com/airbnb/epoxy/ModelState#pair.
 //       ^^^^^^^^^^ reference com/airbnb/epoxy/ModelState#lastMoveOp.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ModelView.java
@@ -65,6 +65,11 @@ public @interface ModelView {
 
   /**
    * If set to an option besides {@link Size#NONE} Epoxy will create an instance of this view
+//                                      ^^^^ reference com/airbnb/epoxy/ModelView#Size#`<init>`().
+//                                      ^^^^ reference com/airbnb/epoxy/ModelView#Size#`<init>`().
+//                                      ^^^^ reference com/airbnb/epoxy/ModelView#Size#`<init>`().
+//                                      ^^^^ reference com/airbnb/epoxy/ModelView#Size#`<init>`().
+//                                      ^^^^ reference com/airbnb/epoxy/ModelView#Size#`<init>`().
    * programmatically at runtime instead of inflating the view from xml. This is an alternative to
    * using {@link #defaultLayout()}, and is a good option if you just need to specify layout
    * parameters on your view with no other styling.

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/NotifyBlocker.java
@@ -41,8 +41,7 @@ class NotifyBlocker extends AdapterDataObserver {
     if (!changesAllowed) {
 //       ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/NotifyBlocker#changesAllowed.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 1:87
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot notify item changes directly. Call `requestModelBuild` instead.");
     }
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/SimpleEpoxyController.java
@@ -47,8 +47,7 @@ public class SimpleEpoxyController extends EpoxyController {
     if (!insideSetModels) {
 //       ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/SimpleEpoxyController#insideSetModels.
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 1:84
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "You cannot call `requestModelBuild` directly. Call `setModels` instead.");
     }
     super.requestModelBuild();
@@ -63,8 +62,7 @@ public class SimpleEpoxyController extends EpoxyController {
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage(
-//          ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`(). 1:78
-//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#
+//              ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/IllegalEpoxyUsage#`<init>`().
           "You cannot call `buildModels` directly. Call `setModels` instead.");
     }
     add(currentModels);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/StringAttributeData.java
@@ -164,8 +164,7 @@ public class StringAttributeData {
       }
     } else {
       throw new IllegalArgumentException("0 is an invalid value for required strings.");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
     }
   }
 

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed2EpoxyController.java
@@ -83,8 +83,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed2EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -118,8 +117,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed2EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -136,8 +134,7 @@ public abstract class Typed2EpoxyController<T, U> extends EpoxyController {
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:41
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `buildModels` directly. Call `setData` instead to trigger a model "
               + "refresh with new data.");
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed3EpoxyController.java
@@ -93,8 +93,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed3EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -128,8 +127,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed3EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -146,8 +144,7 @@ public abstract class Typed3EpoxyController<T, U, V> extends EpoxyController {
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:41
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `buildModels` directly. Call `setData` instead to trigger a model "
               + "refresh with new data.");
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Typed4EpoxyController.java
@@ -103,8 +103,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed4EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -138,8 +137,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/Typed4EpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -156,8 +154,7 @@ public abstract class Typed4EpoxyController<T, U, V, W> extends EpoxyController 
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:41
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `buildModels` directly. Call `setData` instead to trigger a model "
               + "refresh with new data.");
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/TypedEpoxyController.java
@@ -71,8 +71,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/TypedEpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -106,8 +105,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
     if (!allowModelBuildRequests) {
 //       ^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/TypedEpoxyController#allowModelBuildRequests.
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:47
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `requestModelBuild` directly. Call `setData` instead to trigger a "
               + "model refresh with new data.");
     }
@@ -133,8 +131,7 @@ public abstract class TypedEpoxyController<T> extends EpoxyController {
     if (!isBuildingModels()) {
 //       ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalStateException(
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1). 2:41
-//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//              ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
           "You cannot call `buildModels` directly. Call `setData` instead to trigger a model "
               + "refresh with new data.");
     }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -83,8 +83,7 @@ class UpdateOp {
     UpdateOp op = new UpdateOp();
 //  ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
 //           ^^ definition local4 UpdateOp op
-//                ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#`<init>`().
-//                    ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
+//                    ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#`<init>`().
 
     op.type = type;
 //  ^^ reference local4
@@ -157,8 +156,7 @@ class UpdateOp {
       // In most cases this won't be a batch update so we can expect just one payload
       payloads = new ArrayList<>(1);
 //    ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
-//               ^^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`().
-//                   ^^^^^^^^^ reference java/util/ArrayList#
+//                   ^^^^^^^^^ reference java/util/ArrayList#`<init>`().
     } else if (payloads.size() == 1) {
 //             ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#payloads.
 //                      ^^^^ reference java/util/ArrayList#size().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOpHelper.java
@@ -50,8 +50,7 @@ class UpdateOpHelper {
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
 //                     ^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#opList. final List<UpdateOp> opList
-//                              ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                  ^^^^^^^^^ reference java/util/ArrayList#
+//                                  ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
   // We have to be careful to update all item positions in the list when we
   // do a MOVE. This adds some complexity.
   // To do this we keep track of all moves and apply them to an item when we
@@ -60,8 +59,7 @@ class UpdateOpHelper {
 //      ^^^^ reference java/util/List#
 //           ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
 //                     ^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#moves. final List<UpdateOp> moves
-//                             ^^^^^^^^^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
-//                                 ^^^^^^^^^ reference java/util/ArrayList#
+//                                 ^^^^^^^^^ reference java/util/ArrayList#`<init>`(+1).
   private UpdateOp lastOp;
 //        ^^^^^^^^ reference com/airbnb/epoxy/UpdateOp#
 //                 ^^^^^^ definition com/airbnb/epoxy/UpdateOpHelper#lastOp. private UpdateOp lastOp

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewHolderState.java
@@ -118,10 +118,7 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                    ^^^^^^^ reference _root_/
 //                            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                                             ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#CREATOR. public static final unresolved_type CREATOR
-//                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 18:3
 //                                                           ^^^^^^^ reference _root_/
-//                                                           ^^^^^^^ reference _root_/
-//                                                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                                                                   ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 
     public ViewHolderState[] newArray(int size) {
@@ -145,8 +142,7 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
       ViewHolderState state = new ViewHolderState(size);
 //    ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
 //                    ^^^^^ definition local11 ViewHolderState state
-//                            ^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#`<init>`(+1).
-//                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#
+//                                ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#`<init>`(+1).
 //                                                ^^^^ reference local10
 
       for (int i = 0; i < size; i++) {
@@ -228,8 +224,7 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //      ^^^^^ reference local19
       state = new ViewState();
 //    ^^^^^ reference local19
-//            ^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`().
-//                ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`().
     }
 
     state.save(holder.itemView);
@@ -446,12 +441,8 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                              ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                         ^^^^^^^ definition com/airbnb/epoxy/ViewHolderState#ViewState#CREATOR. public static final unresolved_type CREATOR
         new Parcelable.ClassLoaderCreator<ViewState>() {
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference `<any>`#`<init>`# 19:9
-//          ^^^^^^^^^^ reference Parcelable/
 //          ^^^^^^^^^^ reference Parcelable/
 //                     ^^^^^^^^^^^^^^^^^^ reference Parcelable/ClassLoaderCreator#
-//                     ^^^^^^^^^^^^^^^^^^ reference Parcelable/ClassLoaderCreator#
-//                                        ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
 //                                        ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
@@ -480,8 +471,7 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
 //                                       ^^^^^^^^^^^^^^^^^^^ reference readParcelableArray#
 //                                                           ^^^^^^ reference local42
             return new ViewState(size, keys, values);
-//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1).
-//                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#
+//                     ^^^^^^^^^ reference com/airbnb/epoxy/ViewHolderState#ViewState#`<init>`(+1).
 //                               ^^^^ reference local43
 //                                     ^^^^ reference local44
 //                                           ^^^^^^ reference local45

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ViewTypeManager.java
@@ -26,8 +26,7 @@ class ViewTypeManager {
 //                         ^^^^^ reference java/lang/Class#
 //                                ^^^^^^^ reference java/lang/Integer#
 //                                         ^^^^^^^^^^^^^ definition com/airbnb/epoxy/ViewTypeManager#VIEW_TYPE_MAP. private static final Map<Class, Integer> VIEW_TYPE_MAP
-//                                                         ^^^^^^^^^^^^^^^ reference java/util/HashMap#`<init>`(+2).
-//                                                             ^^^^^^^ reference java/util/HashMap#
+//                                                             ^^^^^^^ reference java/util/HashMap#`<init>`(+2).
   /**
    * The last model that had its view type looked up. This is stored so in most cases we can quickly
    * look up what view type belongs to which model.
@@ -147,8 +146,7 @@ class ViewTypeManager {
 //  ^^^^^^^ reference local5
 //          ^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#onExceptionSwallowed().
         new IllegalStateException("Last model did not match expected view type"));
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//          ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//          ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
 
     // To be extra safe in case RecyclerView implementation details change...
     for (EpoxyModel<?> model : adapter.getCurrentModels()) {
@@ -169,8 +167,7 @@ class ViewTypeManager {
     HiddenEpoxyModel hiddenEpoxyModel = new HiddenEpoxyModel();
 //  ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#
 //                   ^^^^^^^^^^^^^^^^ definition local8 HiddenEpoxyModel hiddenEpoxyModel
-//                                      ^^^^^^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
-//                                          ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#
+//                                          ^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/HiddenEpoxyModel#`<init>`().
     if (viewType == hiddenEpoxyModel.getViewType()) {
 //      ^^^^^^^^ reference local6
 //                  ^^^^^^^^^^^^^^^^ reference local8
@@ -180,8 +177,7 @@ class ViewTypeManager {
     }
 
     throw new IllegalStateException("Could not find model for view type: " + viewType);
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
-//            ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#
+//            ^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalStateException#`<init>`(+1).
 //                                                                           ^^^^^^^^ reference local6
   }
 }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/WrappedEpoxyModelCheckedChangeListener.java
@@ -45,8 +45,7 @@ public class WrappedEpoxyModelCheckedChangeListener<T extends EpoxyModel<?>, V>
     if (checkedListener == null) {
 //      ^^^^^^^^^^^^^^^ reference local0
       throw new IllegalArgumentException("Checked change listener cannot be null");
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
-//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#
+//              ^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IllegalArgumentException#`<init>`(+1).
     }
 
     this.originalCheckedChangeListener = checkedListener;

--- a/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/AnonymousClasses.java
@@ -22,10 +22,7 @@ public class AnonymousClasses {
         new Function<Integer, Integer>() {
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local3 5:9
 //          ^^^^^^^^ reference java/util/function/Function#
-//          ^^^^^^^^ reference java/util/function/Function#
 //                   ^^^^^^^ reference java/lang/Integer#
-//                   ^^^^^^^ reference java/lang/Integer#
-//                            ^^^^^^^ reference java/lang/Integer#
 //                            ^^^^^^^ reference java/lang/Integer#
           @Override
 //         ^^^^^^^^ reference java/lang/Override#

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -10,18 +10,18 @@ enum Enums {
 //   ^^^^^ definition minimized/Enums# enum Enums
   A("A", 420),
 //^ definition minimized/Enums#A. Enums.A("A", 420) /* ordinal 0 */
-// ^^^^^^^^^^ reference minimized/Enums#`<init>`().
   B("B", 1),
 //^ definition minimized/Enums#B. Enums.B("B", 1) /* ordinal 1 */
-// ^^^^^^^^ reference minimized/Enums#`<init>`().
   C("C", 5);
 //^ definition minimized/Enums#C. Enums.C("C", 5) /* ordinal 2 */
-// ^^^^^^^^ reference minimized/Enums#`<init>`().
   public String value;
 //       ^^^^^^ reference java/lang/String#
 //              ^^^^^ definition minimized/Enums#value. public String value
 
   Enums(String value, int a) {
+//^^^^^ reference minimized/Enums#`<init>`().
+//^^^^^ reference minimized/Enums#`<init>`().
+//^^^^^ reference minimized/Enums#`<init>`().
 //^^^^^ definition minimized/Enums#`<init>`(). private Enums(String value, int a)
 //      ^^^^^^ reference java/lang/String#
 //             ^^^^^ definition local0 String value

--- a/tests/snapshots/src/main/generated/minimized/Fields.java
+++ b/tests/snapshots/src/main/generated/minimized/Fields.java
@@ -39,19 +39,15 @@ public class Fields {
     Fields fields = new Fields();
 //  ^^^^^^ reference minimized/Fields#
 //         ^^^^^^ definition local0 Fields fields
-//                  ^^^^^^^^^^^^ reference minimized/Fields#`<init>`().
-//                      ^^^^^^ reference minimized/Fields#
+//                      ^^^^^^ reference minimized/Fields#`<init>`().
     InnerFields innerFields = fields.new InnerFields();
 //  ^^^^^^^^^^^ reference minimized/Fields#InnerFields#
 //              ^^^^^^^^^^^ definition local1 InnerFields innerFields
-//                            ^^^^^^ reference local0
-//                            ^^^^^^^^^^^^^^^^^^^^^^^^ reference minimized/Fields#InnerFields#`<init>`().
-//                                       ^^^^^^^^^^^ reference minimized/Fields#InnerFields#
+//                                       ^^^^^^^^^^^ reference minimized/Fields#InnerFields#`<init>`().
     InnerStaticFields innerStaticFields = new InnerStaticFields();
 //  ^^^^^^^^^^^^^^^^^ reference minimized/Fields#InnerStaticFields#
 //                    ^^^^^^^^^^^^^^^^^ definition local2 InnerStaticFields innerStaticFields
-//                                        ^^^^^^^^^^^^^^^^^^^^^^^ reference minimized/Fields#InnerStaticFields#`<init>`().
-//                                            ^^^^^^^^^^^^^^^^^ reference minimized/Fields#InnerStaticFields#
+//                                            ^^^^^^^^^^^^^^^^^ reference minimized/Fields#InnerStaticFields#`<init>`().
     return String.valueOf(fields.privateField)
 //         ^^^^^^ reference java/lang/String#
 //                ^^^^^^^ reference java/lang/String#valueOf(+5).

--- a/tests/snapshots/src/main/generated/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/InnerClasses.java
@@ -103,6 +103,9 @@ public class InnerClasses {
 
   public static void testEnum(InnerEnum magicEnum) {
 //                   ^^^^^^^^ definition minimized/InnerClasses#testEnum(). public static void testEnum(InnerEnum magicEnum)
+//                            ^^^^^^^^^ reference minimized/InnerClasses#InnerEnum#`<init>`().
+//                            ^^^^^^^^^ reference minimized/InnerClasses#InnerEnum#`<init>`().
+//                            ^^^^^^^^^ reference minimized/InnerClasses#InnerEnum#`<init>`().
 //                            ^^^^^^^^^ reference minimized/InnerClasses#InnerEnum#
 //                                      ^^^^^^^^^ definition local6 InnerEnum magicEnum
     if (System.nanoTime() > System.nanoTime()) {
@@ -164,10 +167,7 @@ public class InnerClasses {
         new InnerInterface<String, String>() {
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local9 5:9
 //          ^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerInterface#
-//          ^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerInterface#
 //                         ^^^^^^ reference java/lang/String#
-//                         ^^^^^^ reference java/lang/String#
-//                                 ^^^^^^ reference java/lang/String#
 //                                 ^^^^^^ reference java/lang/String#
           @Override
 //         ^^^^^^^^ reference java/lang/Override#
@@ -199,15 +199,12 @@ public class InnerClasses {
     InnerClasses innerClasses = new InnerClasses(a);
 //  ^^^^^^^^^^^^ reference minimized/InnerClasses#
 //               ^^^^^^^^^^^^ definition local13 InnerClasses innerClasses
-//                              ^^^^^^^^^^^^^^^^^^^ reference minimized/InnerClasses#`<init>`().
-//                                  ^^^^^^^^^^^^ reference minimized/InnerClasses#
+//                                  ^^^^^^^^^^^^ reference minimized/InnerClasses#`<init>`().
 //                                               ^ reference local12
     InnerClass innerClass = innerClasses.new InnerClass(a);
 //  ^^^^^^^^^^ reference minimized/InnerClasses#InnerClass#
 //             ^^^^^^^^^^ definition local14 InnerClass innerClass
-//                          ^^^^^^^^^^^^ reference local13
-//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerClass#`<init>`().
-//                                           ^^^^^^^^^^ reference minimized/InnerClasses#InnerClass#
+//                                           ^^^^^^^^^^ reference minimized/InnerClasses#InnerClass#`<init>`().
 //                                                      ^ reference local12
     innerClass.innerMethod();
 //  ^^^^^^^^^^ reference local14

--- a/tests/snapshots/src/main/generated/minimized/Methods.java
+++ b/tests/snapshots/src/main/generated/minimized/Methods.java
@@ -44,8 +44,7 @@ public class Methods {
     Methods methods = new Methods();
 //  ^^^^^^^ reference minimized/Methods#
 //          ^^^^^^^ definition local6 Methods methods
-//                    ^^^^^^^^^^^^^ reference minimized/Methods#`<init>`().
-//                        ^^^^^^^ reference minimized/Methods#
+//                        ^^^^^^^ reference minimized/Methods#`<init>`().
     int a = staticOverload(n);
 //      ^ definition local7 int a
 //          ^^^^^^^^^^^^^^ reference minimized/Methods#staticOverload().

--- a/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedJavaMain.java
@@ -14,9 +14,7 @@ public class MinimizedJavaMain {
     TypeVariables.app(new TypeVariables.CT());
 //  ^^^^^^^^^^^^^ reference minimized/TypeVariables#
 //                ^^^ reference minimized/TypeVariables#app().
-//                    ^^^^^^^^^^^^^^^^^^^^^^ reference minimized/TypeVariables#CT#`<init>`().
-//                        ^^^^^^^^^^^^^ reference minimized/TypeVariables#
-//                                      ^^ reference minimized/TypeVariables#CT#
+//                                      ^^ reference minimized/TypeVariables#CT#`<init>`().
     System.out.println(
 //  ^^^^^^ reference java/lang/System#
 //         ^^^ reference java/lang/System#out.
@@ -43,10 +41,7 @@ public class MinimizedJavaMain {
 //            ^^^^^^^^^^ reference minimized/Primitives#
 //                       ^^^ reference minimized/Primitives#app().
             + new ParameterizedTypes<Integer, String>().app(42, "42")
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference minimized/ParameterizedTypes#`<init>`().
-//                ^^^^^^^^^^^^^^^^^^ reference minimized/ParameterizedTypes#
-//                                   ^^^^^^^ reference java/lang/Integer#
-//                                            ^^^^^^ reference java/lang/String#
+//                ^^^^^^^^^^^^^^^^^^ reference minimized/ParameterizedTypes#`<init>`().
 //                                                      ^^^ reference minimized/ParameterizedTypes#app().
             + RawTypes.x.toString()
 //            ^^^^^^^^ reference minimized/RawTypes#

--- a/tests/snapshots/src/main/generated/minimized/Primitives.java
+++ b/tests/snapshots/src/main/generated/minimized/Primitives.java
@@ -14,8 +14,7 @@ public class Primitives {
     Random random = new Random();
 //  ^^^^^^ reference java/util/Random#
 //         ^^^^^^ definition local0 Random random
-//                  ^^^^^^^^^^^^ reference java/util/Random#`<init>`().
-//                      ^^^^^^ reference java/util/Random#
+//                      ^^^^^^ reference java/util/Random#`<init>`().
     byte a = (byte) random.nextInt();
 //       ^ definition local1 byte a
 //                  ^^^^^^ reference local0

--- a/tests/snapshots/src/main/generated/minimized/SubClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/SubClasses.java
@@ -28,8 +28,7 @@ public class SubClasses extends AbstractClasses implements Interfaces {
     SubClasses s = new SubClasses();
 //  ^^^^^^^^^^ reference minimized/SubClasses#
 //             ^ definition local0 SubClasses s
-//                 ^^^^^^^^^^^^^^^^ reference minimized/SubClasses#`<init>`().
-//                     ^^^^^^^^^^ reference minimized/SubClasses#
+//                     ^^^^^^^^^^ reference minimized/SubClasses#`<init>`().
     return s.abstractImplementation()
 //         ^ reference local0
 //           ^^^^^^^^^^^^^^^^^^^^^^ reference minimized/SubClasses#abstractImplementation().


### PR DESCRIPTION
Previously, constructor calls would also emit a reference range for the identifier, pointing to the class. Additionally, the range for a constructor call included all the (type) parameters too.

This PR addresses this this by skipping scanning the identifier and by using text-search range finding.

Closes https://github.com/sourcegraph/lsif-java/issues/154