### PR TITLE
Pretty-print `throws` clause in method signatures

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
@@ -178,6 +178,14 @@ public class SignatureFormatter {
                         + " "
                         + symInfo.getDisplayName())
             .collect(Collectors.joining(", ", "(", ")")));
+
+    if (!methodSignature.getThrowsList().isEmpty()) {
+      printKeyword(" throws");
+      s.append(
+          methodSignature.getThrowsList().stream()
+              .map(this::formatType)
+              .collect(Collectors.joining(", ")));
+    }
   }
 
   private void formatValueSignature(ValueSignature valueSignature) {

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -60,6 +60,7 @@ message MethodSignature {
   Scope type_parameters = 1;
   repeated Scope parameter_lists = 2;
   Type return_type = 3;
+  repeated Type throws = 4;
 }
 
 message TypeSignature {

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
@@ -7,6 +7,7 @@ import com.sourcegraph.semanticdb_javac.Semanticdb.*;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.sourcegraph.semanticdb_javac.SemanticdbTypeVisitor.UNRESOLVED_TYPE_REF;
 
@@ -72,6 +73,10 @@ public final class SemanticdbSignatures {
     if (returnType != null) {
       builder.setReturnType(returnType);
     }
+
+    List<Semanticdb.Type> thrownTypes =
+        sym.getThrownTypes().stream().map(this::generateType).collect(Collectors.toList());
+    builder.addAllThrows(thrownTypes);
 
     return Signature.newBuilder().setMethodSignature(builder).build();
   }

--- a/tests/minimized/src/main/java/minimized/Methods.java
+++ b/tests/minimized/src/main/java/minimized/Methods.java
@@ -17,7 +17,7 @@ public class Methods {
     return value + "1";
   }
 
-  public static String app(int n, String m) {
+  public static String app(int n, String m) throws RuntimeException, IndexOutOfBoundsException {
     Methods methods = new Methods();
     int a = staticOverload(n);
     String b = staticOverload(m);

--- a/tests/snapshots/src/main/generated/minimized/Methods.java
+++ b/tests/snapshots/src/main/generated/minimized/Methods.java
@@ -35,12 +35,14 @@ public class Methods {
 //         ^^^^^ reference local3
   }
 
-  public static String app(int n, String m) {
+  public static String app(int n, String m) throws RuntimeException, IndexOutOfBoundsException {
 //              ^^^^^^ reference java/lang/String#
-//                     ^^^ definition minimized/Methods#app(). public static String app(int n, String m)
+//                     ^^^ definition minimized/Methods#app(). public static String app(int n, String m) throws RuntimeException, IndexOutOfBoundsException
 //                             ^ definition local4 int n
 //                                ^^^^^^ reference java/lang/String#
 //                                       ^ definition local5 String m
+//                                                 ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
+//                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ reference java/lang/IndexOutOfBoundsException#
     Methods methods = new Methods();
 //  ^^^^^^^ reference minimized/Methods#
 //          ^^^^^^^ definition local6 Methods methods


### PR DESCRIPTION
Add 'throws' field to `MethodSignature` in semanticdb for implementing pretty-printing, to be upstreamed to semanticdb spec. 
This is a fairly trivial change so it shouldnt be a big deal to upstream.

Closes #147 