### PR TITLE
Upgrade to the latest sbt

### DIFF
--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -33,9 +33,9 @@ object JavaToolchainPlugin extends AutoPlugin {
         "-bootclasspath",
         java8Bootclasspath()
       ),
-    javacOptions.in(doc) --= List("-target", "1.8"),
-    javacOptions.in(doc) --= bootclasspathSettings(javaToolchainVersion.value),
-    javacOptions.in(doc) --= List("-g"),
+    (doc / javacOptions) --= List("-target", "1.8"),
+    (doc / javacOptions) --= bootclasspathSettings(javaToolchainVersion.value),
+    (doc / javacOptions) --= List("-g"),
     javaHome := Some(getJavaHome(javaToolchainVersion.value)),
     javacOptions ++= bootclasspathSettings(javaToolchainVersion.value),
     javaOptions ++= bootclasspathSettings(javaToolchainVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.2


### PR DESCRIPTION
The diff is unusually large because I have resisted to start using the
slash-syntax that was introduced ~2 years. The sbt v1.5 release
deprecated the old syntax that I've been using so now it's time to get
used to the new syntax. Fortunately, there's an automated migration
script so it was easy to create this PR