### PR TITLE
add support for binary operator trees in annotations

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
@@ -315,6 +315,12 @@ public class SignatureFormatter {
         throw new IllegalArgumentException(
             "unexpected apply tree function " + tree.getApplyTree().getFunction());
       }
+    } else if (tree.hasBinopTree()) {
+      return formatTree(tree.getBinopTree().getLhs())
+          + " "
+          + formatBinaryOperator(tree.getBinopTree().getOp())
+          + " "
+          + formatTree(tree.getBinopTree().getRhs());
     }
 
     throw new IllegalArgumentException("tree was of unexpected type " + tree);
@@ -341,6 +347,52 @@ public class SignatureFormatter {
       return '"' + constant.getStringConstant().getValue() + '"';
     }
     throw new IllegalArgumentException("constant was not of known type " + constant);
+  }
+
+  private String formatBinaryOperator(BinaryOperator op) {
+    switch (op) {
+      case PLUS:
+        return "+";
+      case MINUS:
+        return "-";
+      case MULTIPLY:
+        return "*";
+      case DIVIDE:
+        return "/";
+      case REMAINDER:
+        return "%";
+      case GREATER_THAN:
+        return ">";
+      case LESS_THAN:
+        return "<";
+      case AND:
+        return "&";
+      case XOR:
+        return "^";
+      case OR:
+        return "|";
+      case CONDITIONAL_AND:
+        return "&&";
+      case CONDITIONAL_OR:
+        return "||";
+      case SHIFT_LEFT:
+        return "<<";
+      case SHIFT_RIGHT:
+        return ">>";
+      case SHIFT_RIGHT_UNSIGNED:
+        return ">>>";
+      case EQUAL_TO:
+        return "==";
+      case NOT_EQUAL_TO:
+        return "!=";
+      case GREATER_THAN_EQUAL:
+        return ">=";
+      case LESS_THAN_EQUAL:
+        return "<=";
+      case UNRECOGNIZED:
+        throw new IllegalArgumentException("unexpected binary operator " + op);
+    }
+    return null;
   }
 
   private String formatType(Type type) {

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -194,6 +194,7 @@ message Tree {
     // -- OUT OF SPEC -- //
     AnnotationTree annotation_tree = 9;
     AssignTree assign_tree = 10;
+    BinaryOperatorTree binop_tree = 11;
     // -- OUT OF SPEC -- //
   }
 }
@@ -229,6 +230,34 @@ message AnnotationTree {
 message AssignTree {
     Tree lhs = 1;
     Tree rhs = 2;
+}
+
+message BinaryOperatorTree {
+  Tree lhs = 1;
+  BinaryOperator op = 2;
+  Tree rhs = 3;
+}
+
+enum BinaryOperator {
+  PLUS = 0;
+  MINUS = 1;
+  MULTIPLY = 2;
+  DIVIDE = 3;
+  REMAINDER = 4;
+  GREATER_THAN = 5;
+  LESS_THAN = 6;
+  AND = 7;
+  XOR = 8;
+  OR = 9;
+  CONDITIONAL_AND = 10;
+  CONDITIONAL_OR = 11;
+  SHIFT_LEFT = 12;
+  SHIFT_RIGHT = 13;
+  SHIFT_RIGHT_UNSIGNED = 14;
+  EQUAL_TO = 15;
+  NOT_EQUAL_TO = 16;
+  GREATER_THAN_EQUAL = 17;
+  LESS_THAN_EQUAL = 18;
 }
 // -- OUT OF SPEC -- //
 

--- a/tests/minimized/src/main/java/minimized/InnerClasses.java
+++ b/tests/minimized/src/main/java/minimized/InnerClasses.java
@@ -4,6 +4,11 @@ public class InnerClasses {
 
   private final int exampleField;
 
+  private static final String STRING = "asdf";
+
+  private static final int top = 5;
+  private static final int bottom = 10;
+
   public InnerClasses(int exampleField) {
     this.exampleField = exampleField;
   }
@@ -18,7 +23,14 @@ public class InnerClasses {
     B apply(A a);
   }
 
+  public @interface InnerAnnotation {
+    int value();
+  }
+
+  @SuppressWarnings(STRING + " ")
+  @InnerAnnotation(top / bottom)
   public static class InnerStaticClass {
+
     public static void innerStaticMethod() {}
   }
 

--- a/tests/snapshots/src/main/generated/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/minimized/InnerClasses.java
@@ -6,6 +6,15 @@ public class InnerClasses {
   private final int exampleField;
 //                  ^^^^^^^^^^^^ definition minimized/InnerClasses#exampleField. private final int exampleField
 
+  private static final String STRING = "asdf";
+//                     ^^^^^^ reference java/lang/String#
+//                            ^^^^^^ definition minimized/InnerClasses#STRING. private static final String STRING
+
+  private static final int top = 5;
+//                         ^^^ definition minimized/InnerClasses#top. private static final int top
+  private static final int bottom = 10;
+//                         ^^^^^^ definition minimized/InnerClasses#bottom. private static final int bottom
+
   public InnerClasses(int exampleField) {
 //       ^^^^^^^^^^^^ definition minimized/InnerClasses#`<init>`(). public InnerClasses(int exampleField)
 //                        ^^^^^^^^^^^^ definition local0 int exampleField
@@ -36,9 +45,23 @@ public class InnerClasses {
 //            ^ definition local1 A a
   }
 
+  public @interface InnerAnnotation {
+//                  ^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerAnnotation# public @interface InnerAnnotation
+    int value();
+//      ^^^^^ definition minimized/InnerClasses#InnerAnnotation#value(). public abstract int value()
+  }
+
+  @SuppressWarnings(STRING + " ")
+// ^^^^^^^^^^^^^^^^ reference java/lang/SuppressWarnings#
+//                  ^^^^^^ reference minimized/InnerClasses#STRING.
+  @InnerAnnotation(top / bottom)
+// ^^^^^^^^^^^^^^^ reference minimized/InnerClasses#InnerAnnotation#
+//                 ^^^ reference minimized/InnerClasses#top.
+//                       ^^^^^^ reference minimized/InnerClasses#bottom.
   public static class InnerStaticClass {
-//                    ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass# public static class InnerStaticClass
+//                    ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass# @SuppressWarnings(STRING + " ") @InnerAnnotation(top / bottom) public static class InnerStaticClass
 //                    ^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#`<init>`(). public InnerStaticClass()
+
     public static void innerStaticMethod() {}
 //                     ^^^^^^^^^^^^^^^^^ definition minimized/InnerClasses#InnerStaticClass#innerStaticMethod(). public static void innerStaticMethod()
   }


### PR DESCRIPTION
Previously, lsif-java would throw an exception for annotations in the form such as `@Annotation(IDENT  + literal)` or any other binary operation AST.

This PR adds more to be upstreamed in https://github.com/scalameta/scalameta/pull/2281

Closes #178 