### PR TITLE
Use the correct JDK version when indexing Java packages.

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/Dependencies.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/Dependencies.scala
@@ -28,6 +28,7 @@ case class Dependencies(
 }
 
 object Dependencies {
+  val empty = Dependencies(Nil, Fetch.Result(), Fetch.Result())
   private val cache: FileCache[Task] = FileCache[Task]()
     .noCredentials
     .withCachePolicies(List(CachePolicy.LocalOnly, CachePolicy.Update))

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/BuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/BuildTool.scala
@@ -14,8 +14,6 @@ abstract class BuildTool(val name: String, index: IndexCommand) {
 
   def isHidden: Boolean = false
 
-  def indexJdk(): Boolean = true
-
   final def sourceroot: Path = index.workingDirectory
   final def targetroot: Path =
     AbsolutePath

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
@@ -157,7 +157,6 @@ case class IndexCommand(
           generateSemanticdbResult.exitCode
         } else {
           IndexSemanticdbCommand(
-            indexJdk = tool.indexJdk(),
             output = finalOutput,
             targetroot = List(tool.targetroot),
             packagehub = packagehub,

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexSemanticdbCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexSemanticdbCommand.scala
@@ -33,10 +33,6 @@ final case class IndexSemanticdbCommand(
     @Description(
       "Whether to process the SemanticDB files in parallel"
     ) parallel: Boolean = true,
-    @Description(
-      "Whether to index against symbols in the JDK codebase. " +
-        "If false, no 'packageInformation' LSIF edges will be emitted for JDK symbols."
-    ) indexJdk: Boolean = true,
     @Description("URL to a PackageHub instance")
     @Hidden
     packagehub: Option[String] = None,
@@ -76,7 +72,6 @@ final case class IndexSemanticdbCommand(
         "java",
         format,
         parallel,
-        indexJdk,
         packages.map(_.toPackageInformation).asJava
       )
     LsifSemanticdb.run(options)

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JavaVersion.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JavaVersion.java
@@ -1,8 +1,28 @@
 package com.sourcegraph.lsif_semanticdb;
 
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Enumeration;
+import java.util.Optional;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
 public class JavaVersion {
   public final boolean isJava8;
   public final JdkPackage pkg;
+  private static PathMatcher CLASS_PATTERN =
+      FileSystems.getDefault().getPathMatcher("glob:**.class");
+  private static PathMatcher JAR_PATTERN = FileSystems.getDefault().getPathMatcher("glob:**.jar");
+
+  public static int JAVA8_VERSION = 8;
+  public static int JAVA11_VERSION = 11;
+  public static int DEFAULT_JAVA_VERSION = JAVA8_VERSION;
+  private static int JAVA0_MAJOR_VERSION = 44;
 
   public JavaVersion() {
     this(System.getProperty("java.version"));
@@ -18,5 +38,56 @@ public class JavaVersion {
     String[] parts = version.split("\\.");
     if (parts.length > 0) return parts[0];
     else return version;
+  }
+
+  public static int roundToNearestStableRelease(int version) {
+    if (version <= JAVA8_VERSION) return JAVA8_VERSION;
+    if (version <= JAVA11_VERSION) return JAVA11_VERSION;
+    return version;
+  }
+
+  /**
+   * Return the JVM version of the given jar/class file.
+   *
+   * <p>The JVM version is determined by reading the 5-8th bytes of classfiles, according to the
+   * Java Language spec. See
+   * https://docs.oracle.com/javase/specs/jvms/se16/html/jvms-4.html#jvms-4.1
+   *
+   * @return the JVM version such as <code>8</code> for Java 8 and <code>11</code> for Java 11.
+   */
+  public static Optional<Integer> classfileJvmVersion(Path file) {
+    try {
+      int major = classfileMajorVersion(file);
+      return major < 0 ? Optional.empty() : Optional.of(major - JAVA0_MAJOR_VERSION);
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static int classfileMajorVersion(Path file) throws IOException {
+    if (CLASS_PATTERN.matches(file)) {
+      return classfileMajorVersion(Files.newInputStream(file));
+    } else if (JAR_PATTERN.matches(file)) {
+      try (JarFile jar = new JarFile(file.toFile())) {
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+          JarEntry entry = entries.nextElement();
+          if (entry.getName().endsWith(".class")) {
+            return classfileMajorVersion(jar.getInputStream(entry));
+          }
+        }
+      }
+    }
+
+    return -1;
+  }
+
+  private static int classfileMajorVersion(InputStream classfileBytes) throws IOException {
+    DataInputStream in = new DataInputStream(classfileBytes);
+    // See https://docs.oracle.com/javase/specs/jvms/se16/html/jvms-4.html#jvms-4.1
+    int magic = in.readInt(); // u4 magic
+    if (magic != 0xCAFEBABE) return -1;
+    in.readUnsignedShort(); // u2 minor_version
+    return in.readUnsignedShort(); // u2 major_version
   }
 }

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdbOptions.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdbOptions.java
@@ -15,7 +15,6 @@ public class LsifSemanticdbOptions {
   public final String language;
   public final LsifOutputFormat format;
   public final boolean parallel;
-  public final boolean indexJdk;
   public final List<MavenPackage> packages;
 
   public LsifSemanticdbOptions(
@@ -27,7 +26,6 @@ public class LsifSemanticdbOptions {
       String language,
       LsifOutputFormat format,
       boolean parallel,
-      boolean indexJdk,
       List<MavenPackage> packages) {
     this.targetroots = targetroots;
     this.output = output;
@@ -37,7 +35,6 @@ public class LsifSemanticdbOptions {
     this.language = language;
     this.format = format;
     this.parallel = parallel;
-    this.indexJdk = indexJdk;
     this.packages = packages;
   }
 }


### PR DESCRIPTION
Previously, PackageHub was not able to index Java 11 libraries because
it always ran the `index-semanticdb` step on Java 8. Now, we shell out
to `cs launch lsif-java --jvm JVM_VERSION` to ensure that the
`index-semanticdb` command always uses the correct Java version.