### PR TITLE
Return empty `SymbolDescriptor` for empty symbol

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_semanticdb/ConsoleLsifSemanticdbReporter.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_semanticdb/ConsoleLsifSemanticdbReporter.scala
@@ -5,7 +5,6 @@ import java.nio.file.NoSuchFileException
 
 import moped.cli.Application
 import moped.progressbars.InteractiveProgressBar
-import moped.reporters.Diagnostic
 
 /**
  * Console reporter for index-semanticdb command.
@@ -25,7 +24,7 @@ class ConsoleLsifSemanticdbReporter(app: Application)
       case _: NoSuchFileException =>
         app.reporter.error(s"no such file: ${e.getMessage}")
       case _ =>
-        app.reporter.log(Diagnostic.exception(e))
+        e.printStackTrace(app.err)
     }
   }
 

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifProcessingException.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifProcessingException.java
@@ -1,0 +1,13 @@
+package com.sourcegraph.lsif_semanticdb;
+
+public class LsifProcessingException extends Throwable {
+
+  public LsifProcessingException(LsifTextDocument doc, Throwable cause) {
+    super(doc.semanticdbPath.toString(), cause);
+  }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
@@ -80,10 +80,20 @@ public class LsifSemanticdb {
 
   private Stream<Integer> processPath(
       Path path, Set<String> isExportedSymbol, PackageTable packages) {
-    return parseTextDocument(path).map(d -> processDocument(d, isExportedSymbol, packages));
+    return parseTextDocument(path).flatMap(d -> processDocument(d, isExportedSymbol, packages));
   }
 
-  private Integer processDocument(
+  private Stream<Integer> processDocument(
+      LsifTextDocument doc, Set<String> isExportedSymbol, PackageTable packages) {
+    try {
+      return Stream.of(processDocumentUnsafe(doc, isExportedSymbol, packages));
+    } catch (Exception e) {
+      options.reporter.error(new LsifProcessingException(doc, e));
+      return Stream.empty();
+    }
+  }
+
+  private Integer processDocumentUnsafe(
       LsifTextDocument doc, Set<String> isExportedSymbol, PackageTable packages) {
     Symtab symtab = new Symtab(doc.semanticdb);
 

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolDescriptor.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolDescriptor.java
@@ -4,7 +4,6 @@ import com.sourcegraph.semanticdb_javac.SemanticdbSymbols;
 import com.sourcegraph.semanticdb_javac.SemanticdbSymbols.Descriptor;
 import com.sourcegraph.semanticdb_javac.SemanticdbSymbols.Descriptor.Kind;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 
 public class SymbolDescriptor {
 
@@ -15,6 +14,8 @@ public class SymbolDescriptor {
     this.descriptor = descriptor;
     this.owner = owner;
   }
+
+  public static SymbolDescriptor NONE = new SymbolDescriptor(Descriptor.NONE, SemanticdbSymbols.NONE);
 
   public static SymbolDescriptor parseFromSymbol(String symbol) {
     return new Parser(symbol).entryPoint();
@@ -56,6 +57,8 @@ public class SymbolDescriptor {
     public SymbolDescriptor entryPoint() {
       if (SemanticdbSymbols.isLocal(symbol))
         return new SymbolDescriptor(Descriptor.local(symbol), SemanticdbSymbols.NONE);
+      if (SemanticdbSymbols.NONE.equals(symbol))
+        return SymbolDescriptor.NONE;
       readChar();
       SemanticdbSymbols.Descriptor descriptor = parseDescriptor();
 

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolDescriptor.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolDescriptor.java
@@ -15,7 +15,8 @@ public class SymbolDescriptor {
     this.owner = owner;
   }
 
-  public static SymbolDescriptor NONE = new SymbolDescriptor(Descriptor.NONE, SemanticdbSymbols.NONE);
+  public static SymbolDescriptor NONE =
+      new SymbolDescriptor(Descriptor.NONE, SemanticdbSymbols.NONE);
 
   public static SymbolDescriptor parseFromSymbol(String symbol) {
     return new Parser(symbol).entryPoint();
@@ -55,10 +56,12 @@ public class SymbolDescriptor {
     }
 
     public SymbolDescriptor entryPoint() {
-      if (SemanticdbSymbols.isLocal(symbol))
+      if (SemanticdbSymbols.isLocal(symbol)) {
         return new SymbolDescriptor(Descriptor.local(symbol), SemanticdbSymbols.NONE);
-      if (SemanticdbSymbols.NONE.equals(symbol))
+      }
+      if (SemanticdbSymbols.NONE.equals(symbol)) {
         return SymbolDescriptor.NONE;
+      }
       readChar();
       SemanticdbSymbols.Descriptor descriptor = parseDescriptor();
 


### PR DESCRIPTION
This change should fix the following stack trace
```
Caused by: java.lang.IllegalArgumentException: invalid symbol format
^
	at com.sourcegraph.lsif_semanticdb.SymbolDescriptor$Parser.fail(SymbolDescriptor.java:72)
	at com.sourcegraph.lsif_semanticdb.SymbolDescriptor$Parser.parseDescriptor(SymbolDescriptor.java:143)
	at com.sourcegraph.lsif_semanticdb.SymbolDescriptor$Parser.entryPoint(SymbolDescriptor.java:60)
	at com.sourcegraph.lsif_semanticdb.SymbolDescriptor.parseFromSymbol(SymbolDescriptor.java:20)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.symbolDisplayName(SignatureFormatter.java:532)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.formatType(SignatureFormatter.java:424)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.formatTypeArguments(SignatureFormatter.java:249)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.formatType(SignatureFormatter.java:414)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.formatMethodSignature(SignatureFormatter.java:164)
	at com.sourcegraph.lsif_semanticdb.SignatureFormatter.formatSymbol(SignatureFormatter.java:38)
	at com.sourcegraph.lsif_semanticdb.LsifSemanticdb.processDocument(LsifSemanticdb.java:140)
	at com.sourcegraph.lsif_semanticdb.LsifSemanticdb.lambda$processPath$3(LsifSemanticdb.java:83)
```

Reported by @wiwa 