### PR TITLE
add --no-transfer-progress flag to maven invocation

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
@@ -40,7 +40,8 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
           // issue for this repo.
           s"-Dmaven.compiler.compilerId=javac",
           s"-Dmaven.compiler.executable=$executable",
-          s"-Dmaven.compiler.fork=true"
+          s"-Dmaven.compiler.fork=true",
+          s"--no-transfer-progress"
         )
       buildCommand ++=
         index.finalBuildCommand(


### PR DESCRIPTION
Reduces log-spam from maven invocation e.g.
```
Downloading: http://.../artifactory/repo/com/codahale/metrics/metrics-core/3.0.1/metrics-core-3.0.1.jar
4/2122 KB   
8/2122 KB   
12/2122 KB   
16/2122 KB   
18/2122 KB   
18/2122 KB   4/480 KB   
18/2122 KB   8/480 KB   
18/2122 KB   12/480 KB   
18/2122 KB   16/480 KB   
18/2122 KB   16/480 KB   4/1181 KB   
18/2122 KB   16/480 KB   8/1181 KB   
18/2122 KB   16/480 KB   12/1181 KB
```

Closes #181 