### PR TITLE
Fix bug when indexing JDK 11 sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:8-jdk-alpine@sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
-COPY bin/coursier coursier
-RUN apk add --no-cache git curl \
-    && git config --global user.email "you@example.com" \
-    && git config --global user.name "Your Name" \
-    && git config --global http.postBuffer 1048576000 \
-    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
-    && chmod +x /src \
-    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:0.5.0-12-69905fcb-SNAPSHOT -o /packagehub
+FROM sourcegraph/lsif-java
+COPY bin/packagehub.sh /packagehub.sh
+RUN chmod +x /packagehub.sh
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "Your Name"
+RUN git config --global http.postBuffer 1048576000
+RUN curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src
+RUN chmod +x /src
+RUN /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:0.5.1-26-2d4609cc-SNAPSHOT -o /packagehub
 ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
-ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M
+CMD ["/packagehub.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,11 +1,11 @@
-FROM openjdk:8-jdk-alpine@sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
-COPY bin/coursier coursier
-RUN apk add --no-cache git curl \
-    && git config --global user.email "you@example.com" \
-    && git config --global user.name "Your Name" \
-    && git config --global http.postBuffer 1048576000 \
-    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
-    && chmod +x /src \
-    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:VERSION -o /packagehub
+FROM sourcegraph/lsif-java
+COPY bin/packagehub.sh /packagehub.sh
+RUN chmod +x /packagehub.sh
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "Your Name"
+RUN git config --global http.postBuffer 1048576000
+RUN curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src
+RUN chmod +x /src
+RUN /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:VERSION -o /packagehub
 ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
-ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M
+CMD ["/packagehub.sh"]

--- a/bin/packagehub.sh
+++ b/bin/packagehub.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
@@ -30,6 +30,7 @@ import os.SubProcess
 import ujson.Arr
 import ujson.Bool
 import ujson.Obj
+import ujson.Str
 
 /**
  * Actor that creates git repos from package sources and (optionally LSIF
@@ -237,13 +238,13 @@ class PackageActor(
       List("dump.lsif", packagehubCached).asJava
     )
     val build = Obj()
-    val dependencies =
-      dep match {
-        case MavenPackage(dep) =>
-          build("dependencies") = Arr(packageId(dep))
-        case _ =>
-          build("indexJdk") = Bool(false)
-      }
+    dep match {
+      case MavenPackage(dep) =>
+        build("dependencies") = Arr(packageId(dep))
+      case JdkPackage(version) =>
+        build("indexJdk") = Bool(false)
+        build("jvm") = Str(version)
+    }
     Files.write(
       repo.resolve("lsif-java.json"),
       List(ujson.write(build, indent = 2)).asJava


### PR DESCRIPTION
Previously, PackageHub was unable to auto-index the JDK 11 sources
because it was missing appropriate `--module` flags that are not needed
for JDK 8.