### PR TITLE
Make `snapshot-lsif` command more robust

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/CommentSyntax.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/CommentSyntax.scala
@@ -1,0 +1,18 @@
+package com.sourcegraph.lsif_java.commands
+
+case class CommentSyntax(value: String) {
+  private val map =
+    value
+      .split("\\s+")
+      .map(_.split(","))
+      .collect { case Array(a, b) =>
+        a -> b
+      }
+      .toMap
+  def extensionSyntax(fileExtension: String): String =
+    map.getOrElse(fileExtension, "//")
+}
+object CommentSyntax {
+  val default = CommentSyntax("py,# sql,-- yaml,# yml,#")
+  implicit val codec = moped.macros.deriveCodec(default)
+}

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotCommand.scala
@@ -82,8 +82,12 @@ case class SnapshotCommand(
 }
 
 object SnapshotCommand {
-  def writeSnapshot(doc: TextDocument, outputDirectory: Path): Unit = {
-    val document = SemanticdbPrinters.printTextDocument(doc)
+  def writeSnapshot(
+      doc: TextDocument,
+      outputDirectory: Path,
+      commentSyntax: CommentSyntax = CommentSyntax.default
+  ): Unit = {
+    val document = SemanticdbPrinters.printTextDocument(doc, commentSyntax)
     val snapshotOutput = outputDirectory.resolve(doc.getUri)
     Files.createDirectories(snapshotOutput.getParent)
     Files.write(snapshotOutput, document.getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
These changes are needed to make the `snapshot-lsif` work the output of
an experimental Python indexer.

- Don't crash with `NoSuchElementException` when a range has no text
  document, silently ignore it instead.
- Use `#` instead of `//` for comments in Python snapshots.
- Print the absolute path of the generated output directory.
- Report a warning when skipping a file because it's not part of the
  sourceroot.