### PR TITLE
Update packageInformation structure

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
@@ -279,7 +279,7 @@ object SnapshotLsifCommand {
             )
             s"range(${node.getId}) ${renderPos(node.getStart)} '${p.text}'"
           case ("vertex", "packageInformation") =>
-            s"${node.getName}(${node.getId})"
+            s"${node.getName} ${node.getVersion}(${node.getId})"
           case ("vertex", label) =>
             s"${label}(${node.getId})"
           case _ =>

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JdkPackage.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/JdkPackage.java
@@ -9,7 +9,7 @@ public class JdkPackage extends Package {
 
   @Override
   public String repoName() {
-    return String.format("jdk/%s", version);
+    return "jdk";
   }
 
   @Override

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
@@ -127,7 +127,7 @@ public class LsifWriter implements AutoCloseable {
     return emitObject(
         lsifVertex("packageInformation")
             .setName(pkg.repoName())
-            .setManager("packagehub")
+            .setManager("jvm-dependencies")
             .setVersion(pkg.version()));
   }
 

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/MavenPackage.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/MavenPackage.java
@@ -17,7 +17,7 @@ public class MavenPackage extends Package {
 
   @Override
   public String repoName() {
-    return String.format("maven/%s/%s/%s", groupId, artifactId, version);
+    return String.format("maven/%s/%s", groupId, artifactId);
   }
 
   @Override

--- a/tests/snapshots/src/main/generated/index-semanticdb/packages
+++ b/tests/snapshots/src/main/generated/index-semanticdb/packages
@@ -57,5 +57,5 @@ public class Example {
                          │             │                               │      │
                          v             v                               v      │
            ╭────────────────────────────────────────╮           ╭─────────────┴─────╮
-           │maven/org.hamcrest/hamcrest-core/1.3(23)│           │referenceResult(76)│
+           │maven/org.hamcrest/hamcrest-core 1.3(23)│           │referenceResult(76)│
            ╰────────────────────────────────────────╯           ╰───────────────────╯

--- a/tests/snapshots/src/main/generated/index-semanticdb/packages-jvm
+++ b/tests/snapshots/src/main/generated/index-semanticdb/packages-jvm
@@ -43,5 +43,5 @@ public class Example {
        │                    ││
        v                    v│
  ╭──────────╮ ╭──────────────┴────╮
- │jdk/11(33)│ │referenceResult(35)│
+ │jdk 11(33)│ │referenceResult(35)│
  ╰──────────╯ ╰───────────────────╯


### PR DESCRIPTION
Fixes #266. Previously, `packageInformation` vertices used a structure
that was suited for PackageHub, a prototype implementation of package
repos for Sourcegraph. PackageHub has now been made redundant by the new
"JVM Dependencies" external service type that got recently added to
Sourcegraph. Now, the new `packageInformation` structure matches what's
most suitable for the new "JVM Dependencies".