### PR TITLE
Add server to host sources of published Java libraries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ test-report.json
 dump.lsif
 
 ./generated
+/sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8-jdk-alpine
+COPY bin/coursier coursier
+RUN apk add --no-cache git curl \
+    && git config --global user.email "you@example.com" \
+    && git config --global user.name "Your Name" \
+    && git config --global http.postBuffer 1048576000 \
+    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
+    && chmod +x /src \
+    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:0.5.0-12-69905fcb-SNAPSHOT -o /packagehub
+ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
+ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,11 @@
+FROM openjdk:8-jdk-alpine
+COPY bin/coursier coursier
+RUN apk add --no-cache git curl \
+    && git config --global user.email "you@example.com" \
+    && git config --global user.name "Your Name" \
+    && git config --global http.postBuffer 1048576000 \
+    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
+    && chmod +x /src \
+    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:VERSION -o /packagehub
+ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
+ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
@@ -167,6 +167,7 @@ class LsifBuildTool(index: IndexCommand) extends BuildTool("LSIF", index) {
   /** Recursively collects all Java files in the working directory */
   private def collectAllJavaFiles(dir: Path): List[Path] = {
     val javaPattern = FileSystems.getDefault.getPathMatcher("glob:**.java")
+    val moduleInfo = Paths.get("module-info.java")
     val buf = ListBuffer.empty[Path]
     Files.walkFileTree(
       dir,
@@ -184,7 +185,7 @@ class LsifBuildTool(index: IndexCommand) extends BuildTool("LSIF", index) {
             file: Path,
             attrs: BasicFileAttributes
         ): FileVisitResult = {
-          if (javaPattern.matches(file)) {
+          if (javaPattern.matches(file) && !file.endsWith(moduleInfo)) {
             buf += file
           }
           FileVisitResult.CONTINUE

--- a/packagehub/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/packagehub/src/main/resources/db/migration/V1__Create_tables.sql
@@ -1,0 +1,7 @@
+CREATE TABLE packages (
+ id VARCHAR(1000) NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE indexed_packages (
+ id VARCHAR(1000) NOT NULL PRIMARY KEY
+);

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/EmptyJsonCodec.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/EmptyJsonCodec.scala
@@ -1,0 +1,22 @@
+package com.sourcegraph.packagehub
+
+import moped.json.DecodingContext
+import moped.json.ErrorResult
+import moped.json.JsonCodec
+import moped.json.JsonElement
+import moped.json.JsonString
+import moped.json.Result
+import moped.macros.ClassShape
+import moped.reporters.Diagnostic
+
+/**
+ * Codec that always fails the decoding step.
+ *
+ * Useful for types that cannot be configured from the command-line.
+ */
+class EmptyJsonCodec[T] extends JsonCodec[T] {
+  def decode(context: DecodingContext): Result[T] =
+    ErrorResult(Diagnostic.error(s"not supported: $context"))
+  def encode(value: T): JsonElement = JsonString(value.toString())
+  def shape: ClassShape = ClassShape.empty
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/Package.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/Package.scala
@@ -1,0 +1,120 @@
+package com.sourcegraph.packagehub
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.util.control.NonFatal
+
+import com.sourcegraph.lsif_java.Dependencies
+import coursier.core.Dependency
+import coursier.core.Module
+import coursier.core.ModuleName
+import coursier.core.Organization
+import ujson.Obj
+
+/**
+ * Package represents a published library such as a Java artifact, or the JDK.
+ *
+ * @param id
+ *   unique representation for this package that does not include the forward
+ *   slash character. Can be used as the primary key in a relational database.
+ *   Should ideally be human-readable and be easy to parse.
+ * @param path
+ *   relative URL of this package.
+ */
+sealed abstract class Package(
+    val id: String,
+    val path: String,
+    val version: String
+) {
+  def toJsonRepo: Obj = Obj("Name" -> path, "URI" -> s"/repos/$path")
+  def relativePath: Path = Paths.get(path)
+}
+object Package {
+  def jdk(version: String): JdkPackage = {
+    JdkPackage(version)
+  }
+  def maven(org: String, name: String, version: String): MavenPackage = {
+    MavenPackage(
+      Dependency(
+        Module(Organization(org), ModuleName(name), Map.empty),
+        version
+      )
+    )
+  }
+  def parse(value: String): Package = {
+    value match {
+      case s"jdk:$version" =>
+        JdkPackage(version)
+      case s"maven:$library" =>
+        val Right(dep) = Dependencies.parseDependencyEither(library)
+        MavenPackage(dep)
+    }
+  }
+  def fromPath(path: List[String]): Option[(Package, List[String])] =
+    path match {
+      case "maven" :: org :: name :: version :: requestPath =>
+        Some(Package.maven(org, name, version) -> requestPath)
+      case "jdk" :: version :: requestPath =>
+        Some(Package.jdk(version) -> requestPath)
+      case _ =>
+        None
+    }
+  def fromString(value: String, coursier: String): Either[String, Package] = {
+    value match {
+      case s"jdk:$version" =>
+        val exit = os
+          .proc(coursier, "java-home", "--jvm", version)
+          .call(check = false)
+        if (exit.exitCode == 0)
+          Right(JdkPackage(version))
+        else
+          Left(exit.out.trim())
+      case s"maven:$library" =>
+        Dependencies
+          .parseDependencyEither(library)
+          .flatMap { dep =>
+            try {
+              // Report an error if the dependency can't be resolved.
+              Dependencies.resolveProvidedDeps(dep)
+              Right(MavenPackage(dep))
+            } catch {
+              case NonFatal(e) =>
+                Left(e.getMessage())
+            }
+          }
+      case other =>
+        Left(
+          s"unsupported package '$other'. To fix this problem, use a valid syntax " +
+            s"such as 'maven:ORGANIZATION:ARTIFACT_NAME_VERSION' for Java libraries."
+        )
+    }
+  }
+}
+
+/**
+ * A Java library that is published "Maven style".
+ *
+ * The most widely used Maven package host is "Maven Central"
+ * https://search.maven.org/. Most companies self-host an Artifactory instance
+ * to publish internal libraries and to proxy Maven Central.
+ */
+case class MavenPackage(dep: Dependency)
+    extends Package(
+      s"maven:${dep.module.repr}:${dep.version}",
+      s"maven/${dep.module.organization.value}/${dep.module.name.value}/${dep.version}",
+      dep.version
+    ) {
+  def repr = id.stripPrefix("maven:")
+}
+
+/**
+ * The Java standard library.
+ *
+ * The sources of the Java standard library are typically available under
+ * JAVA_HOME.
+ */
+case class JdkPackage(override val version: String)
+    extends Package(s"jdk:${version}", s"jdk/${version}", version) {
+  def repr = id.stripPrefix("jdk:")
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
@@ -1,0 +1,253 @@
+package com.sourcegraph.packagehub
+
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.PrintStream
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.BasicFileAttributes
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.io.FileIO
+import scala.meta.io.AbsolutePath
+
+import castor.Context
+import castor.SimpleActor
+import com.sourcegraph.io.DeleteVisitor
+import com.sourcegraph.lsif_java.Dependencies
+import com.sourcegraph.lsif_java.LsifJava
+import coursier.core.Dependency
+import moped.reporters.ConsoleReporter
+import os.Shellable
+import os.SubProcess
+import ujson.Arr
+import ujson.Bool
+import ujson.Obj
+
+/**
+ * Actor that creates git repos from package sources and (optionally LSIF
+ * indexes the sources.
+ *
+ * This class is implemented as an actor in order to support the use-case:
+ * "schedule an LSIF index job for this package after 1 minute". We don't care
+ * about the return value of that scheduled LSIF index job so the "fire and
+ * forget" nature of actors is OK.
+ */
+class PackageActor(
+    src: String,
+    coursier: String,
+    store: PackageStore,
+    packagehubUrl: String,
+    val dir: Path,
+    val addr: Int = 3434
+)(implicit ctx: Context, log: cask.Logger)
+    extends SimpleActor[Package] {
+  createGitConfig()
+
+  def run(msg: Package): Unit = {
+    lsifIndex(msg, lsifUpload = true)
+  }
+  private def tmpDir = dir.resolve("lsif-java-tmp")
+  private var serveGit = Option.empty[SubProcess]
+  private def createGitConfig(): Unit = {
+    def setConfig(key: String, value: String): Unit = {
+      val result = os.proc("git", "config", "--get", key).call(check = false)
+      if (result.exitCode != 0) {
+        os.proc("git", "config", "--global", key, value).call()
+      }
+    }
+    setConfig("user.name", "lsif-java")
+    setConfig("user.email", "lsif-java@sourcegraph.com")
+  }
+  def lsifIndex(msg: Package, lsifUpload: Boolean): Path = {
+    commitSources(msg)
+    val dump = indexClasspathArtifact(msg)
+    if (lsifUpload) {
+      os.proc(src, "login").call(stdout = os.Pipe, stderr = os.Pipe)
+      os.proc(src, "lsif", "upload", "--no-progress", "--repo", msg.path)
+        .call(
+          stdout = os.Pipe,
+          stderr = os.Pipe,
+          cwd = os.Path(packageDir(msg))
+        )
+      store.addIndexedPackage(msg)
+    }
+    dump
+  }
+
+  def commitSources(pkg: Package): Unit = {
+    if (isCached(pkg))
+      return
+    pkg match {
+      case JdkPackage(version) =>
+        val home = os
+          .proc(coursier, "java-home", "--jvm", version)
+          .call()
+          .out
+          .trim()
+        val srcs = List(
+          Paths.get(home, "src.zip"),
+          Paths.get(home, "lib", "src.zip")
+        )
+        srcs.find(Files.isRegularFile(_)) match {
+          case Some(src) =>
+            commitSourcesArtifact(pkg, src)
+          case None =>
+            throw new IllegalArgumentException(s"no such files: $srcs")
+        }
+      case mvn @ MavenPackage(dep) =>
+        val deps = Dependencies
+          .resolveDependencies(List(mvn.repr), transitive = false)
+        indexDeps(mvn, deps)
+    }
+  }
+
+  private def indexDeps(dep: MavenPackage, deps: Dependencies): Unit = {
+    deps
+      .sourcesResult
+      .fullDetailedArtifacts
+      .foreach {
+        case (dep, _, _, Some(file)) =>
+          val dependency = s"${dep.module.repr}:${dep.version}"
+          commitSourcesArtifact(MavenPackage(dep), file.toPath)
+        case _ =>
+      }
+  }
+
+  private def packageId(dep: Dependency): String = {
+    s"${dep.module.organization.value}:${dep.module.name.value}:${dep.version}"
+  }
+  private def packageRelDir(dep: Dependency): Path = {
+    Paths.get(dep.module.organization.value, dep.module.name.value, dep.version)
+  }
+  def packageTmpDir(dep: Dependency): Path = {
+    tmpDir.resolve(packageRelDir(dep))
+  }
+  def packageDir(dep: Dependency): Path = {
+    Paths.get(dep.module.organization.value, dep.module.name.value, dep.version)
+  }
+  def packageDir(pkg: Package): Path = {
+    dir.resolve(pkg.relativePath)
+  }
+  private def collectAllJavaFiles(dir: Path): List[Path] = {
+    val javaPattern = FileSystems.getDefault.getPathMatcher("glob:**.java")
+    val buf = ListBuffer.empty[Path]
+    Files.walkFileTree(
+      dir,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(
+            file: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = {
+          if (javaPattern.matches(file)) {
+            buf += file
+          }
+          FileVisitResult.CONTINUE
+        }
+        override def visitFileFailed(
+            file: Path,
+            exc: IOException
+        ): FileVisitResult = FileVisitResult.CONTINUE
+      }
+    )
+    buf.toList
+  }
+
+  def indexClasspathArtifact(pkg: Package): Path = {
+    val sourceroot = packageDir(pkg)
+    val dump = sourceroot.resolve("dump.lsif")
+    val out = new ByteArrayOutputStream
+    val ps =
+      new PrintStream(out) {
+        override def toString(): String = "foobar"
+      }
+    val env = LsifJava.app.env.withStandardOutput(ps).withStandardError(ps)
+    val app = LsifJava.app.withEnv(env).withReporter(ConsoleReporter(ps))
+    val index = app.run(
+      List("index", "--cwd", sourceroot.toString(), "--output", dump.toString())
+    )
+    if (index != 0) {
+      ps.flush()
+      sys.error(out.toString())
+    }
+    dump
+  }
+
+  private def commitSourcesArtifact(dep: Package, file: Path): Unit = {
+    val repo = packageDir(dep)
+    val date = "Thu Apr 8 14:24:52 2021 +0200"
+    def proc(command: String*) = {
+      os.proc(Shellable(command))
+        .call(cwd = os.Path(repo), env = Map("GIT_COMMITTER_DATE" -> date))
+    }
+    Files.createDirectories(repo)
+    proc("git", "init")
+    val gitDir = repo.resolve(".git")
+    val deleteNonGitFiles =
+      new DeleteVisitor(deleteFile = file => !file.startsWith(gitDir))
+    Files.walkFileTree(repo, deleteNonGitFiles)
+    FileIO.withJarFileSystem(AbsolutePath(file), create = false, close = true) {
+      root =>
+        FileIO
+          .listAllFilesRecursively(root)
+          .foreach { file =>
+            val bytes = Files.readAllBytes(file.toNIO)
+            val rel = file.toRelative(root).toURI(false).toString()
+            val out = repo.resolve(rel)
+            Files.createDirectories(out.getParent())
+            Files.write(
+              out,
+              bytes,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.TRUNCATE_EXISTING
+            )
+          }
+        Files.walkFileTree(
+          root.toNIO,
+          new SimpleFileVisitor[Path] {
+            override def visitFile(
+                file: Path,
+                attrs: BasicFileAttributes
+            ): FileVisitResult = {
+              FileVisitResult.CONTINUE
+            }
+          }
+        )
+    }
+    val message = s"Version ${dep.version}"
+    Files.write(
+      repo.resolve(".gitignore"),
+      List("dump.lsif", packagehubCached).asJava
+    )
+    val build = Obj()
+    val dependencies =
+      dep match {
+        case MavenPackage(dep) =>
+          build("dependencies") = Arr(packageId(dep))
+        case _ =>
+          build("indexJdk") = Bool(false)
+      }
+    Files.write(
+      repo.resolve("lsif-java.json"),
+      List(ujson.write(build, indent = 2)).asJava
+    )
+    Files.write(repo.resolve(packagehubCached), List[String]().asJava)
+    proc("git", "add", ".")
+    proc("git", "commit", "--allow-empty", "--date", date, "-m", message)
+    proc("git", "tag", "-f", "-m", message, s"v${dep.version}")
+  }
+
+  private val packagehubCached = "packagehub_cached"
+
+  private def isCached(pkg: Package): Boolean = {
+    Files.exists(packageDir(pkg).resolve(packagehubCached))
+  }
+
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageHub.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageHub.scala
@@ -1,0 +1,113 @@
+package com.sourcegraph.packagehub
+
+import java.nio.file.Path
+import java.time
+import java.time.Duration
+
+import scala.concurrent.Await
+import scala.concurrent.Promise
+import scala.concurrent.duration
+
+import cask.main.Main
+import cask.util.Logger
+import castor.Context
+import com.sourcegraph.lsif_java.BuildInfo
+import io.undertow.Undertow
+import moped.annotations.Description
+import moped.annotations.ExampleValue
+import moped.annotations.Hidden
+import moped.cli.Application
+import moped.cli.Command
+import moped.cli.CommandParser
+import moped.commands.HelpCommand
+import moped.commands.VersionCommand
+import moped.json.DecodingContext
+import moped.json.JsonString
+import moped.json.Result
+
+/**
+ * Entrypoint to start the PackageHub server.
+ */
+case class PackageHub(
+    port: String = "8080",
+    host: String = "localhost",
+    verbose: Boolean = false,
+    dir: Option[Path] = None,
+    app: Application = Application.default,
+    @Hidden() cancelToken: Promise[Unit] = Promise(),
+    ctx: Context = castor.Context.Simple.global,
+    postgres: PostgresOptions = PostgresOptions(),
+    @Description("URL of the PackageHub server") packagehubUrl: String =
+      "https://packagehub-ohcltxh6aq-uc.a.run.app",
+    @Description("Path to the src-cli binary") src: String = "src",
+    @Description("Path to the coursier binary") coursier: String = "coursier",
+    @Description("If enabled, schedule an LSIF index after the given delay")
+    @ExampleValue("--auto-index-delay=PT1M") autoIndexDelay: Option[Duration] =
+      None
+) extends Command {
+  val log = new Logger.Console()
+  def run(): Int = {
+    val store: PackageStore =
+      postgres.toDataSource(app.reporter) match {
+        case Some(source) =>
+          app.info("Connected to PostgreSQL database")
+          new PostgresPackageStore(source)
+        case None =>
+          new InMemoryPackageStore
+      }
+    if (!verbose)
+      Main.silenceJboss()
+    val actor =
+      new PackageActor(
+        src,
+        coursier,
+        store,
+        packagehubUrl,
+        dir.getOrElse(app.env.cacheDirectory)
+      )(ctx, log)
+    val routes = new PackageRoutes(this, actor, store, log)(ctx)
+    val server = Undertow
+      .builder
+      .addHttpListener(routes.port, host)
+      .setHandler(routes.defaultHandler)
+      .build()
+    server.start()
+    app.info(s"Listening on http://$host:$port")
+    try Await.result(cancelToken.future, duration.Duration.Inf)
+    finally server.stop()
+    0
+  }
+
+  def isEnv(name: String): Boolean = app.env.environmentVariables.contains(name)
+
+}
+
+object PackageHub {
+  implicit val promiseCodec = new EmptyJsonCodec[Promise[Unit]]
+  implicit val contextCodec = new EmptyJsonCodec[Context]
+  implicit val durationCodec =
+    new EmptyJsonCodec[Duration] {
+      override def decode(context: DecodingContext): Result[Duration] =
+        context.json match {
+          case JsonString(value) =>
+            Result.fromUnsafe(() => Duration.parse(value))
+          case _ =>
+            super.decode(context)
+        }
+    }
+  implicit val parser = CommandParser.derive(PackageHub())
+  val app = Application
+    .fromName(
+      "packagehub",
+      BuildInfo.version,
+      commands = List(
+        CommandParser[HelpCommand],
+        CommandParser[VersionCommand],
+        CommandParser[PackageHub]
+      )
+    )
+    .withIsSingleCommand(true)
+  def main(args: Array[String]): Unit = {
+    app.runAndExitIfNonZero(args.toList)
+  }
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageRoutes.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageRoutes.scala
@@ -1,0 +1,249 @@
+package com.sourcegraph.packagehub
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.nio.file.Files
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NoStackTrace
+
+import cask.Response.Data
+import cask.model.Request
+import cask.model.Response
+import cask.model.StaticFile
+import cask.model.Status
+import cask.util.Logger
+import castor.Context
+import os.Internals
+import os.Shellable
+import os.SubProcess
+import ujson.Arr
+import ujson.Obj
+import ujson.Value
+
+/**
+ * The HTTP routes that are served by PackageHub.
+ */
+class PackageRoutes(
+    server: PackageHub,
+    actor: PackageActor,
+    store: PackageStore,
+    override implicit val log: Logger
+)(implicit ctx: Context)
+    extends cask.MainRoutes {
+  override def host: String = server.host
+  override def port: Int = server.port.toInt
+  override def verbose: Boolean = server.verbose
+
+  // ===========================================================
+  // The following endpoints are required by src-cli "serve-git"
+  // ===========================================================
+
+  @cask.get("/v1/list-repos")
+  def listRepos(): ujson.Value = {
+    val items = Arr.from(store.allPackages().map(_.toJsonRepo))
+    Obj("Items" -> items)
+  }
+
+  @cask.route("/repos", methods = Seq("get", "post"), subpath = true)
+  def repoSubpath(
+      request: cask.Request,
+      service: Seq[String] = Nil
+  ): cask.Response[Data] = {
+    Package.fromPath(request.remainingPathSegments.toList) match {
+      case Some((pkg, requestPath)) =>
+        repoSubpath(request, pkg, requestPath)
+      case _ =>
+        badRequest(
+          "invalid repo name (want /repos/maven/ORGANIZATION/NAME/VERSION/...)"
+        )
+    }
+  }
+
+  // =====================================================================
+  // The following endpoints are not required by src-cli "serve-git". They
+  // monstly exist for debugging purposes and to manually trigger stuff.
+  // =====================================================================
+
+  @cask.get("/packagehub/packages")
+  def packages(): ujson.Value = Arr.from(store.allPackages().map(_.id))
+
+  @cask.postJson("/packagehub/packages")
+  def addPackage(packages: Seq[String]): cask.Response[Value] = {
+    val parsed = packages.toList.map(parsePackage)
+    val ok = parsed.collect { case Right(value) =>
+      value
+    }
+    store.addPackages(ok)
+    val errors = parsed.collect { case Left(value) =>
+      value
+    }
+    cask.Response(Obj("errors" -> Arr.from(errors)))
+  }
+
+  @cask.post("/packagehub/package/:pkg")
+  def addPackage(pkg: String): cask.Response[Value] = {
+    withPackage(pkg) { p =>
+      store.addPackage(p)
+    }
+  }
+
+  @cask.get("/packagehub/indexed-packages")
+  def indexedPackages(): ujson.Value =
+    Arr.from(store.allIndexedPackages().map(_.id))
+
+  @cask.post("/packagehub/index-package/:pkg")
+  def indexPackage(
+      pkg: String,
+      upload: Boolean = false
+  ): cask.Response[Data] = {
+    parsePackage(pkg) match {
+      case Left(error) =>
+        badRequest(error)
+      case Right(pkg) =>
+        store.addPackage(pkg)
+        if (!store.isIndexedPackage(pkg)) {
+          val dump = actor.lsifIndex(pkg, lsifUpload = upload)
+          val size = Files.size(dump)
+          val verb =
+            if (upload)
+              "uploaded"
+            else
+              "generated"
+          okResponse(s"$verb index for package '${pkg.id}'")
+        } else {
+          okResponse(s"package '${pkg.id}' is already indexed")
+        }
+    }
+  }
+
+  @cask.post("/packagehub/indexed-package/:pkg")
+  def addIndexedPackage(pkg: String): cask.Response[Value] = {
+    withPackage(pkg) { p =>
+      store.addIndexedPackage(p)
+    }
+  }
+
+  private def repoSubpath(
+      request: cask.Request,
+      pkg: Package,
+      requestPath: List[String]
+  ): cask.Response[Data] = {
+    val path = actor.packageDir(pkg)
+    actor.commitSources(pkg)
+    val args = ListBuffer[String](
+      "git",
+      // Partial clones/fetches
+      "-c",
+      "uploadpack.allowFilter=true",
+      // Can fetch any object. Used in case of race between a resolve ref and a
+      // fetch of a commit. Safe to do, since this is only used internally.
+      "-c",
+      "uploadpack.allowAnySHA1InWant=true",
+      "upload-pack",
+      "--stateless-rpc"
+    )
+    val headers = mutable.Map.empty[String, String]
+    val bytes = new ByteArrayOutputStream
+    val isStaticFile: Boolean =
+      if (requestPath.endsWith(List("info", "refs"))) {
+        server
+          .autoIndexDelay
+          .foreach { delay =>
+            ctx.scheduleMsg(actor, pkg, delay)
+          }
+        headers("Content-Type") = "application/x-git-upload-pack-advertisement"
+        bytes.write(packetWrite("# service=git-upload-pack\n"))
+        bytes.write("0000".getBytes())
+        args += "--advertise-refs"
+        false
+      } else if (requestPath.endsWith(List("git-upload-pack"))) {
+        headers("Content-Type") = "application/x-git-upload-pack-result"
+        false
+      } else {
+        true
+      }
+    if (isStaticFile) {
+      val file = path.resolve(requestPath.mkString("/"))
+      if (Files.isRegularFile(file)) {
+        val text = new String(Files.readAllBytes(file))
+        StaticFile(file.toString(), Nil)
+      } else if (Files.isDirectory(file)) {
+        val ls = file.toFile().list().map(f => s"<li>$f</li>")
+        ls.mkString("<ul>\n . ", "\n ", "</ul>")
+      } else {
+        notFound(s"no such file: $file")
+      }
+    } else {
+      val env = mutable.Map.empty[String, String]
+      Option(request.exchange.getRequestHeaders().getLast("Git-Protocol"))
+        .foreach { protocol =>
+          env("GIT_PROTOCOL") = protocol
+        }
+      args += path.toString()
+      val result = os
+        .proc(Shellable(args.toSeq))
+        .spawn(
+          env = env.toMap,
+          stdout = os.Pipe,
+          stderr = os.Pipe,
+          stdin = request.bytes
+        )
+      Response(new ProcessData(result, request), 200, headers.toSeq)
+    }
+  }
+
+  private class ProcessData(proc: SubProcess, request: Request) extends Data {
+    def write(out: OutputStream): Unit = {
+      Internals.transfer(proc.stdout, out)
+      proc.waitFor()
+      val exit = proc.exitCode()
+      if (exit != 0) {
+        val path = Obj(
+          "exit" -> exit,
+          "path" -> request.exchange.getRequestPath(),
+          "method" -> request.exchange.getRequestMethod().toString()
+        )
+        throw new RuntimeException(ujson.write(path)) with NoStackTrace
+      }
+    }
+    def headers: Seq[(String, String)] = Nil
+  }
+
+  private def packetWrite(str: String): Array[Byte] = {
+    var s = Integer.toString(str.length() + 4, 16)
+    val modulo = s.length() % 4
+    if (modulo != 0) {
+      val padding = "0" * (4 - modulo)
+      s = padding + s
+    }
+    (s + str).getBytes()
+  }
+
+  private def parsePackage(pkg: String) =
+    Package.fromString(pkg, server.coursier)
+
+  private def withPackage(
+      pkg: String
+  )(fn: Package => Unit): cask.Response[Value] = {
+    parsePackage(pkg) match {
+      case Left(error) =>
+        badRequest(error)
+      case Right(p) =>
+        fn(p)
+        cask.Response(Obj())
+    }
+  }
+
+  private def badRequest(error: Value): Response[Value] =
+    errorResponse(error, Status.BadRequest.code)
+  private def notFound(error: Value): Response[Value] =
+    errorResponse(error, Status.NotFound.code)
+  private def okResponse(result: String*): Response[Value] =
+    Response(Obj("message" -> Arr.from(result)))
+  private def errorResponse(error: Value, code: Int): Response[Value] =
+    Response(Obj("error" -> error), code, Nil, Nil)
+
+  initialize()
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageStore.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageStore.scala
@@ -1,0 +1,110 @@
+package com.sourcegraph.packagehub
+
+import java.sql.PreparedStatement
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.{util => ju}
+import javax.sql.DataSource
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+import org.flywaydb.core.Flyway
+
+/**
+ * Data storage for what packages to host.
+ */
+trait PackageStore {
+  def addPackages(pkg: List[Package]): Unit
+  final def addPackage(pkg: Package): Unit = addPackages(List(pkg))
+  def allPackages(): List[Package]
+
+  def addIndexedPackages(pkg: List[Package]): Unit
+  final def addIndexedPackage(pkg: Package): Unit =
+    addIndexedPackages(List(pkg))
+  def isIndexedPackage(pkg: Package): Boolean
+  def allIndexedPackages(): List[Package]
+}
+
+class InMemoryPackageStore extends PackageStore {
+  private def concurrentHashSet[T]: ju.Set[T] =
+    Collections.newSetFromMap(new ConcurrentHashMap[T, java.lang.Boolean])
+  val packages = new ConcurrentHashMap[String, Package]
+  val jdks = concurrentHashSet[String]
+  val indexedPackages = concurrentHashSet[String]
+
+  override def addPackages(pkgs: List[Package]): Unit = {
+    pkgs.foreach { pkg =>
+      packages.put(pkg.id, pkg)
+    }
+  }
+  override def allPackages(): List[Package] = packages.values.asScala.toList
+  override def addIndexedPackages(pkgs: List[Package]): Unit = {
+    pkgs.foreach { pkg =>
+      indexedPackages.add(pkg.id)
+    }
+  }
+  override def isIndexedPackage(pkg: Package): Boolean = {
+    indexedPackages.contains(pkg.id)
+  }
+  override def allIndexedPackages(): List[Package] =
+    indexedPackages.asScala.map(Package.parse).toList
+
+}
+
+class PostgresPackageStore(source: DataSource) extends PackageStore {
+  Flyway.configure().dataSource(source).load().migrate()
+
+  override def addPackages(pkgs: List[Package]): Unit = {
+    add("packages", pkgs)
+  }
+  override def allPackages(): List[Package] = {
+    all("packages")
+  }
+  override def addIndexedPackages(pkgs: List[Package]): Unit = {
+    add("indexed_packages", pkgs)
+  }
+  override def isIndexedPackage(pkg: Package): Boolean = {
+    withStatement("select id from indexed_packages where id = ?") { stat =>
+      stat.setString(1, pkg.id)
+      stat.executeQuery().next()
+    }
+  }
+  override def allIndexedPackages(): List[Package] = {
+    all("indexed_packages")
+  }
+
+  private def withStatement[T](query: String)(fn: PreparedStatement => T): T = {
+    Using
+      .Manager { use =>
+        val conn = use(source.getConnection())
+        val stat = use(conn.prepareStatement(query))
+        fn(stat)
+      }
+      .get
+  }
+
+  private def add(table: String, pkgs: List[Package]): Unit = {
+    withStatement(
+      s"INSERT into $table (id) VALUES (?) ON CONFLICT DO NOTHING"
+    ) { stat =>
+      pkgs.foreach { pkg =>
+        stat.setString(1, pkg.id)
+        stat.addBatch()
+      }
+      stat.executeBatch()
+    }
+  }
+
+  private def all(table: String): List[Package] = {
+    withStatement(s"SELECT id FROM $table") { stat =>
+      val rs = stat.executeQuery()
+      val buf = ListBuffer.empty[Package]
+      while (rs.next()) {
+        buf += Package.parse(rs.getString("id"))
+      }
+      buf.toList
+    }
+  }
+}

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PostgresOptions.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PostgresOptions.scala
@@ -1,0 +1,50 @@
+package com.sourcegraph.packagehub
+
+import javax.sql.DataSource
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import moped.reporters.Reporter
+
+final case class PostgresOptions(
+    url: String = "",
+    username: String = "",
+    password: String = ""
+) {
+  def toDataSource(reporter: Reporter): Option[DataSource] = {
+    if (url.isEmpty() || username.isEmpty() || password.isEmpty()) {
+      if (url.nonEmpty) {
+        reporter.warning(
+          "ignoring unused PostgresSQL URL. To fix this problem, ensure the username, password and URL are all configured."
+        )
+      }
+      if (username.nonEmpty) {
+        reporter.warning(
+          "ignoring unused PostgresSQL username. To fix this problem, ensure the username, password and URL are all configured."
+        )
+      }
+      if (password.nonEmpty) {
+        reporter.warning(
+          "ignoring unused PostgresSQL password. To fix this problem, ensure the username, password and URL are all configured."
+        )
+      }
+      None
+    } else {
+      Class.forName("org.postgresql.Driver")
+      val config = new HikariConfig()
+      config.setUsername(username)
+      config.setPassword(password)
+      config.setJdbcUrl(url)
+      config.setMaximumPoolSize(5)
+      config.setMinimumIdle(5)
+      config.setConnectionTimeout(10000) // 10 seconds
+      config.setIdleTimeout(600000) // 10 minutes
+      config.setMaxLifetime(1800000) // 30 minutes
+      Some(new HikariDataSource(config))
+    }
+  }
+}
+
+object PostgresOptions {
+  implicit val codec = moped.macros.deriveCodec(PostgresOptions())
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@ addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.1.8")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 // sbt-jdi-tools appears to fix an error related to this message:
 // [error] (plugin / Compile / compileIncremental) java.lang.NoClassDefFoundError: com/sun/tools/javac/code/Symbol

--- a/sbt
+++ b/sbt
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 ./bin/coursier launch --jvm 11 sbt

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSignatures.java
@@ -113,6 +113,6 @@ public final class SemanticdbSignatures {
   }
 
   private Semanticdb.Type generateType(TypeMirror mirror) {
-    return mirror.accept(new SemanticdbTypeVisitor(cache, locals), null);
+    return new SemanticdbTypeVisitor(cache, locals).semanticdbType(mirror);
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTypeVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTypeVisitor.java
@@ -23,6 +23,11 @@ class SemanticdbTypeVisitor extends SimpleTypeVisitor8<Semanticdb.Type, Void> {
     this.locals = locals;
   }
 
+  public Semanticdb.Type semanticdbType(TypeMirror tpe) {
+    Semanticdb.Type result = super.visit(tpe);
+    return result == null ? UNRESOLVED_TYPE_REF : result;
+  }
+
   @Override
   public Semanticdb.Type visitDeclared(DeclaredType t, Void unused) {
     boolean isExistential =
@@ -31,11 +36,7 @@ class SemanticdbTypeVisitor extends SimpleTypeVisitor8<Semanticdb.Type, Void> {
     ArrayList<Semanticdb.Type> typeParams = new ArrayList<>();
     Semanticdb.Scope.Builder declarations = Semanticdb.Scope.newBuilder();
     for (TypeMirror type : t.getTypeArguments()) {
-      Semanticdb.Type visited = super.visit(type);
-      if (visited == null) {
-        visited = UNRESOLVED_TYPE_REF;
-      }
-      typeParams.add(visited);
+      typeParams.add(semanticdbType(type));
 
       if (type instanceof WildcardType) {
         Semanticdb.TypeSignature.Builder typeSig = Semanticdb.TypeSignature.newBuilder();
@@ -83,15 +84,11 @@ class SemanticdbTypeVisitor extends SimpleTypeVisitor8<Semanticdb.Type, Void> {
 
   @Override
   public Semanticdb.Type visitArray(ArrayType t, Void unused) {
-    Semanticdb.Type arrayComponentType = super.visit(t.getComponentType());
-    if (arrayComponentType == null) {
-      arrayComponentType = UNRESOLVED_TYPE_REF;
-    }
     return Semanticdb.Type.newBuilder()
         .setTypeRef(
             Semanticdb.TypeRef.newBuilder()
                 .setSymbol(ARRAY_SYMBOL)
-                .addTypeArguments(arrayComponentType))
+                .addTypeArguments(semanticdbType(t.getComponentType())))
         .build();
   }
 

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -203,6 +203,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   public Void visitIdentifier(IdentifierTree node, Void unused) {
     if (node instanceof JCTree.JCIdent) {
       JCTree.JCIdent ident = (JCTree.JCIdent) node;
+      if (ident.name == null || ident.sym == null) return null;
       if (ident.name.toString().equals("this") && ident.sym.getKind() != ElementKind.CONSTRUCTOR)
         return null;
       emitSymbolOccurrence(ident.sym, ident, Role.REFERENCE, CompilerRange.FROM_START_TO_END);
@@ -233,7 +234,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   public Void visitNewClass(NewClassTree node, Void unused) {
     if (node instanceof JCTree.JCNewClass) {
       JCTree.JCNewClass cls = (JCTree.JCNewClass) node;
-      if (!cls.type.tsym.isAnonymous()) {
+      if (cls.type != null && cls.type.tsym != null && !cls.type.tsym.isAnonymous()) {
         emitSymbolOccurrence(cls.constructor, cls, Role.REFERENCE, CompilerRange.FROM_TEXT_SEARCH);
       }
     }
@@ -388,7 +389,8 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
   private Semanticdb.AnnotationTree.Builder semanticdbAnnotation(JCTree.JCAnnotation annotation) {
     Semanticdb.AnnotationTree.Builder annotationBuilder = Semanticdb.AnnotationTree.newBuilder();
-    annotationBuilder.setTpe(new SemanticdbTypeVisitor(globals, locals).visit(annotation.type));
+    annotationBuilder.setTpe(
+        new SemanticdbTypeVisitor(globals, locals).semanticdbType(annotation.type));
 
     for (JCTree.JCExpression param : annotation.args) {
       Semanticdb.AssignTree.Builder parameterBuilder = Semanticdb.AssignTree.newBuilder();

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -81,6 +81,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
        |repositories { mavenCentral() }
        |dependencies { implementation "junit:junit:4.13.1" }
        |/src/main/java/Example.java
+       |import org.junit.Assert;
        |public class Example {}
        |/src/test/java/ExampleSuite.java
        |public class ExampleSuite {}
@@ -97,6 +98,8 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
        |    languageVersion = JavaLanguageVersion.of(8)
        |  }
        |}
+       |repositories { mavenCentral() }
+       |dependencies { implementation "junit:junit:4.13.1" }
        |/src/main/java/Example.java
        |public class Example {}
        |""".stripMargin,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyController.java
@@ -65,7 +65,7 @@ public abstract class AsyncEpoxyController extends EpoxyController {
 
   private static Handler getHandler(boolean enableAsync) {
 //               ^^^^^^^ reference _root_/
-//                       ^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#getHandler(). private static getHandler(boolean enableAsync)
+//                       ^^^^^^^^^^ definition com/airbnb/epoxy/AsyncEpoxyController#getHandler(). private static unresolved_type getHandler(boolean enableAsync)
 //                                          ^^^^^^^^^^^ definition local3 boolean enableAsync
     return enableAsync ? getAsyncBackgroundHandler() : MAIN_THREAD_HANDLER;
 //         ^^^^^^^^^^^ reference local3

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -616,7 +616,7 @@ public abstract class BaseEpoxyAdapter
    */
   public SpanSizeLookup getSpanSizeLookup() {
 //       ^^^^^^^^^^^^^^ reference _root_/
-//                      ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getSpanSizeLookup(). public getSpanSizeLookup()
+//                      ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/BaseEpoxyAdapter#getSpanSizeLookup(). public unresolved_type getSpanSizeLookup()
     return spanSizeLookup;
 //         ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#spanSizeLookup.
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Carousel.java
@@ -127,7 +127,7 @@ public class Carousel extends EpoxyRecyclerView {
 //       ^^^^^^^ reference androidx/annotation/NonNull#
         public SnapHelper buildSnapHelper(Context context) {
 //             ^^^^^^^^^^ reference _root_/
-//                        ^^^^^^^^^^^^^^^ definition local2 @Override @NonNull public buildSnapHelper(unresolved_type context)
+//                        ^^^^^^^^^^^^^^^ definition local2 @Override @NonNull public unresolved_type buildSnapHelper(unresolved_type context)
 //                                        ^^^^^^^ reference _root_/
 //                                                ^^^^^^^ definition local3 unresolved_type context
           return new LinearSnapHelper();
@@ -1145,7 +1145,7 @@ public class Carousel extends EpoxyRecyclerView {
 //   ^^^^^^^ reference androidx/annotation/NonNull#
     public abstract SnapHelper buildSnapHelper(Context context);
 //                  ^^^^^^^^^^ reference _root_/
-//                             ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#buildSnapHelper(). @NonNull public abstract buildSnapHelper(unresolved_type context)
+//                             ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/Carousel#SnapHelperFactory#buildSnapHelper(). @NonNull public abstract unresolved_type buildSnapHelper(unresolved_type context)
 //                                             ^^^^^^^ reference _root_/
 //                                                     ^^^^^^^ definition local69 unresolved_type context
   }

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAsyncUtil.java
@@ -77,7 +77,7 @@ public final class EpoxyAsyncUtil {
 // ^^^^^^^^^^ reference androidx/annotation/MainThread#
   public static Handler getAsyncBackgroundHandler() {
 //              ^^^^^^^ reference _root_/
-//                      ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#getAsyncBackgroundHandler(). @MainThread public static getAsyncBackgroundHandler()
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#getAsyncBackgroundHandler(). @MainThread public static unresolved_type getAsyncBackgroundHandler()
     // This is initialized lazily so we don't create the thread unless it will be used.
     // It isn't synchronized so it should only be accessed on the main thread.
     if (asyncBackgroundHandler == null) {
@@ -100,7 +100,7 @@ public final class EpoxyAsyncUtil {
    */
   public static Handler createHandler(Looper looper, boolean async) {
 //              ^^^^^^^ reference _root_/
-//                      ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#createHandler(). public static createHandler(unresolved_type looper, boolean async)
+//                      ^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#createHandler(). public static unresolved_type createHandler(unresolved_type looper, boolean async)
 //                                    ^^^^^^ reference _root_/
 //                                           ^^^^^^ definition local0 unresolved_type looper
 //                                                           ^^^^^ definition local1 boolean async
@@ -157,7 +157,7 @@ public final class EpoxyAsyncUtil {
    */
   public static Looper buildBackgroundLooper(String threadName) {
 //              ^^^^^^ reference _root_/
-//                     ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#buildBackgroundLooper(). public static buildBackgroundLooper(String threadName)
+//                     ^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyAsyncUtil#buildBackgroundLooper(). public static unresolved_type buildBackgroundLooper(String threadName)
 //                                           ^^^^^^ reference java/lang/String#
 //                                                  ^^^^^^^^^^ definition local3 String threadName
     HandlerThread handlerThread = new HandlerThread(threadName);

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -1326,7 +1326,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 // ^^^^^^^ reference androidx/annotation/NonNull#
   public SpanSizeLookup getSpanSizeLookup() {
 //       ^^^^^^^^^^^^^^ reference _root_/
-//                      ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#getSpanSizeLookup(). @NonNull public getSpanSizeLookup()
+//                      ^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyController#getSpanSizeLookup(). @NonNull public unresolved_type getSpanSizeLookup()
     return adapter.getSpanSizeLookup();
 //         ^^^^^^^ reference com/airbnb/epoxy/EpoxyController#adapter.
 //                 ^^^^^^^^^^^^^^^^^ reference com/airbnb/epoxy/BaseEpoxyAdapter#getSpanSizeLookup().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -170,7 +170,7 @@ public abstract class EpoxyModel<T> {
    */
   protected View buildView(@NonNull ViewGroup parent) {
 //          ^^^^ reference _root_/
-//               ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#buildView(). protected buildView(unresolved_type parent)
+//               ^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModel#buildView(). protected unresolved_type buildView(unresolved_type parent)
 //                          ^^^^^^^ reference androidx/annotation/NonNull#
 //                                  ^^^^^^^^^ reference _root_/
 //                                            ^^^^^^ definition local1 @NonNull unresolved_type parent

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -627,7 +627,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 // ^^^^^^^^ reference java/lang/Override#
   protected final ModelGroupHolder createNewHolder(@NonNull ViewParent parent) {
 //                ^^^^^^^^^^^^^^^^ reference _root_/
-//                                 ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#createNewHolder(). @Override protected final createNewHolder(unresolved_type parent)
+//                                 ^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyModelGroup#createNewHolder(). @Override protected final unresolved_type createNewHolder(unresolved_type parent)
 //                                                  ^^^^^^^ reference androidx/annotation/NonNull#
 //                                                          ^^^^^^^^^^ reference _root_/
 //                                                                     ^^^^^^ definition local65 @NonNull unresolved_type parent

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -383,7 +383,7 @@ public abstract class EpoxyTouchHelper {
      */
     public ItemTouchHelper andCallbacks(final DragCallbacks<U> callbacks) {
 //         ^^^^^^^^^^^^^^^ reference _root_/
-//                         ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#andCallbacks(). public andCallbacks(DragCallbacks<U> callbacks)
+//                         ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#andCallbacks(). public unresolved_type andCallbacks(DragCallbacks<U> callbacks)
 //                                            ^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#
 //                                                          ^ reference com/airbnb/epoxy/EpoxyTouchHelper#DragBuilder4#[U]
 //                                                             ^^^^^^^^^ definition local17 final DragCallbacks<U> callbacks
@@ -840,7 +840,7 @@ public abstract class EpoxyTouchHelper {
      */
     public ItemTouchHelper andCallbacks(final SwipeCallbacks<U> callbacks) {
 //         ^^^^^^^^^^^^^^^ reference _root_/
-//                         ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#andCallbacks(). public andCallbacks(SwipeCallbacks<U> callbacks)
+//                         ^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#andCallbacks(). public unresolved_type andCallbacks(SwipeCallbacks<U> callbacks)
 //                                            ^^^^^^^^^^^^^^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#
 //                                                           ^ reference com/airbnb/epoxy/EpoxyTouchHelper#SwipeBuilder3#[U]
 //                                                              ^^^^^^^^^ definition local69 final SwipeCallbacks<U> callbacks

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
@@ -211,7 +211,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 // ^^^^^^^^ reference java/lang/Override#
   public final ViewHolder chooseDropTarget(ViewHolder selected, List dropTargets, int curX,
 //             ^^^^^^^^^^ reference _root_/
-//                        ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#chooseDropTarget(). @Override public final chooseDropTarget(unresolved_type selected, List dropTargets, int curX, int curY)
+//                        ^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/EpoxyTouchHelperCallback#chooseDropTarget(). @Override public final unresolved_type chooseDropTarget(unresolved_type selected, List dropTargets, int curX, int curY)
 //                                         ^^^^^^^^^^ reference _root_/
 //                                                    ^^^^^^^^ definition local24 unresolved_type selected
 //                                                              ^^^^ reference java/util/List#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ListenersUtils.java
@@ -72,7 +72,7 @@ public class ListenersUtils {
 // ^^^^^^^^ reference androidx/annotation/Nullable#
   private static RecyclerView findParentRecyclerView(@Nullable View v) {
 //               ^^^^^^^^^^^^ reference _root_/
-//                            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#findParentRecyclerView(). @Nullable private static findParentRecyclerView(unresolved_type v)
+//                            ^^^^^^^^^^^^^^^^^^^^^^ definition com/airbnb/epoxy/ListenersUtils#findParentRecyclerView(). @Nullable private static unresolved_type findParentRecyclerView(unresolved_type v)
 //                                                    ^^^^^^^^ reference androidx/annotation/Nullable#
 //                                                             ^^^^ reference _root_/
 //                                                                  ^ definition local3 @Nullable unresolved_type v

--- a/tests/unit/src/test/scala/tests/PackageStoreSuite.scala
+++ b/tests/unit/src/test/scala/tests/PackageStoreSuite.scala
@@ -1,0 +1,61 @@
+package tests
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.sourcegraph.packagehub.Package
+import com.sourcegraph.packagehub.PackageHub
+import com.sourcegraph.packagehub.PostgresOptions
+import com.sourcegraph.packagehub.PostgresPackageStore
+import moped.testkit.MopedSuite
+
+class PackageStoreSuite
+    extends MopedSuite(PackageHub.app)
+    with TestContainerForAll {
+  val store =
+    new Fixture[PostgresPackageStore]("store") {
+      private var p: PostgresPackageStore = _
+      def apply(): PostgresPackageStore = p
+      override def beforeEach(context: BeforeEach): Unit = {
+        withContainers { c =>
+          val options = PostgresOptions(
+            url = c.jdbcUrl,
+            username = c.username,
+            password = c.password
+          )
+          p = new PostgresPackageStore(options.toDataSource(app().reporter).get)
+        }
+      }
+    }
+  override def munitFixtures: Seq[Fixture[_]] =
+    super.munitFixtures ++ List(store)
+  val pkg1 = Package.parse("maven:com.sourcegraph:semanticdb-javac:0.4.0")
+  val pkg2 = Package.parse("maven:com.sourcegraph:semanticdb-javac:0.4.1")
+  val pkg3 = Package.parse("maven:com.sourcegraph:semanticdb-javac:0.4.2")
+  val containerDef = PostgreSQLContainer.Def()
+
+  test("packages") {
+    assertEquals(store().allPackages(), Nil)
+    store().addPackage(pkg1)
+    assertEquals(store().allPackages(), List(pkg1))
+    store().addPackage(pkg1)
+    assertEquals(store().allPackages(), List(pkg1))
+    store().addPackages(List(pkg2, pkg3))
+    assertEquals(store().allPackages(), List(pkg1, pkg2, pkg3))
+  }
+
+  test("indexed_packages") {
+    assertEquals(store().allIndexedPackages(), Nil)
+    store().addIndexedPackage(pkg1)
+    assertEquals(store().allIndexedPackages(), List(pkg1))
+    assert(store().isIndexedPackage(pkg1))
+    assert(!store().isIndexedPackage(pkg2))
+    assert(!store().isIndexedPackage(pkg3))
+    store().addIndexedPackage(pkg1)
+    assertEquals(store().allIndexedPackages(), List(pkg1))
+    store().addIndexedPackages(List(pkg2, pkg3))
+    assertEquals(store().allIndexedPackages(), List(pkg1, pkg2, pkg3))
+    assert(store().isIndexedPackage(pkg1))
+    assert(store().isIndexedPackage(pkg2))
+    assert(store().isIndexedPackage(pkg3))
+  }
+}


### PR DESCRIPTION
Previously, Sourcegraph was only able to LSIF index Java repositories.
There was no good way to LSIF index a Java library on Maven Central
because they don't have an associated git repository.

This commit adds a new `PackageHub` server that is implemented as a
proxy on top of Maven repositories that serves git repositories that
Sourcegraph can understand. This new server can be used with lsif-java
to enable navigation between repositories and their transitive
Java library dependencies.