### PR TITLE
skip outputting lsif snapshot for files located outside the sourceroot

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
@@ -49,8 +49,8 @@ case class SnapshotLsifCommand(
     @PositionalArguments() input: List[Path] = List(Paths.get("dump.lsif"))
 ) extends Command {
 
-  private val finalOutput = AbsolutePath.of(output, sourceroot)
   def sourceroot: Path = AbsolutePath.of(app.env.workingDirectory)
+  private val finalOutput = AbsolutePath.of(output, sourceroot)
 
   def run(): Int = {
     Files.walkFileTree(finalOutput, new DeleteVisitor())
@@ -59,7 +59,10 @@ case class SnapshotLsifCommand(
       in = AbsolutePath.of(inputPath, sourceroot)
       doc <- SnapshotLsifCommand.parseTextDocument(in, sourceroot)
     } {
-      SnapshotCommand.writeSnapshot(doc, finalOutput)
+      val docPath = AbsolutePath.of(Path.of(doc.getUri), sourceroot).toRealPath()
+      if (docPath.toAbsolutePath.startsWith(sourceroot)) {
+        SnapshotCommand.writeSnapshot(doc, finalOutput)
+      }
     }
     0
   }

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
@@ -59,7 +59,9 @@ case class SnapshotLsifCommand(
       in = AbsolutePath.of(inputPath, sourceroot)
       doc <- SnapshotLsifCommand.parseTextDocument(in, sourceroot)
     } {
-      val docPath = AbsolutePath.of(Path.of(doc.getUri), sourceroot).toRealPath()
+      val docPath = AbsolutePath
+        .of(Paths.get(doc.getUri), sourceroot)
+        .toRealPath()
       if (docPath.toAbsolutePath.startsWith(sourceroot)) {
         SnapshotCommand.writeSnapshot(doc, finalOutput)
       }


### PR DESCRIPTION
Fixes the following exception being thrown when a document in the LSIF dump points to a file outside the source root. They get filtered out by the backend _anyways_ so I see no reason to come up with a way to display them in the snapshot
```
$ lsif-java snapshot-lsif
java.nio.file.NoSuchFileException: /tmp/highlight_tool/generated/../../home/noah/.config/nvm/14.15.4/lib/node_modules/@sourcegraph/lsif-tsc/node_modules/typescript-lsif/lib/lib.es5.d.ts
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:478)
	at java.base/java.nio.file.Files.newOutputStream(Files.java:224)
	at java.base/java.nio.file.Files.write(Files.java:3491)
	at com.sourcegraph.lsif_java.commands.SnapshotCommand$.writeSnapshot(SnapshotCommand.scala:89)
	at com.sourcegraph.lsif_java.commands.SnapshotLsifCommand.$anonfun$run$3(SnapshotLsifCommand.scala:62)
	at com.sourcegraph.lsif_java.commands.SnapshotLsifCommand.$anonfun$run$3$adapted(SnapshotLsifCommand.scala:60)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at com.sourcegraph.lsif_java.commands.SnapshotLsifCommand.$anonfun$run$2(SnapshotLsifCommand.scala:60)
	at com.sourcegraph.lsif_java.commands.SnapshotLsifCommand.$anonfun$run$2$adapted(SnapshotLsifCommand.scala:58)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at com.sourcegraph.lsif_java.commands.SnapshotLsifCommand.run(SnapshotLsifCommand.scala:58)
	at moped.cli.Command.$anonfun$runAsFuture$1(BaseCommand.scala:14)
	at scala.runtime.java8.JFunction0$mcI$sp.apply(JFunction0$mcI$sp.scala:17)
	at scala.util.Try$.apply(Try.scala:210)
	at moped.cli.Command.runAsFuture(BaseCommand.scala:14)
	at moped.cli.Application$.$anonfun$run$7(Application.scala:317)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:434)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1429)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```