### PR TITLE
Declare local symbols as "export" instead "import" monikers

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/ResultSets.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/ResultSets.java
@@ -43,7 +43,7 @@ public class ResultSets implements Function<String, ResultIds> {
     int resultSet = writer.emitResultSet();
 
     // Moniker
-    int monikerId = writer.emitMonikerVertex(symbol, isExportedSymbol);
+    int monikerId = writer.emitMonikerVertex(symbol, hasDefinitionResult);
     writer.emitMonikerEdge(resultSet, monikerId);
     packages.writeImportedSymbol(symbol, monikerId);
 


### PR DESCRIPTION
Previously, `localN` symbols were declared as imported monikers. I don't think this change affects anything, but I noticed  this bug while investigating the issue to JDK navigation because I saw lots of `import` monikers in the JDK dump.lsif, when I expected only to see `export` monikers