### PR TITLE
Add dockerfile for auto-indexing

### DIFF
--- a/auto-indexing/Dockerfile
+++ b/auto-indexing/Dockerfile
@@ -1,0 +1,6 @@
+FROM gradle:7.0.0-jdk8
+RUN apt-get update && \
+      apt-get install --yes maven && \
+      curl -fLo /coursier https://git.io/coursier-cli && \
+      chmod +x /coursier && \
+      /coursier launch --contrib lsif-java -- --help


### PR DESCRIPTION
The docker image is published to dockerhub as sourcegraph/lsif-java