### PR TITLE
Disable GradleBuildToolSuite until #164 is fixed

### DIFF
--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -1,5 +1,9 @@
 package tests
 
+import munit.IgnoreSuite
+
+// FIXME: disabled because of https://github.com/sourcegraph/lsif-java/issues/164
+@IgnoreSuite
 class GradleBuildToolSuite extends BaseBuildToolSuite {
 
   checkBuild(


### PR DESCRIPTION
Currently, the CI is failing due to this test suite.