### PR TITLE
fix range building for tabs or mixed tabs/spaces files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,16 +230,19 @@ lazy val minimized = project
   .in(file("tests/minimized/.j11"))
   .settings(minimizedSettings)
   .dependsOn(agent, plugin)
+  .disablePlugins(JavaFormatterPlugin)
 
 lazy val minimized8 = project
   .in(file("tests/minimized/.j8"))
   .settings(minimizedSettings, javaToolchainVersion := "8")
   .dependsOn(agent, plugin)
+  .disablePlugins(JavaFormatterPlugin)
 
 lazy val minimized15 = project
   .in(file("tests/minimized/.j15"))
   .settings(minimizedSettings, javaToolchainVersion := "15")
   .dependsOn(agent, plugin)
+  .disablePlugins(JavaFormatterPlugin)
 
 lazy val minimizedScala = project
   .in(file("tests/minimized-scala"))

--- a/tests/minimized/src/main/java/minimized/TabIndented.java
+++ b/tests/minimized/src/main/java/minimized/TabIndented.java
@@ -1,0 +1,17 @@
+package minimized;
+
+public class TabIndented {
+	public void app() {
+		Object o = new Object() {
+			@Override
+			public boolean equals(Object other) {
+				return false;
+			}
+
+			@Override
+			public String toString() {
+				return "";
+			}
+		};
+	}
+}

--- a/tests/snapshots/src/main/generated/minimized/TabIndented.java
+++ b/tests/snapshots/src/main/generated/minimized/TabIndented.java
@@ -1,0 +1,30 @@
+package minimized;
+
+public class TabIndented {
+//           ^^^^^^^^^^^ definition minimized/TabIndented# public class TabIndented
+//           ^^^^^^^^^^^ definition minimized/TabIndented#`<init>`(). public TabIndented()
+→public void app() {
+//           ^^^ definition minimized/TabIndented#app(). public void app()
+→→Object o = new Object() {
+//^^^^^^ reference java/lang/Object#
+//       ^ definition local0 Object o
+//               ^^^^^^ reference java/lang/Object#
+→→→@Override
+//  ^^^^^^^^ reference java/lang/Override#
+→→→public boolean equals(Object other) {
+//                ^^^^^^ definition local3 @Override public boolean equals(Object other)
+//                       ^^^^^^ reference java/lang/Object#
+//                              ^^^^^ definition local5 Object other
+→→→→return false;
+→→→}
+
+→→→@Override
+//  ^^^^^^^^ reference java/lang/Override#
+→→→public String toString() {
+//        ^^^^^^ reference java/lang/String#
+//               ^^^^^^^^ definition local4 @Override public String toString()
+→→→→return "";
+→→→}
+→→};
+→}
+}


### PR DESCRIPTION
Previously, ranges would be wrong for files indented with tabs or tabs&spaces.

This happened because javac replaces every tab with 8 spaces in the linemap. As this is potentially inconsistent with the source file itself, we adjust for that when building ranges if the line is actually indented with tabs.

As for every tab there are 8 spaces, we remove 7 spaces for every tab to get the correct char offset (note: different to _column_ offset your editor shows)

![image](https://user-images.githubusercontent.com/18282288/115249940-04b69780-a121-11eb-8d3a-890b1d60a422.png)


Closes #115 and closes #169 