### PR TITLE
Add support for the Gradle Playframework plugin.

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/BuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/BuildTool.scala
@@ -16,6 +16,7 @@ abstract class BuildTool(val name: String, index: IndexCommand) {
 
   def indexJdk(): Boolean = true
 
+  final def sourceroot: Path = index.workingDirectory
   final def targetroot: Path =
     AbsolutePath
       .of(index.targetroot.getOrElse(defaultTargetroot), index.workingDirectory)

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
@@ -92,7 +92,9 @@ object GradleJavaToolchains {
           |}
           |""".stripMargin
     Files.write(scriptPath, script.getBytes(StandardCharsets.UTF_8))
-    index.process(gradleCommand, "--init-script", scriptPath.toString, taskName)
+    index.process(
+      List(gradleCommand, "--init-script", scriptPath.toString, taskName)
+    )
     val toolchains: List[GradleJavaCompiler] =
       if (Files.isRegularFile(toolchainsPath)) {
         Files

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
@@ -53,7 +53,7 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
           )
         )
 
-      val exit = index.process(buildCommand.toList: _*)
+      val exit = index.process(buildCommand)
       Embedded
         .reportUnexpectedJavacErrors(index.app.reporter, tmp)
         .getOrElse(exit)

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
@@ -61,15 +61,19 @@ case class IndexCommand(
     app: Application = Application.default
 ) extends Command {
 
-  def process(shellable: String*): CommandResult = {
-    app.info(shellable.mkString(" "))
+  def process(
+      shellable: Shellable,
+      env: Map[String, String] = Map.empty
+  ): CommandResult = {
+    app.info(shellable.value.mkString(" "))
     app
-      .process(Shellable(shellable))
+      .process(shellable)
       .call(
         check = false,
         stdout = Inherit,
         stderr = Inherit,
-        cwd = workingDirectory
+        cwd = workingDirectory,
+        env = env
       )
   }
 

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
@@ -37,12 +37,21 @@ public class LsifSemanticdb {
 
   private void run() throws IOException {
     PackageTable packages = new PackageTable(options, writer);
-    writer.emitMetaData();
-    int projectId = writer.emitProject(options.language);
-
     List<Path> files = SemanticdbWalker.findSemanticdbFiles(options);
     if (options.reporter.hasErrors()) return;
+    if (files.isEmpty()) {
+      options.reporter.error(
+          "No SemanticDB files found. "
+              + "This typically means that `lsif-java` is unable to automatically "
+              + "index this codebase. If you are using Gradle or Maven, please report an issue to "
+              + "https://github.com/sourcegraph/lsif-java and include steps to reproduce. "
+              + "If you are using a different build tool, make sure that you have followed all "
+              + "of the steps from https://sourcegraph.github.io/lsif-java/docs/manual-configuration.html");
+      return;
+    }
     options.reporter.startProcessing(files.size());
+    writer.emitMetaData();
+    int projectId = writer.emitProject(options.language);
 
     Set<String> isExportedSymbol = exportSymbols(files);
     List<Integer> documentIds =

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdbReporter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdbReporter.java
@@ -9,6 +9,10 @@ package com.sourcegraph.lsif_semanticdb;
 public abstract class LsifSemanticdbReporter {
   public void error(Throwable e) {}
 
+  public void error(String message) {
+    error(new RuntimeException(message));
+  }
+
   public void startProcessing(int taskSize) {}
 
   public void processedOneItem() {}

--- a/tests/buildTools/src/main/scala/tests/GradleDefaultJvmLanguageCompileSpec.scala
+++ b/tests/buildTools/src/main/scala/tests/GradleDefaultJvmLanguageCompileSpec.scala
@@ -1,0 +1,12 @@
+package tests
+
+import java.io.File
+import java.util
+
+import scala.jdk.CollectionConverters._
+
+class GradleDefaultJvmLanguageCompileSpec(base: List[String]) {
+  def getCompileClasspath: util.List[File] = {
+    base.map(new File(_)).asJava
+  }
+}

--- a/tests/buildTools/src/main/scala/tests/GradleJavaCompilerArgumentsBuilder.scala
+++ b/tests/buildTools/src/main/scala/tests/GradleJavaCompilerArgumentsBuilder.scala
@@ -2,6 +2,6 @@ package tests
 
 import scala.jdk.CollectionConverters._
 
-class GradleOptionsBuilder(base: List[String]) {
+class GradleJavaCompilerArgumentsBuilder(base: List[String]) {
   def build(): java.util.List[String] = base.asJava
 }

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -150,4 +150,55 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
     1,
     extraArguments = List("--", "compileJava")
   )
+
+  checkBuild(
+    "playframework",
+    """|/build.gradle
+       |plugins {
+       |  id 'org.gradle.playframework' version '0.11'
+       |  id 'idea'
+       |}
+       |
+       |play {
+       |  platform {
+       |    playVersion = '2.6.7'
+       |    scalaVersion = '2.12'
+       |    javaVersion = JavaVersion.VERSION_1_8
+       |  }
+       |  injectedRoutesGenerator = true
+       |}
+       |dependencies {
+       |  implementation "com.typesafe.play:play-guice_2.12:2.6.7"
+       |}
+       |
+       |repositories {
+       |  mavenCentral()
+       |  maven {
+       |    name "lightbend-maven-releases"
+       |    url "https://repo.lightbend.com/lightbend/maven-release"
+       |  }
+       |  ivy {
+       |    name "lightbend-ivy-release"
+       |    url "https://repo.lightbend.com/lightbend/ivy-releases"
+       |    layout "ivy"
+       |  }
+       |}
+       |/app/controllers/HomeController.java
+       |package controllers;
+       |import play.mvc.*;
+       |import views.html.*;
+       |public class HomeController extends Controller {
+       |    public Result index() {
+       |        return ok(index.render("Your new application is ready."));
+       |    }
+       |}
+       |/app/views/index.scala.html
+       |@(message: String)
+       |<h1>@message</h1>
+       |/conf/routes
+       |GET / controllers.HomeController.index
+       |""".stripMargin,
+    2, // Two files because `conf/routes` generates a Java file.
+    initCommand = gradleVersion("6.8")
+  )
 }

--- a/tests/buildTools/src/test/scala/tests/GradleDefaultJvmLanguageCompileSpecSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleDefaultJvmLanguageCompileSpecSuite.scala
@@ -1,0 +1,29 @@
+package tests
+
+import scala.jdk.CollectionConverters._
+
+import munit.FunSuite
+import munit.TestOptions
+
+class GradleDefaultJvmLanguageCompileSpecSuite extends FunSuite {
+  val pluginpath = System.getProperty("semanticdb.pluginpath")
+  def check(
+      options: TestOptions,
+      original: List[String],
+      expected: List[String]
+  ): Unit = {
+    test(options) {
+      val obtained =
+        new GradleDefaultJvmLanguageCompileSpec(original)
+          .getCompileClasspath
+          .asScala
+          .map(_.toString)
+          .toList
+      assertEquals(obtained, expected)
+    }
+  }
+
+  check("empty", List(), List(pluginpath))
+  check("non-empty", List("foo"), List("foo", pluginpath))
+
+}

--- a/tests/buildTools/src/test/scala/tests/GradleJavaCompilerArgumentsBuilderSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleJavaCompilerArgumentsBuilderSuite.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters._
 import munit.FunSuite
 import munit.TestOptions
 
-class GradleOptionsBuilderSuite extends FunSuite {
+class GradleJavaCompilerArgumentsBuilderSuite extends FunSuite {
   val targetroot = System.getProperty("semanticdb.targetroot")
   val sourceroot = System.getProperty("semanticdb.sourceroot")
   val pluginpath = System.getProperty("semanticdb.pluginpath")
@@ -19,7 +19,8 @@ class GradleOptionsBuilderSuite extends FunSuite {
       expected: List[String]
   ): Unit = {
     test(options) {
-      val obtained = new GradleOptionsBuilder(original).build().asScala.toList
+      val obtained =
+        new GradleJavaCompilerArgumentsBuilder(original).build().asScala.toList
       assertEquals(obtained, expected)
     }
   }


### PR DESCRIPTION
Previously, the `index` command didn't work with Gradle projects that
use the Playframework plugin. The codebase would compile, but no LSIF
index would be created. Now, everything should work as expected.

The problem was that the Playframework plugin uses the Scala plugin to
compile auto-generated template and routes files. The Scala plugin runs
Zinc (Scala incremental compiler) in a daemon process behind the scenes
so it ignores the `javac` fork settings that `lsif-java index` adds to
the build.

The fix is to enable the SemanticDB Java agent on the Zinc daemon
process and to add one more injection point to ensure that the
SemanticDB compiler plugin is always on the classpath for all projects.

Fixes #170