### PR TITLE
Remove `--no-transfer-progress` from Maven command

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/MavenBuildTool.scala
@@ -40,8 +40,7 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
           // issue for this repo.
           s"-Dmaven.compiler.compilerId=javac",
           s"-Dmaven.compiler.executable=$executable",
-          s"-Dmaven.compiler.fork=true",
-          s"--no-transfer-progress"
+          s"-Dmaven.compiler.fork=true"
         )
       buildCommand ++=
         index.finalBuildCommand(

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
@@ -34,6 +34,7 @@ public class LsifSemanticdb {
   private void run() throws IOException {
     PackageTable packages = new PackageTable(options, writer);
     List<Path> files = SemanticdbWalker.findSemanticdbFiles(options);
+    Collections.sort(files);
     if (options.reporter.hasErrors()) return;
     if (files.isEmpty()) {
       options.reporter.error(


### PR DESCRIPTION
Users can manually add this flag if they want to. This flag got added in
2019 and there are still builds that are using older versions that don't
support this flag. Fixes #208