### PR TITLE
Return non-zero exit code when missing SemanticDB files

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/LsifBuildTool.scala
@@ -160,18 +160,20 @@ class LsifBuildTool(index: IndexCommand) extends BuildTool("LSIF", index) {
       .isDirectory(targetroot.resolve("META-INF"))
     if (errors.nonEmpty && !isSemanticdbGenerated) {
       CommandResult(1, Nil)
-    } else if (errors.nonEmpty && isSemanticdbGenerated) {
-      index
-        .app
-        .reporter
-        .info(
-          "Some SemanticDB files got generated even if there were compile errors. " +
-            "In most cases, this means that lsif-java managed to index everything " +
-            "except the locations that had compile errors and you can ignore the compile errors." +
-            errors.mkString("\n")
-        )
+    } else {
+      if (errors.nonEmpty && isSemanticdbGenerated) {
+        index
+          .app
+          .reporter
+          .info(
+            "Some SemanticDB files got generated even if there were compile errors. " +
+              "In most cases, this means that lsif-java managed to index everything " +
+              "except the locations that had compile errors and you can ignore the compile errors." +
+              errors.mkString("\n")
+          )
+      }
+      CommandResult(0, Nil)
     }
-    CommandResult(0, Nil)
   }
 
   private def compileScalaFiles(


### PR DESCRIPTION
Previously, `lsif-java index` would occasionally return a successful
exit code even if it didn't produce a `dump.lsif` file. Now, it should
return the exit code 1 instead in these scenarios.