### PR TITLE
Handle `-cp` javac compiler option just like `-classpath`

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbOptionBuilder.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbOptionBuilder.java
@@ -27,7 +27,9 @@ public class SemanticdbOptionBuilder {
   public void processArgument(String arg) {
     oldArgs.add(arg);
     arg = unwrapQuote(arg);
-    if ("-processorpath".equals(previousArg) || "-classpath".equals(previousArg)) {
+    if ("-processorpath".equals(previousArg)
+        || "-classpath".equals(previousArg)
+        || "-cp".equals(previousArg)) {
       isClasspathUpdated = true;
       result.add(PLUGINPATH + File.pathSeparator + arg);
     } else if (arg.startsWith("-J")) {


### PR DESCRIPTION
Previously, the `lsif-java index` command only worked if the build tool
used the `-classpath` javac option, but not the equivalent `-cp` option.
Now, we treat `-cp` and `-classpath` equally.