### PR TITLE
Disable auto-indexing on packagehub

### DIFF
--- a/bin/packagehub.sh
+++ b/bin/packagehub.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-/packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL --auto-index-delay=PT1M
+/packagehub --host 0.0.0.0 --port $PORT --src /src --coursier /coursier --postgres.username=$DB_USER --postgres.password=$DB_PASS --postgres.url=$DB_URL


### PR DESCRIPTION
Previously, packagehub automatically scheduled LSIF indexing for repos.
This commit disables that feature so that you need to manually send a
`curl -X POST` requst to trigger LSIF indexing of repos.