### PR TITLE
Add support for Gradle v7, fixes #164

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,17 +156,18 @@ of Java versions.
 Please open an issue if your build tool is not listed in the table below. Feel
 free to subscribe to the tracking issues to receive updates on your build tool.
 
-| Build tool | Support | Tracking issue                                                                   |
-| ---------- | ------- | -------------------------------------------------------------------------------- |
-| Gradle     | ✅      |                                                                                  |
-| Maven      | ✅      |                                                                                  |
-| Bazel      | ❌      | [sourcegraph/lsif-java#88](https://github.com/sourcegraph/lsif-java/issues/88)   |
-| Buck       | ❌      | [sourcegraph/lsif-java#99](https://github.com/sourcegraph/lsif-java/issues/99)   |
-| sbt        | ❌      | [sourcegraph/lsif-java#110](https://github.com/sourcegraph/lsif-java/issues/110) |
+| Build tool     | Single repo navigation | Cross-repo navigation | Tracking issue                                                                   |
+| -------------- | ---------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| Maven          | ✅                     | ✅                    |                                                                                  |
+| Gradle v4.0+   | ✅                     | ✅                    |                                                                                  |
+| Gradle v2.2.1+ | ✅                     | ❌                    | [sourcegraph/lsif-java#167](https://github.com/sourcegraph/lsif-java/issues/167) |
+| Bazel          | ❌                     | ❌                    | [sourcegraph/lsif-java#88](https://github.com/sourcegraph/lsif-java/issues/88)   |
+| Buck           | ❌                     | ❌                    | [sourcegraph/lsif-java#99](https://github.com/sourcegraph/lsif-java/issues/99)   |
+| sbt            | ❌                     | ❌                    | [sourcegraph/lsif-java#110](https://github.com/sourcegraph/lsif-java/issues/110) |
 
 **✅**: automatic indexing is fully supported. Please report a bug if the
 `lsif-java index` command does not work on your codebase.
 
-**❌**: automatic inference is not supported but (!) you may still be able to
-use `lsif-java` by configuring it manually using the instructions
+**❌**: automatic indexing is not supported but (!) you may still be able to use
+`lsif-java` by configuring it manually using the instructions
 [here](manual-configuration.md).

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/Embedded.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/Embedded.scala
@@ -23,11 +23,20 @@ object Embedded {
   private def javacErrorpath(tmp: Path) = tmp.resolve("errorpath.txt")
 
   def customJavac(sourceroot: Path, targetroot: Path, tmp: Path): Path = {
-    val javac = tmp.resolve("javac")
+    val bin = tmp.resolve("bin")
+    val javac = bin.resolve("javac")
+    val java = bin.resolve("java")
     val pluginpath = Embedded.semanticdbJar(tmp)
     val errorpath = javacErrorpath(tmp)
     val javacopts = targetroot.resolve("javacopts.txt")
     Files.createDirectories(targetroot)
+    Files.createDirectories(bin)
+    Files.write(
+      java,
+      """#!/usr/bin/env bash
+        |java "$@"
+        |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
     val newJavacopts = tmp.resolve("javac_newarguments")
     val injectSemanticdbArguments = List[String](
       "java",
@@ -60,6 +69,7 @@ object Embedded {
          |""".stripMargin
     Files.write(javac, script.getBytes(StandardCharsets.UTF_8))
     javac.toFile.setExecutable(true)
+    java.toFile.setExecutable(true)
     javac
   }
 

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
@@ -17,7 +17,7 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
     Files.isRegularFile(index.workingDirectory.resolve("pom.xml"))
 
   override def generateSemanticdb(): CommandResult = {
-    TemporaryFiles.withDirectory(index.cleanup) { tmp =>
+    TemporaryFiles.withDirectory(index) { tmp =>
       val mvnw = index.workingDirectory.resolve("mvnw")
       val mavenScript =
         if (Files.isRegularFile(mvnw))

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/TemporaryFiles.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/TemporaryFiles.scala
@@ -4,15 +4,21 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import com.sourcegraph.io.DeleteVisitor
+import com.sourcegraph.lsif_java.commands.IndexCommand
 
 object TemporaryFiles {
-  def withDirectory[T](cleanup: Boolean)(fn: Path => T): T = {
-    val tmp = Files.createTempDirectory("lsif-java")
-    try fn(tmp)
-    finally {
-      if (cleanup) {
-        Files.walkFileTree(tmp, new DeleteVisitor())
-      }
+  def withDirectory[T](index: IndexCommand)(fn: Path => T): T = {
+    index.temporaryDirectory match {
+      case Some(tmp) =>
+        fn(tmp)
+      case None =>
+        val tmp = Files.createTempDirectory("lsif-java")
+        try fn(tmp)
+        finally {
+          if (index.cleanup) {
+            Files.walkFileTree(tmp, new DeleteVisitor())
+          }
+        }
     }
   }
 }

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
@@ -49,6 +49,8 @@ case class IndexCommand(
     @Description("URL to a PackageHub instance")
     @Hidden // Hidden because it's not supposed to be used yet by normal users.
     packagehub: Option[String] = None,
+    @Hidden // Hidden because it's only used for testing purposes
+    temporaryDirectory: Option[Path] = None,
     @Description(
       "Optional. The build command to use to compile all sources. " +
         "Defaults to a build-specific command. For example, the default command for Maven command is 'clean verify -DskipTests'." +

--- a/semanticdb-agent/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbAgent.java
+++ b/semanticdb-agent/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbAgent.java
@@ -1,22 +1,21 @@
 package com.sourcegraph.semanticdb_javac;
 
-import java.nio.charset.StandardCharsets;
-import net.bytebuddy.agent.builder.AgentBuilder;
-import net.bytebuddy.asm.Advice;
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.instrument.Instrumentation;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
-import static net.bytebuddy.matcher.ElementMatchers.named;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
 
 /** Java agent that injects SemanticDB into the Java compilation process. */
 public class SemanticdbAgent {

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -1,32 +1,76 @@
 package tests
 
-import munit.IgnoreSuite
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
 
-// FIXME: disabled because of https://github.com/sourcegraph/lsif-java/issues/164
-@IgnoreSuite
 class GradleBuildToolSuite extends BaseBuildToolSuite {
 
-  checkBuild(
-    "basic",
-    """|/build.gradle
-       |apply plugin: 'java'
-       |repositories { mavenCentral() }
-       |dependencies { implementation "junit:junit:4.13.1" }
-       |/src/main/java/Example.java
-       |import org.junit.Assert;
-       |public class Example {}
-       |/src/test/java/ExampleSuite.java
-       |public class ExampleSuite {}
-       |""".stripMargin,
-    expectedSemanticdbFiles = 2,
-    expectedPackages =
-      """|maven:junit:junit:4.11
-         |maven:org.hamcrest:hamcrest-core:1.3
-         |""".stripMargin
-  )
+  def gradleVersion(version: String = ""): List[String] = {
+    createEmptyBuildScript()
+    if (version.isEmpty || version == "latest")
+      List("gradle", "wrapper")
+    else
+      List("gradle", "wrapper", "--gradle-version", version)
+  }
+
+  def createEmptyBuildScript(): Unit = {
+    val script = workingDirectory.resolve("build.gradle")
+    Files.createDirectories(script.getParent)
+    Files.write(
+      script,
+      Array.emptyByteArray,
+      StandardOpenOption.TRUNCATE_EXISTING,
+      StandardOpenOption.CREATE
+    )
+  }
+
+  List("latest" -> "implementation", "4.0" -> "compile").foreach {
+    case (version, config) =>
+      checkBuild(
+        s"basic-$version",
+        s"""|/build.gradle
+            |apply plugin: 'java'
+            |repositories {
+            |  mavenCentral()
+            |}
+            |dependencies {
+            |  $config 'junit:junit:4.13.1'
+            |}
+            |/src/main/java/Example.java
+            |import org.junit.Assert;
+            |public class Example {}
+            |/src/test/java/ExampleSuite.java
+            |public class ExampleSuite {}
+            |""".stripMargin,
+        expectedSemanticdbFiles = 2,
+        expectedPackages =
+          """|maven:junit:junit:4.13.1
+             |maven:org.hamcrest:hamcrest-core:1.3
+             |""".stripMargin,
+        initCommand = {
+          gradleVersion(version)
+        }
+      )
+  }
+
+  List("3.3", "2.2.1").foreach { version =>
+    checkBuild(
+      s"legacy-$version",
+      s"""|/build.gradle
+          |apply plugin: 'java'
+          |/src/main/java/Example.java
+          |public class Example {}
+          |/src/test/java/ExampleSuite.java
+          |public class ExampleSuite {}
+          |""".stripMargin,
+      expectedSemanticdbFiles = 2,
+      initCommand = gradleVersion(version)
+      // NOTE(olafur): no packages because we use more modern APIs.
+    )
+  }
 
   checkBuild(
-    "toolchains",
+    "toolchains-latest",
     """|/build.gradle
        |apply plugin: 'java'
        |java {
@@ -42,6 +86,41 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
        |public class ExampleSuite {}
        |""".stripMargin,
     2
+  )
+
+  checkBuild(
+    "toolchains-6.7",
+    """|/build.gradle
+       |apply plugin: 'java'
+       |java {
+       |  toolchain {
+       |    languageVersion = JavaLanguageVersion.of(8)
+       |  }
+       |}
+       |/src/main/java/Example.java
+       |public class Example {}
+       |""".stripMargin,
+    expectedError =
+      """|info: /workingDirectory/gradlew --init-script /cache/java-toolchains.gradle lsifDetectJavaToolchains
+         |error: lsif-java does not support Gradle 6.7 when used together with Java toolchains. To fix this problem, upgrade to Gradle version 6.8 or newer and try again.
+         |""".stripMargin,
+    initCommand = gradleVersion("6.7")
+  )
+
+  checkBuild(
+    "toolchains-6.8",
+    """|/build.gradle
+       |apply plugin: 'java'
+       |java {
+       |  toolchain {
+       |    languageVersion = JavaLanguageVersion.of(8)
+       |  }
+       |}
+       |/src/main/java/Example.java
+       |public class Example {}
+       |""".stripMargin,
+    expectedSemanticdbFiles = 1,
+    initCommand = gradleVersion("6.8")
   )
 
   checkBuild(


### PR DESCRIPTION
Also adds a custom error message for users on Gradle v6.7 using the
experimental toolchains feature. We can only support toolchains from
version v6.8.