### PR TITLE
change manual gradle configuration to use compileOnly instead of implementation

### DIFF
--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -38,7 +38,7 @@ javac -classpath semanticdb-javac.jar MyApplication.java
 If you're using Gradle.
 
 ```groovy
-implementation group: 'com.sourcegraph', name: 'semanticdb-javac', version: '@STABLE_VERSION@'
+compileOnly group: 'com.sourcegraph', name: 'semanticdb-javac', version: '@STABLE_VERSION@'
 ```
 
 If you're using Maven.


### PR DESCRIPTION
Due to how Gradle classpath configurations are laid out, we should recommend semanticdb-javac dependency be in the `compileOnly` configuration, as building fatjars by default takes from the `runtimeClasspath` classpath, as well as other runtime implications.

![image](https://user-images.githubusercontent.com/18282288/129389473-014e1193-39d1-4582-aa28-196bb94d2d90.png)