### PR TITLE
Properly fix issue with checkerframework Gradle plugin.

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
@@ -78,17 +78,7 @@ class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
       buildCommand +=
         s"-Porg.gradle.java.installations.paths=${toolchains.paths()}"
     }
-    buildCommand ++=
-      index.finalBuildCommand(
-        List(
-          // Disable the checkerframework plugin because it updates the processorpath
-          // in a way that causes the error "plug-in not found: semanticdb".
-          // Details: https://github.com/kelloggm/checkerframework-gradle-plugin/blob/76d1926ae22144b082dfcfde1abe625750469398/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy#L374-L376
-          "-PskipCheckerFramework",
-          "clean",
-          "compileTestJava"
-        )
-      )
+    buildCommand ++= index.finalBuildCommand(List("clean", "compileTestJava"))
     buildCommand += lsifJavaDependencies
 
     val result = index.process(buildCommand, env = Map("TERM" -> "dumb"))


### PR DESCRIPTION
Previously, `lsif-java index` had custom logic to disable the
checkerframework Gradle plugin in order to prevent the error
"plug-in not found: semanticdb". This commit replaces that custom logic
with a proper fix to this bug, which is to automatically inject the
SemanticDB compiler plugin jar to the annotation processor path
as well as the compile classpath.