### PR TITLE
Handle null/unit constant types.

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SignatureFormatter.java
@@ -472,7 +472,9 @@ public class SignatureFormatter {
   }
 
   private String formatConstant(Constant constant) {
-    if (constant.hasBooleanConstant()) {
+    if (constant.hasUnitConstant()) {
+      return isScala ? "()" : "scala.Unit()";
+    } else if (constant.hasBooleanConstant()) {
       return Boolean.toString(constant.getBooleanConstant().getValue());
     } else if (constant.hasByteConstant()) {
       return Integer.toString(constant.getByteConstant().getValue());
@@ -490,6 +492,8 @@ public class SignatureFormatter {
       return Double.toString(constant.getDoubleConstant().getValue());
     } else if (constant.hasStringConstant()) {
       return '"' + constant.getStringConstant().getValue() + '"';
+    } else if (constant.hasNullConstant()) {
+      return "null";
     }
     throw new IllegalArgumentException("constant was not of known type " + constant);
   }

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -346,6 +346,7 @@ enum BinaryOperator {
 
 message Constant {
   oneof sealed_value {
+    UnitConstant unit_constant = 1;
     BooleanConstant boolean_constant = 2;
     ByteConstant byte_constant = 3;
     ShortConstant short_constant = 4;
@@ -355,7 +356,11 @@ message Constant {
     FloatConstant float_constant = 8;
     DoubleConstant double_constant = 9;
     StringConstant string_constant = 10;
+    NullConstant null_constant = 11;
   }
+}
+
+message UnitConstant {
 }
 
 message BooleanConstant {
@@ -392,4 +397,7 @@ message DoubleConstant {
 
 message StringConstant {
   string value = 1;
+}
+
+message NullConstant {
 }


### PR DESCRIPTION
Previously, the snapshot-lsif command failed when encountering these
types.