### PR TITLE
fix range emitted for member references to only include the reference

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/CompilerRange.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/CompilerRange.java
@@ -32,15 +32,21 @@ public enum CompilerRange {
 
   /**
    * Use text search to find the start of the symbol name and use (found start + symbol name length)
-   * for the SemanticDB end position;
+   * for the SemanticDB end position.
    */
   FROM_TEXT_SEARCH,
 
   /**
    * Use text search to find the start of the symbol name, using the point position as the starting
-   * search offset and using (found start + symbol name length) for the SemanticDB end position;
+   * search offset and using (found start + symbol name length) for the SemanticDB end position.
    */
-  FROM_POINT_WITH_TEXT_SEARCH;
+  FROM_POINT_WITH_TEXT_SEARCH,
+
+  /**
+   * Use text search to find the start of the symbol name, searching from the end instead of the
+   * start.
+   */
+  FROM_END_WITH_TEXT_SEARCH;
 
   public boolean isFromPoint() {
     switch (this) {
@@ -56,10 +62,15 @@ public enum CompilerRange {
   public boolean isFromTextSearch() {
     switch (this) {
       case FROM_TEXT_SEARCH:
+      case FROM_END_WITH_TEXT_SEARCH:
       case FROM_POINT_WITH_TEXT_SEARCH:
         return true;
       default:
         return false;
     }
+  }
+
+  public boolean isFromEnd() {
+    return this == CompilerRange.FROM_END_WITH_TEXT_SEARCH;
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/RangeFinder.java
@@ -22,7 +22,8 @@ public class RangeFinder {
       CompilationUnitTree root,
       Element element,
       int startPos,
-      String source) {
+      String source,
+      boolean fromEnd) {
     LineMap lineMap = root.getLineMap();
     Name name = element.getSimpleName();
     if (name.contentEquals("<init>")) name = element.getEnclosingElement().getSimpleName();
@@ -30,7 +31,7 @@ public class RangeFinder {
     int endPos = (int) trees.getSourcePositions().getEndPosition(root, path.getLeaf());
     // false for anonymous classes
     if (name.length() != 0) {
-      startPos = findNameIn(name, startPos, source);
+      startPos = findNameIn(name, fromEnd ? endPos : startPos, source, fromEnd);
       endPos = startPos + name.length();
     }
 
@@ -48,10 +49,12 @@ public class RangeFinder {
     return Optional.of(range);
   }
 
-  private static int findNameIn(CharSequence name, int start, String source) {
+  private static int findNameIn(CharSequence name, int start, String source, boolean fromEnd) {
     if (source.equals("")) return -1;
 
-    int offset = source.indexOf(name.toString(), start);
+    int offset;
+    if (fromEnd) offset = source.lastIndexOf(name.toString(), start);
+    else offset = source.indexOf(name.toString(), start);
     if (offset > -1) {
       return offset;
     }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -216,7 +216,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   public Void visitMemberReference(MemberReferenceTree node, Void unused) {
     if (node instanceof JCTree.JCMemberReference) {
       JCTree.JCMemberReference ref = (JCTree.JCMemberReference) node;
-      emitSymbolOccurrence(ref.sym, ref, Role.REFERENCE, CompilerRange.FROM_START_TO_END);
+      emitSymbolOccurrence(ref.sym, ref, Role.REFERENCE, CompilerRange.FROM_END_WITH_TEXT_SEARCH);
     }
     return super.visitMemberReference(node, unused);
   }
@@ -284,7 +284,8 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
               getCurrentPath().getCompilationUnit(),
               sym,
               start,
-              this.source);
+              this.source,
+              kind.isFromEnd());
       if (range.isPresent()) return Optional.of(correctForTabs(range.get(), lineMap, start));
       else return range;
     } else if (start != Position.NOPOS && end != Position.NOPOS && end > start) {

--- a/tests/snapshots/src/main/generated/minimized/Enums.java
+++ b/tests/snapshots/src/main/generated/minimized/Enums.java
@@ -46,7 +46,7 @@ enum Enums {
 //                                                  ^^^^^ reference minimized/Enums#value.
 //                                                         ^^^ reference java/util/stream/Stream#map().
 //                                                             ^^^^^ reference minimized/Enums#
-//                                                             ^^^^^^^^^^^^^^ reference minimized/Enums#valueOf().
+//                                                                    ^^^^^^^ reference minimized/Enums#valueOf().
 //                                                                             ^^^^^^^^ reference java/lang/Object#toString().
     return all + A.value + B.value + C.value;
 //         ^^^ reference local2


### PR DESCRIPTION
Fixes #307 

Unfortunately, the referenced method in a member reference tree node doesn't have a child node. In the example of `this.getThis().getThis().getThis()::supplyFoo`, the only descendant nodes are `this` and each `getThis`. For that reason, this approach uses a basic text search starting from the _end_ position of the member reference tree node. 