### PR TITLE
abstract semanticdb builders and move tree modeling to new class

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
@@ -5,18 +5,17 @@ import com.sourcegraph.semanticdb_javac.Semanticdb.*;
 
 import com.sourcegraph.semanticdb_javac.SemanticdbSymbols;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-public class SignatureFormatter {
-  private static final Type OBJECT_TYPE_REF =
-      Type.newBuilder().setTypeRef(TypeRef.newBuilder().setSymbol("java/lang/Object#")).build();
+import static com.sourcegraph.semanticdb_javac.SemanticdbBuilders.typeRef;
 
-  private static final Type WILDCARD_TYPE_REF =
-      Type.newBuilder().setTypeRef(TypeRef.newBuilder().setSymbol("local_wildcard")).build();
+public class SignatureFormatter {
+  private static final Type OBJECT_TYPE_REF = typeRef("java/lang/Object#");
+
+  private static final Type WILDCARD_TYPE_REF = typeRef("local_wildcard");
 
   private static final String ARRAY_SYMBOL = "scala/Array#";
   private static final String ENUM_SYMBOL = "java/lang/Enum#";

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbBuilders.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbBuilders.java
@@ -1,0 +1,216 @@
+package com.sourcegraph.semanticdb_javac;
+
+import java.util.List;
+
+public class SemanticdbBuilders {
+  // SemanticDB Types
+  public static Semanticdb.Type typeRef(String symbol) {
+    return Semanticdb.Type.newBuilder()
+        .setTypeRef(Semanticdb.TypeRef.newBuilder().setSymbol(symbol))
+        .build();
+  }
+
+  public static Semanticdb.Type typeRef(String symbol, List<Semanticdb.Type> typeArguments) {
+    return Semanticdb.Type.newBuilder()
+        .setTypeRef(
+            Semanticdb.TypeRef.newBuilder().setSymbol(symbol).addAllTypeArguments(typeArguments))
+        .build();
+  }
+
+  public static Semanticdb.Type existentialType(
+      Semanticdb.Type type, Semanticdb.Scope declarations) {
+    return Semanticdb.Type.newBuilder()
+        .setExistentialType(
+            Semanticdb.ExistentialType.newBuilder().setTpe(type).setDeclarations(declarations))
+        .build();
+  }
+
+  public static Semanticdb.Type intersectionType(List<? extends Semanticdb.Type> types) {
+    return Semanticdb.Type.newBuilder()
+        .setIntersectionType(Semanticdb.IntersectionType.newBuilder().addAllTypes(types))
+        .build();
+  }
+
+  // SemanticDB Signatures
+
+  public static Semanticdb.Signature signature(Semanticdb.ClassSignature.Builder signature) {
+    return Semanticdb.Signature.newBuilder().setClassSignature(signature).build();
+  }
+
+  public static Semanticdb.Signature signature(Semanticdb.MethodSignature.Builder signature) {
+    return Semanticdb.Signature.newBuilder().setMethodSignature(signature).build();
+  }
+
+  public static Semanticdb.Signature signature(Semanticdb.ValueSignature.Builder signature) {
+    return Semanticdb.Signature.newBuilder().setValueSignature(signature).build();
+  }
+
+  public static Semanticdb.Signature signature(Semanticdb.TypeSignature.Builder signature) {
+    return Semanticdb.Signature.newBuilder().setTypeSignature(signature).build();
+  }
+
+  // SemanticDB Symbols
+
+  public static Semanticdb.SymbolOccurrence symbolOccurrence(
+      String symbol, Semanticdb.Range range, Semanticdb.SymbolOccurrence.Role role) {
+    return Semanticdb.SymbolOccurrence.newBuilder()
+        .setSymbol(symbol)
+        .setRange(range)
+        .setRole(role)
+        .build();
+  }
+
+  public static Semanticdb.SymbolInformation.Builder symbolInformation(String symbol) {
+    return Semanticdb.SymbolInformation.newBuilder().setSymbol(symbol);
+  }
+
+  // SemanticDB Access
+
+  public static Semanticdb.Access privateAccess() {
+    return Semanticdb.Access.newBuilder()
+        .setPrivateAccess(Semanticdb.PrivateAccess.newBuilder())
+        .build();
+  }
+
+  public static Semanticdb.Access publicAccess() {
+    return Semanticdb.Access.newBuilder()
+        .setPublicAccess(Semanticdb.PublicAccess.newBuilder())
+        .build();
+  }
+
+  public static Semanticdb.Access protectedAccess() {
+    return Semanticdb.Access.newBuilder()
+        .setProtectedAccess(Semanticdb.ProtectedAccess.newBuilder())
+        .build();
+  }
+
+  public static Semanticdb.Access privateWithinAccess(String symbol) {
+    return Semanticdb.Access.newBuilder()
+        .setPrivateWithinAccess(Semanticdb.PrivateWithinAccess.newBuilder().setSymbol(symbol))
+        .build();
+  }
+
+  // SemanticDB Trees
+
+  public static Semanticdb.Tree tree(Semanticdb.IdTree idTree) {
+    return Semanticdb.Tree.newBuilder().setIdTree(idTree).build();
+  }
+
+  public static Semanticdb.IdTree idTree(String symbol) {
+    return Semanticdb.IdTree.newBuilder().setSymbol(symbol).build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.ApplyTree applyTree) {
+    return Semanticdb.Tree.newBuilder().setApplyTree(applyTree).build();
+  }
+
+  public static Semanticdb.ApplyTree applyTree(
+      Semanticdb.Tree function, Iterable<Semanticdb.Tree> arguments) {
+    return Semanticdb.ApplyTree.newBuilder()
+        .setFunction(function)
+        .addAllArguments(arguments)
+        .build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.SelectTree selectTree) {
+    return Semanticdb.Tree.newBuilder().setSelectTree(selectTree).build();
+  }
+
+  public static Semanticdb.SelectTree selectTree(
+      Semanticdb.Tree qualifier, Semanticdb.IdTree idTree) {
+    return Semanticdb.SelectTree.newBuilder().setQualifier(qualifier).setId(idTree).build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.LiteralTree literalTree) {
+    return Semanticdb.Tree.newBuilder().setLiteralTree(literalTree).build();
+  }
+
+  public static Semanticdb.LiteralTree literalTree(Semanticdb.Constant constant) {
+    return Semanticdb.LiteralTree.newBuilder().setConstant(constant).build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.AnnotationTree annotationTree) {
+    return Semanticdb.Tree.newBuilder().setAnnotationTree(annotationTree).build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.BinaryOperatorTree binaryOperatorTree) {
+    return Semanticdb.Tree.newBuilder().setBinopTree(binaryOperatorTree).build();
+  }
+
+  public static Semanticdb.BinaryOperatorTree binopTree(
+      Semanticdb.Tree lhs, Semanticdb.BinaryOperator operator, Semanticdb.Tree rhs) {
+    return Semanticdb.BinaryOperatorTree.newBuilder()
+        .setLhs(lhs)
+        .setOp(operator)
+        .setRhs(rhs)
+        .build();
+  }
+
+  public static Semanticdb.Tree tree(Semanticdb.AssignTree assignTree) {
+    return Semanticdb.Tree.newBuilder().setAssignTree(assignTree).build();
+  }
+
+  public static Semanticdb.AssignTree assignTree(Semanticdb.Tree lhs, Semanticdb.Tree rhs) {
+    return Semanticdb.AssignTree.newBuilder().setLhs(lhs).setRhs(rhs).build();
+  }
+
+  public static Semanticdb.AnnotationTree annotationTree(
+      Semanticdb.Type type, Iterable<Semanticdb.Tree> parameters) {
+    return Semanticdb.AnnotationTree.newBuilder().setTpe(type).addAllParameters(parameters).build();
+  }
+  // SemanticDB Constants
+
+  public static Semanticdb.Constant stringConst(String value) {
+    return Semanticdb.Constant.newBuilder()
+        .setStringConstant(Semanticdb.StringConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant doubleConst(Double value) {
+    return Semanticdb.Constant.newBuilder()
+        .setDoubleConstant(Semanticdb.DoubleConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant floatConst(Float value) {
+    return Semanticdb.Constant.newBuilder()
+        .setFloatConstant(Semanticdb.FloatConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant longConst(Long value) {
+    return Semanticdb.Constant.newBuilder()
+        .setLongConstant(Semanticdb.LongConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant intConst(Integer value) {
+    return Semanticdb.Constant.newBuilder()
+        .setIntConstant(Semanticdb.IntConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant charConst(Character value) {
+    return Semanticdb.Constant.newBuilder()
+        .setCharConstant(Semanticdb.CharConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant shortConst(Short value) {
+    return Semanticdb.Constant.newBuilder()
+        .setShortConstant(Semanticdb.ShortConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant byteConst(Byte value) {
+    return Semanticdb.Constant.newBuilder()
+        .setByteConstant(Semanticdb.ByteConstant.newBuilder().setValue(value))
+        .build();
+  }
+
+  public static Semanticdb.Constant booleanConst(Boolean value) {
+    return Semanticdb.Constant.newBuilder()
+        .setBooleanConstant(Semanticdb.BooleanConstant.newBuilder().setValue(value))
+        .build();
+  }
+}

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
@@ -1,0 +1,198 @@
+package com.sourcegraph.semanticdb_javac;
+
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.sourcegraph.semanticdb_javac.SemanticdbBuilders.*;
+import static com.sourcegraph.semanticdb_javac.SemanticdbTypeVisitor.ARRAY_SYMBOL;
+
+public class SemanticdbTrees {
+  public SemanticdbTrees(
+      GlobalSymbolsCache globals, LocalSymbolsCache locals, String semanticdbUri) {
+    this.globals = globals;
+    this.locals = locals;
+    this.semanticdbUri = semanticdbUri;
+  }
+
+  private final GlobalSymbolsCache globals;
+  private final LocalSymbolsCache locals;
+  private final String semanticdbUri;
+
+  public List<Semanticdb.AnnotationTree> annotations(JCTree node) {
+    if (!(node instanceof JCTree.JCClassDecl)
+        && !(node instanceof JCTree.JCVariableDecl)
+        && !(node instanceof JCTree.JCMethodDecl)) return null;
+
+    List<Semanticdb.AnnotationTree> annotations = new ArrayList<>();
+
+    JCTree.JCModifiers mods;
+    if (node instanceof JCTree.JCClassDecl) {
+      mods = ((JCTree.JCClassDecl) node).getModifiers();
+    } else if (node instanceof JCTree.JCMethodDecl) {
+      mods = ((JCTree.JCMethodDecl) node).getModifiers();
+    } else {
+      mods = ((JCTree.JCVariableDecl) node).getModifiers();
+    }
+
+    for (JCTree.JCAnnotation annotation : mods.getAnnotations()) {
+      annotations.add(annotationBuilder(annotation));
+    }
+
+    return annotations;
+  }
+
+  private Semanticdb.AnnotationTree annotationBuilder(JCTree.JCAnnotation annotation) {
+    ArrayList<Semanticdb.Tree> params = new ArrayList<>(annotation.args.size());
+
+    for (JCTree.JCExpression param : annotation.args) {
+      // anecdotally not always JCAssign in some situations when a compilation unit can't resolve
+      // symbols fully
+      if (param instanceof JCTree.JCAssign) {
+        JCTree.JCAssign assign = (JCTree.JCAssign) param;
+        JCTree.JCExpression assignValue = assign.rhs;
+
+        String symbol = globals.semanticdbSymbol(((JCTree.JCIdent) assign.lhs).sym, locals);
+        params.add(tree(assignTree(tree(idTree(symbol)), annotationParameter(assignValue))));
+      } else {
+        params.add(annotationParameter(param));
+      }
+    }
+
+    Semanticdb.Type type =
+        new SemanticdbTypeVisitor(globals, locals).semanticdbType(annotation.type);
+    return annotationTree(type, params);
+  }
+
+  private Semanticdb.Tree annotationParameter(JCTree.JCExpression expr) {
+    if (expr instanceof JCTree.JCFieldAccess) {
+      JCTree.JCFieldAccess rhs = (JCTree.JCFieldAccess) expr;
+
+      return tree(
+          selectTree(
+              tree(idTree(globals.semanticdbSymbol(rhs.sym.owner, locals))),
+              idTree(globals.semanticdbSymbol(rhs.sym, locals))));
+    } else if (expr instanceof JCTree.JCNewArray) {
+      JCTree.JCNewArray rhs = (JCTree.JCNewArray) expr;
+      return tree(
+          applyTree(
+              tree(idTree(ARRAY_SYMBOL)),
+              rhs.elems.stream().map(this::annotationParameter).collect(Collectors.toList())));
+    } else if (expr instanceof JCTree.JCLiteral) {
+      // Literals can either be a primitive or String
+      JCTree.JCLiteral rhs = (JCTree.JCLiteral) expr;
+
+      if (rhs.type instanceof Type.JCPrimitiveType) {
+        Type.JCPrimitiveType type = (Type.JCPrimitiveType) rhs.type;
+        switch (type.getKind()) {
+          case BOOLEAN:
+            return tree(literalTree(booleanConst(((Integer) rhs.value) == 1)));
+          case BYTE:
+            return tree(literalTree(byteConst((Byte) rhs.value)));
+          case SHORT:
+            return tree(literalTree(shortConst((Short) rhs.value)));
+          case INT:
+            return tree(literalTree(intConst((Integer) rhs.value)));
+          case LONG:
+            return tree(literalTree(longConst((Long) rhs.value)));
+          case CHAR:
+            return tree(literalTree(charConst((Character.forDigit((Integer) rhs.value, 10)))));
+          case FLOAT:
+            return tree(literalTree(floatConst((Float) rhs.value)));
+          case DOUBLE:
+            return tree(literalTree(doubleConst((Double) rhs.value)));
+        }
+      } else if (rhs.type instanceof Type.ClassType) {
+        if (rhs.value instanceof String) {
+          return tree(literalTree(stringConst((String) rhs.value)));
+        } else {
+          throw new IllegalStateException(
+              semanticdbUri
+                  + ": annotation parameter rhs was of unexpected class type "
+                  + rhs.value.getClass()
+                  + "\n"
+                  + rhs.value);
+        }
+      } else if (rhs.type instanceof Type.UnknownType) {
+        return tree(literalTree(stringConst("UNRESOLVED")));
+      } else {
+        throw new IllegalStateException(
+            semanticdbUri
+                + ": annotation parameter rhs was of unexpected type "
+                + rhs.type.getClass()
+                + "\n"
+                + rhs.type
+                + " "
+                + rhs);
+      }
+    } else if (expr instanceof JCTree.JCAnnotation) {
+      return tree(annotationBuilder((JCTree.JCAnnotation) expr));
+    } else if (expr instanceof JCTree.JCIdent) {
+      return tree(idTree(globals.semanticdbSymbol(((JCTree.JCIdent) expr).sym, locals)));
+    } else if (expr instanceof JCTree.JCBinary) {
+      JCTree.JCBinary binExpr = (JCTree.JCBinary) expr;
+      return tree(
+          binopTree(
+              annotationParameter(binExpr.lhs),
+              semanticdbBinaryOperator(expr.getKind()),
+              annotationParameter(binExpr.rhs)));
+    }
+
+    throw new IllegalArgumentException(
+        semanticdbUri
+            + ": annotation parameter rhs was of unexpected tree node type "
+            + expr.getClass()
+            + "\n"
+            + expr);
+  }
+
+  private Semanticdb.BinaryOperator semanticdbBinaryOperator(Tree.Kind kind) {
+    switch (kind) {
+      case PLUS:
+        return Semanticdb.BinaryOperator.PLUS;
+      case MINUS:
+        return Semanticdb.BinaryOperator.MINUS;
+      case MULTIPLY:
+        return Semanticdb.BinaryOperator.MULTIPLY;
+      case DIVIDE:
+        return Semanticdb.BinaryOperator.DIVIDE;
+      case REMAINDER:
+        return Semanticdb.BinaryOperator.REMAINDER;
+      case LESS_THAN:
+        return Semanticdb.BinaryOperator.LESS_THAN;
+      case GREATER_THAN:
+        return Semanticdb.BinaryOperator.GREATER_THAN;
+      case LEFT_SHIFT:
+        return Semanticdb.BinaryOperator.SHIFT_LEFT;
+      case RIGHT_SHIFT:
+        return Semanticdb.BinaryOperator.SHIFT_RIGHT;
+      case UNSIGNED_RIGHT_SHIFT:
+        return Semanticdb.BinaryOperator.SHIFT_RIGHT_UNSIGNED;
+      case EQUAL_TO:
+        return Semanticdb.BinaryOperator.EQUAL_TO;
+      case NOT_EQUAL_TO:
+        return Semanticdb.BinaryOperator.NOT_EQUAL_TO;
+      case LESS_THAN_EQUAL:
+        return Semanticdb.BinaryOperator.LESS_THAN_EQUAL;
+      case GREATER_THAN_EQUAL:
+        return Semanticdb.BinaryOperator.GREATER_THAN_EQUAL;
+      case CONDITIONAL_AND:
+        return Semanticdb.BinaryOperator.CONDITIONAL_AND;
+      case CONDITIONAL_OR:
+        return Semanticdb.BinaryOperator.CONDITIONAL_OR;
+      case AND:
+        return Semanticdb.BinaryOperator.AND;
+      case OR:
+        return Semanticdb.BinaryOperator.OR;
+      case XOR:
+        return Semanticdb.BinaryOperator.XOR;
+      default:
+        throw new IllegalStateException(
+            semanticdbUri + ": unexpected binary expression operator kind " + kind);
+    }
+  }
+}


### PR DESCRIPTION
Related to https://github.com/sourcegraph/lsif-java/pull/148#discussion_r610604073 and https://github.com/sourcegraph/lsif-java/pull/148#discussion_r610589964, doing some cleanup of the SemanticdbVisitor class and the many usages of builders.