### PR TITLE
Fix: message error '--build-tools=BUILD_TOOL_NAME'

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/IndexCommand.scala
@@ -163,7 +163,7 @@ case class IndexCommand(
         val names = many.map(_.name).mkString(", ")
         app.error(
           s"Multiple build tools detected: $names. " +
-            s"To fix this problem, use the '--build-tools=BUILD_TOOL_NAME' flag to specify which build tool to run."
+            s"To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run."
         )
         1
     }

--- a/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
@@ -14,7 +14,7 @@ class MissingBuildToolSuite extends BaseBuildToolSuite {
     "ambiguous",
     List("index"),
     expectedOutput =
-      """|error: Multiple build tools detected: Gradle, Maven. To fix this problem, use the '--build-tools=BUILD_TOOL_NAME' flag to specify which build tool to run.
+      """|error: Multiple build tools detected: Gradle, Maven. To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run.
          |""".stripMargin,
     workingDirectoryLayout =
       """|/pom.xml


### PR DESCRIPTION
This PR fixes the message showed when lsif-java identifies more than one build tool.

It is now show `'--build-tool=BUILD_TOOL_NAME'`. instead of `'--build-tools=BUILD_TOOL_NAME'` 

Below I'm sharing logs showing the wrong beharior.

lsif-java version: `0.6.4`

<details><summary>Usage logs with wrong error message</summary>
<pre>
coursier launch --jvm 8 com.sourcegraph:lsif-java_2.13:0.6.4 -- index
https://repo1.maven.org/maven2/com/sourcegraph/lsif-java_2.13/0.6.4/lsif-java_2.13-0.6.4.pom
  100.0% [##########] 3.2 KiB (5.9 KiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/lsif-semanticdb/0.6.4/lsif-semanticdb-0.6.4.pom
  100.0% [##########] 2.2 KiB (16.8 KiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/semanticdb-java/0.6.4/semanticdb-java-0.6.4.pom
  100.0% [##########] 1.8 KiB (15.1 KiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/lsif-semanticdb/0.6.4/lsif-semanticdb-0.6.4.jar
  100.0% [##########] 110.2 KiB (437.3 KiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/semanticdb-java/0.6.4/semanticdb-java-0.6.4.jar
  100.0% [##########] 592.0 KiB (1.3 MiB / s)
https://repo1.maven.org/maven2/com/sourcegraph/lsif-java_2.13/0.6.4/lsif-java_2.13-0.6.4.jar
  100.0% [##########] 5.6 MiB (6.4 MiB / s)
error: Multiple build tools detected: Gradle, sbt. To fix this problem, use the '--build-tools=BUILD_TOOL_NAME' flag to specify which build tool to run.
</pre>
</details>

<details><summary>Usage logs with --build-tools=gradle</summary>
<pre>
coursier launch --jvm 8 com.sourcegraph:lsif-java_2.13:0.6.4 -- index --build-tools=gradle
error: found argument '--build-tools' which wasn't expected, or isn't valid in this context.
	Did you mean '--build-tool'?
</pre>
</details>
