### PR TITLE
Fix bug for cross-repo navigation to the JDK sources.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:8-jdk-alpine@sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
-COPY bin/coursier coursier
-RUN apk add --no-cache git curl \
-    && git config --global user.email "you@example.com" \
-    && git config --global user.name "Your Name" \
-    && git config --global http.postBuffer 1048576000 \
-    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
-    && chmod +x /src \
-    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:0.5.0-12-69905fcb-SNAPSHOT -o /packagehub
+FROM sourcegraph/lsif-java
+COPY bin/packagehub.sh /packagehub.sh
+RUN chmod +x /packagehub.sh
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "Your Name"
+RUN git config --global http.postBuffer 1048576000
+RUN curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src
+RUN chmod +x /src
+RUN /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:0.5.1-26-2d4609cc-SNAPSHOT -o /packagehub
 ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
-ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M
+CMD ["/packagehub.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,11 +1,11 @@
-FROM openjdk:8-jdk-alpine@sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
-COPY bin/coursier coursier
-RUN apk add --no-cache git curl \
-    && git config --global user.email "you@example.com" \
-    && git config --global user.name "Your Name" \
-    && git config --global http.postBuffer 1048576000 \
-    && curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src \
-    && chmod +x /src \
-    && /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:VERSION -o /packagehub
+FROM sourcegraph/lsif-java
+COPY bin/packagehub.sh /packagehub.sh
+RUN chmod +x /packagehub.sh
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "Your Name"
+RUN git config --global http.postBuffer 1048576000
+RUN curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /src
+RUN chmod +x /src
+RUN /coursier bootstrap -r sonatype:snapshots com.sourcegraph:packagehub_2.13:VERSION -o /packagehub
 ENV COURSIER_REPOSITORIES=central|https://maven.google.com/|jitpack
-ENTRYPOINT /packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M
+CMD ["/packagehub.sh"]

--- a/bin/packagehub.sh
+++ b/bin/packagehub.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
@@ -10,11 +10,9 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
-
 import com.sourcegraph.io.DeleteVisitor
 import com.sourcegraph.lsif_java.Dependencies
 import com.sourcegraph.lsif_java.Embedded
@@ -30,7 +28,8 @@ import moped.macros.ClassShape
 import moped.parsers.JsonParser
 import moped.reporters.Diagnostic
 import moped.reporters.Input
-import os.CommandResult
+import os.ProcessOutput.Readlines
+import os.{CommandResult, ProcessOutput}
 
 /**
  * A custom build tool that is specifically made for lsif-java.
@@ -133,11 +132,14 @@ class LsifBuildTool(index: IndexCommand) extends BuildTool("LSIF", index) {
     if (javaFiles.size > 1) {
       index.app.reporter.info(f"Compiling ${javaFiles.size}%,.0f Java sources")
     }
+    val pipe = Readlines(line => {
+      index.app.reporter.info(line)
+    })
     val result = os
       .proc("javac", s"@$argsfile")
       .call(
-        stdout = os.Pipe,
-        stderr = os.Pipe,
+        stdout = pipe,
+        stderr = pipe,
         cwd = os.Path(sourceroot),
         check = false
       )

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JdkPackage.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JdkPackage.java
@@ -9,7 +9,7 @@ public class JdkPackage extends Package {
 
   @Override
   public String repoName() {
-    return String.format("jdk:%s", version);
+    return String.format("jdk/%s", version);
   }
 
   @Override

--- a/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
+++ b/packagehub/src/main/scala/com/sourcegraph/packagehub/PackageActor.scala
@@ -30,6 +30,7 @@ import os.SubProcess
 import ujson.Arr
 import ujson.Bool
 import ujson.Obj
+import ujson.Str
 
 /**
  * Actor that creates git repos from package sources and (optionally LSIF
@@ -237,13 +238,13 @@ class PackageActor(
       List("dump.lsif", packagehubCached).asJava
     )
     val build = Obj()
-    val dependencies =
-      dep match {
-        case MavenPackage(dep) =>
-          build("dependencies") = Arr(packageId(dep))
-        case _ =>
-          build("indexJdk") = Bool(false)
-      }
+    dep match {
+      case MavenPackage(dep) =>
+        build("dependencies") = Arr(packageId(dep))
+      case JdkPackage(version) =>
+        build("indexJdk") = Bool(false)
+        build("jvm") = Str(version)
+    }
     Files.write(
       repo.resolve("lsif-java.json"),
       List(ujson.write(build, indent = 2)).asJava

--- a/tests/snapshots/src/main/generated/index-semanticdb/packages-jvm
+++ b/tests/snapshots/src/main/generated/index-semanticdb/packages-jvm
@@ -43,5 +43,5 @@ public class Example {
        │                    ││
        v                    │v
  ╭──────────╮ ╭─────────────┴─────╮
- │jdk:11(33)│ │referenceResult(35)│
+ │jdk/11(33)│ │referenceResult(35)│
  ╰──────────╯ ╰───────────────────╯


### PR DESCRIPTION
Previously, the generated LSIF pointed to a non-existing repo "jdk:8"
causing goto definition to stop working for JDK symbols.