### PR TITLE
Index SemanticDB synthetics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,7 +313,8 @@ lazy val minimizedScala = project
   .in(file("tests/minimized-scala"))
   .settings(
     (publish / skip) := true,
-    semanticdbOptions ++= List("-P:semanticdb:text:on")
+    semanticdbOptions ++=
+      List("-P:semanticdb:text:on", "-P:semanticdb:synthetics:on")
   )
   .dependsOn(minimized)
 

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
@@ -3,6 +3,7 @@ package com.sourcegraph.lsif_java
 import scala.jdk.CollectionConverters._
 
 import com.sourcegraph.lsif_java.commands.CommentSyntax
+import com.sourcegraph.lsif_semanticdb.LsifTextDocument
 import com.sourcegraph.lsif_semanticdb.SignatureFormatter
 import com.sourcegraph.lsif_semanticdb.Symtab
 import com.sourcegraph.semanticdb_javac.Semanticdb.SymbolOccurrence
@@ -14,8 +15,8 @@ object SemanticdbPrinters {
       doc: TextDocument,
       comments: CommentSyntax = CommentSyntax.default
   ): String = {
-    val occurrencesByLine = doc
-      .getOccurrencesList
+    val occurrencesByLine = LsifTextDocument
+      .sortedSymbolOccurrences(doc)
       .asScala
       .groupBy(_.getRange.getStartLine)
     val out = new StringBuilder()
@@ -80,13 +81,7 @@ object SemanticdbPrinters {
       .append(occ.getSymbol)
       .append(
         if (isMultiline)
-          " "
-        else
-          ""
-      )
-      .append(
-        if (isMultiline)
-          s"${r.getEndLine - r.getStartLine}:${r.getEndCharacter}"
+          s" ${r.getEndLine - r.getStartLine}:${r.getEndCharacter}"
         else
           ""
       )
@@ -102,7 +97,10 @@ object SemanticdbPrinters {
             ""
         }
       )
-      .append("\n")
+    while (out.last == ' ') { // Trim trailing whitespace
+      out.setLength(out.length() - 1)
+    }
+    out.append("\n")
   }
 
 }

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SemanticdbTreeVisitor.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SemanticdbTreeVisitor.java
@@ -1,0 +1,80 @@
+package com.sourcegraph.lsif_semanticdb;
+
+import com.sourcegraph.semanticdb_javac.Semanticdb.*;
+
+public abstract class SemanticdbTreeVisitor {
+  public void visitTree(Tree tree) {
+    if (tree.hasApplyTree()) {
+      this.visitApplyTree(tree.getApplyTree());
+    } else if (tree.hasFunctionTree()) {
+      this.visitFunctionTree(tree.getFunctionTree());
+    } else if (tree.hasIdTree()) {
+      this.visitIdTree(tree.getIdTree());
+    } else if (tree.hasLiteralTree()) {
+      this.visitLiteralTree(tree.getLiteralTree());
+    } else if (tree.hasMacroExpansionTree()) {
+      this.visitMacroExpansionTree(tree.getMacroExpansionTree());
+    } else if (tree.hasOriginalTree()) {
+      this.visitOriginalTree(tree.getOriginalTree());
+    } else if (tree.hasSelectTree()) {
+      this.visitSelectTree(tree.getSelectTree());
+    } else if (tree.hasTypeApplyTree()) {
+      this.visitTypeApplyTree(tree.getTypeApplyTree());
+    } else if (tree.hasAnnotationTree()) {
+      this.visitAnnotationTree(tree.getAnnotationTree());
+    } else if (tree.hasAssignTree()) {
+      this.visitAssignTree(tree.getAssignTree());
+    } else if (tree.hasBinopTree()) {
+      this.visitBinaryOperatorTree(tree.getBinopTree());
+    }
+  }
+
+  void visitApplyTree(ApplyTree tree) {
+    visitTree(tree.getFunction());
+    for (Tree argument : tree.getArgumentsList()) {
+      visitTree(argument);
+    }
+  }
+
+  void visitFunctionTree(FunctionTree tree) {
+    for (IdTree parameter : tree.getParametersList()) {
+      visitIdTree(parameter);
+    }
+    visitTree(tree.getBody());
+  }
+
+  void visitIdTree(IdTree tree) {}
+
+  void visitLiteralTree(LiteralTree tree) {}
+
+  void visitMacroExpansionTree(MacroExpansionTree tree) {
+    visitTree(tree.getBeforeExpansion());
+  }
+
+  void visitOriginalTree(OriginalTree tree) {}
+
+  void visitSelectTree(SelectTree tree) {
+    visitTree(tree.getQualifier());
+    visitIdTree(tree.getId());
+  }
+
+  void visitTypeApplyTree(TypeApplyTree tree) {
+    visitTree(tree.getFunction());
+  }
+
+  void visitAnnotationTree(AnnotationTree tree) {
+    for (Tree parameter : tree.getParametersList()) {
+      visitTree(parameter);
+    }
+  }
+
+  void visitAssignTree(AssignTree tree) {
+    visitTree(tree.getLhs());
+    visitTree(tree.getRhs());
+  }
+
+  void visitBinaryOperatorTree(BinaryOperatorTree tree) {
+    visitTree(tree.getLhs());
+    visitTree(tree.getRhs());
+  }
+}

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -26,6 +26,7 @@ message TextDocument {
   Language language = 10;
   repeated SymbolInformation symbols = 5;
   repeated SymbolOccurrence occurrences = 6;
+  repeated Synthetic synthetics = 12;
 }
 
 enum Language {
@@ -267,13 +268,21 @@ message RepeatedType {
   Type tpe = 1;
 }
 
+message Synthetic {
+  Range range = 1;
+  Tree tree = 2;
+}
+
 message Tree {
   oneof sealed_value {
     ApplyTree apply_tree = 1;
+    FunctionTree function_tree = 2;
     IdTree id_tree = 3;
     LiteralTree literal_tree = 4;
+    MacroExpansionTree macro_expansion_tree = 5;
     OriginalTree original_tree = 6;
     SelectTree select_tree = 7;
+    TypeApplyTree type_apply_tree = 8;
     // -- OUT OF SPEC -- //
     AnnotationTree annotation_tree = 9;
     AssignTree assign_tree = 10;
@@ -287,21 +296,38 @@ message ApplyTree {
   repeated Tree arguments = 2;
 }
 
+
+message FunctionTree {
+  repeated IdTree parameters = 1;
+  Tree body = 2;
+}
+
 message IdTree {
   string symbol = 1;
+}
+
+
+message LiteralTree {
+  Constant constant = 1;
+}
+
+message MacroExpansionTree {
+  Tree before_expansion = 1;
+  Type tpe = 2;
 }
 
 message OriginalTree {
   Range range = 1;
 }
 
-message LiteralTree {
-  Constant constant = 1;
-}
-
 message SelectTree {
   Tree qualifier = 1;
   IdTree id = 2;
+}
+
+message TypeApplyTree {
+  Tree function = 1;
+  repeated Type type_arguments = 2;
 }
 
 // -- OUT OF SPEC -- //

--- a/tests/minimized-scala/src/main/scala/minimized/MinimizedScalaSynthetic.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/MinimizedScalaSynthetic.scala
@@ -1,0 +1,19 @@
+package minimized
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class MinimizedScalaSynthetic {
+  def everything(): Unit = Future(1)
+  def applyTree(): Unit = Future.apply[Int](1)
+  def applyTree2(): Unit = List.apply[Int](1).sorted
+  def selectTree(): Unit = Future[Int](1)
+  def typeApplyTree(): Unit = Future.apply(1)
+  def forComprehensions(): Unit =
+    for {
+      x <- Future(1)
+      y <- Future.successful(1)
+      if y < 2
+      z <- Future.apply[Int](1)
+    } yield x + y + z
+}

--- a/tests/snapshots/src/main/generated/ByteParser.scala
+++ b/tests/snapshots/src/main/generated/ByteParser.scala
@@ -144,6 +144,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
     val (value, i) = parseTopLevel(0, facade)
 //       ^^^^^ definition local0
 //              ^ definition local1
+//                 reference scala/Tuple2.apply().
 //                   ^^^^^^^^^^^^^ reference ujson/ByteParser#parseTopLevel().
 //                                    ^^^^^^ reference ujson/ByteParser#parse().(facade)
     var j = i
@@ -208,6 +209,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //        ^^^^^^^^^^^^^^^^^ reference scala/Predef.ArrayCharSequence#
 //                          reference scala/Predef.ArrayCharSequence#`<init>`().
 //                          ^^^^^ reference scala/Array.
+//                                reference scala/Array.apply(+4).
 //                                ^^^^^^^ reference ujson/ByteParser#elemOps.
 //                                        ^^^^^ reference upickle/core/ByteOps.toInt().
 //                                              ^^^^^^^^^^^ reference ujson/ByteParser#getByteSafe().
@@ -218,12 +220,14 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
     )
     val s = "%s got %s" format (msg, out.makeString())
 //      ^ definition local5
+//                      reference scala/Predef.augmentString().
 //                      ^^^^^^ reference scala/collection/StringOps#format().
 //                              ^^^ reference ujson/ByteParser#die().(msg)
 //                                   ^^^ reference local4
 //                                       ^^^^^^^^^^ reference upickle/core/ByteBuilder#makeString().
     throw ParseException(s, i)
 //        ^^^^^^^^^^^^^^ reference ujson/ParseException.
+//                       reference ujson/ParseException.apply().
 //                       ^ reference local5
 //                          ^ reference ujson/ByteParser#die().(i)
   }
@@ -898,6 +902,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
     catch reject(i)
 //        ^^^^^^ reference ujson/ByteParser#reject().
 //               ^ reference ujson/ByteParser#parseTopLevel().(i)
+//                  reference scala/Function1#apply().
   }
   /**
    * Parse and return the next JSON value and the position beyond it.
@@ -1007,6 +1012,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                                    ^ reference ujson/ByteParser#reject().(j)
 //                                               ^ reference local21
   }
+//  reference scala/Function1#apply().
   /**
    * Tail-recursive parsing method to do the bulk of JSON parsing.
    *
@@ -1070,6 +1076,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                                            ^^^^^^^^^ reference ujson/ByteParser#parseNested().(stackHead)
 //                                                             ^^^^^^ reference ujson/ByteParser#reject().
 //                                                                    ^ reference ujson/ByteParser#parseNested().(i)
+//                                                                       reference scala/Function1#apply().
             parseNested(COLON, nextJ, stackHead, stackTail)
 //          ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                      ^^^^^ reference ujson/ByteParser#COLON.
@@ -1087,6 +1094,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                                              ^^^^^^^^^ reference ujson/ByteParser#parseNested().(stackHead)
 //                                                               ^^^^^^ reference ujson/ByteParser#reject().
 //                                                                      ^ reference ujson/ByteParser#parseNested().(i)
+//                                                                         reference scala/Function1#apply().
             parseNested(collectionEndFor(stackHead), nextJ, stackHead, stackTail)
 //          ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                      ^^^^^^^^^^^^^^^^ reference ujson/ByteParser#collectionEndFor().
@@ -1137,6 +1145,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/ByteParser#reject().
 //                     ^ reference ujson/ByteParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(ARRBEG, i + 1, ctx, stackHead :: stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^ reference ujson/ByteParser#ARRBEG.
@@ -1165,6 +1174,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/ByteParser#reject().
 //                     ^ reference ujson/ByteParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(OBJBEG, i + 1, ctx, stackHead :: stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^ reference ujson/ByteParser#OBJBEG.
@@ -1195,6 +1205,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/ByteParser#reject().
 //                     ^ reference ujson/ByteParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), ctx, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/ByteParser#collectionEndFor().
@@ -1226,6 +1237,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/ByteParser#reject().
 //                   ^ reference ujson/ByteParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 4, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/ByteParser#collectionEndFor().
@@ -1258,6 +1270,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/ByteParser#reject().
 //                   ^ reference ujson/ByteParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 5, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/ByteParser#collectionEndFor().
@@ -1290,6 +1303,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/ByteParser#reject().
 //                   ^ reference ujson/ByteParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 4, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/ByteParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/ByteParser#collectionEndFor().
@@ -1436,6 +1450,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
     die(i, s"expected $expected")
 //  ^^^ reference ujson/ByteParser#die().
 //      ^ reference ujson/ByteParser#dieWithFailureMessage().(i)
+//          reference scala/StringContext.apply().
 //         ^ reference scala/StringContext#s().
 //                     ^^^^^^^^ reference local34
   }
@@ -1472,13 +1487,16 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                ^^^^^^^ reference scala/collection/immutable/List#isEmpty().
       Some(try stackHead.visitEnd(i) catch reject(i), i + 1)
 //    ^^^^ reference scala/Some.
+//         reference scala/Some.apply().
 //             ^^^^^^^^^ reference ujson/ByteParser#tryCloseCollection().(stackHead)
 //                       ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
 //                                ^ reference ujson/ByteParser#tryCloseCollection().(i)
 //                                         ^^^^^^ reference ujson/ByteParser#reject().
 //                                                ^ reference ujson/ByteParser#tryCloseCollection().(i)
+//                                                   reference scala/Function1#apply().
 //                                                    ^ reference ujson/ByteParser#tryCloseCollection().(i)
 //                                                      ^ reference scala/Int#`+`(+4).
+//                                                           reference scala/Tuple2.apply().
     } else {
       val ctxt2 = stackTail.head.narrow
 //        ^^^^^ definition local35
@@ -1494,6 +1512,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                                                ^ reference ujson/ByteParser#tryCloseCollection().(i)
 //                                                         ^^^^^^ reference ujson/ByteParser#reject().
 //                                                                ^ reference ujson/ByteParser#tryCloseCollection().(i)
+//                                                                   reference scala/Function1#apply().
       None
 //    ^^^^ reference scala/None.
 
@@ -1540,6 +1559,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //          ^ reference scala/Int#`<`(+2).
 //                 ^^^ reference ujson/ByteParser#die().
 //                     ^ reference local36
+//                         reference scala/StringContext.apply().
 //                        ^ reference scala/StringContext#s().
 //                                          ^ reference local37
       if (c == '\\' || c > 127) return -1 - j
@@ -1591,6 +1611,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //          ^ reference scala/Int#`<`(+2).
 //                 ^^^ reference ujson/ByteParser#die().
 //                     ^ reference local38
+//                         reference scala/StringContext.apply().
 //                        ^ reference scala/StringContext#s().
 //                                          ^ reference local39
       else if (c == '\\') {
@@ -1662,6 +1683,7 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
 //                  ^^^ reference ujson/ByteParser#die().
 //                      ^ reference local38
 //                        ^ reference scala/Int#`+`(+4).
+//                              reference scala/StringContext.apply().
 //                             ^ reference scala/StringContext#s().
         }
       } else {

--- a/tests/snapshots/src/main/generated/CharParser.scala
+++ b/tests/snapshots/src/main/generated/CharParser.scala
@@ -144,6 +144,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
     val (value, i) = parseTopLevel(0, facade)
 //       ^^^^^ definition local0
 //              ^ definition local1
+//                 reference scala/Tuple2.apply().
 //                   ^^^^^^^^^^^^^ reference ujson/CharParser#parseTopLevel().
 //                                    ^^^^^^ reference ujson/CharParser#parse().(facade)
     var j = i
@@ -208,6 +209,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //        ^^^^^^^^^^^^^^^^^ reference scala/Predef.ArrayCharSequence#
 //                          reference scala/Predef.ArrayCharSequence#`<init>`().
 //                          ^^^^^ reference scala/Array.
+//                                reference scala/Array.apply(+4).
 //                                ^^^^^^^ reference ujson/CharParser#elemOps.
 //                                        ^^^^^ reference upickle/core/CharOps.toInt().
 //                                              ^^^^^^^^^^^ reference ujson/CharParser#getCharSafe().
@@ -218,12 +220,14 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
     )
     val s = "%s got %s" format (msg, out.makeString())
 //      ^ definition local5
+//                      reference scala/Predef.augmentString().
 //                      ^^^^^^ reference scala/collection/StringOps#format().
 //                              ^^^ reference ujson/CharParser#die().(msg)
 //                                   ^^^ reference local4
 //                                       ^^^^^^^^^^ reference upickle/core/CharBuilder#makeString().
     throw ParseException(s, i)
 //        ^^^^^^^^^^^^^^ reference ujson/ParseException.
+//                       reference ujson/ParseException.apply().
 //                       ^ reference local5
 //                          ^ reference ujson/CharParser#die().(i)
   }
@@ -898,6 +902,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
     catch reject(i)
 //        ^^^^^^ reference ujson/CharParser#reject().
 //               ^ reference ujson/CharParser#parseTopLevel().(i)
+//                  reference scala/Function1#apply().
   }
   /**
    * Parse and return the next JSON value and the position beyond it.
@@ -1007,6 +1012,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                                    ^ reference ujson/CharParser#reject().(j)
 //                                               ^ reference local21
   }
+//  reference scala/Function1#apply().
   /**
    * Tail-recursive parsing method to do the bulk of JSON parsing.
    *
@@ -1070,6 +1076,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                                            ^^^^^^^^^ reference ujson/CharParser#parseNested().(stackHead)
 //                                                             ^^^^^^ reference ujson/CharParser#reject().
 //                                                                    ^ reference ujson/CharParser#parseNested().(i)
+//                                                                       reference scala/Function1#apply().
             parseNested(COLON, nextJ, stackHead, stackTail)
 //          ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                      ^^^^^ reference ujson/CharParser#COLON.
@@ -1087,6 +1094,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                                              ^^^^^^^^^ reference ujson/CharParser#parseNested().(stackHead)
 //                                                               ^^^^^^ reference ujson/CharParser#reject().
 //                                                                      ^ reference ujson/CharParser#parseNested().(i)
+//                                                                         reference scala/Function1#apply().
             parseNested(collectionEndFor(stackHead), nextJ, stackHead, stackTail)
 //          ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                      ^^^^^^^^^^^^^^^^ reference ujson/CharParser#collectionEndFor().
@@ -1137,6 +1145,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/CharParser#reject().
 //                     ^ reference ujson/CharParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(ARRBEG, i + 1, ctx, stackHead :: stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^ reference ujson/CharParser#ARRBEG.
@@ -1165,6 +1174,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/CharParser#reject().
 //                     ^ reference ujson/CharParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(OBJBEG, i + 1, ctx, stackHead :: stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^ reference ujson/CharParser#OBJBEG.
@@ -1195,6 +1205,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
           catch reject(i)
 //              ^^^^^^ reference ujson/CharParser#reject().
 //                     ^ reference ujson/CharParser#parseNested().(i)
+//                        reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), ctx, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/CharParser#collectionEndFor().
@@ -1226,6 +1237,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/CharParser#reject().
 //                   ^ reference ujson/CharParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 4, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/CharParser#collectionEndFor().
@@ -1258,6 +1270,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/CharParser#reject().
 //                   ^ reference ujson/CharParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 5, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/CharParser#collectionEndFor().
@@ -1290,6 +1303,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
         catch reject(i)
 //            ^^^^^^ reference ujson/CharParser#reject().
 //                   ^ reference ujson/CharParser#parseNested().(i)
+//                      reference scala/Function1#apply().
         parseNested(collectionEndFor(stackHead), i + 4, stackHead, stackTail)
 //      ^^^^^^^^^^^ reference ujson/CharParser#parseNested().
 //                  ^^^^^^^^^^^^^^^^ reference ujson/CharParser#collectionEndFor().
@@ -1436,6 +1450,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
     die(i, s"expected $expected")
 //  ^^^ reference ujson/CharParser#die().
 //      ^ reference ujson/CharParser#dieWithFailureMessage().(i)
+//          reference scala/StringContext.apply().
 //         ^ reference scala/StringContext#s().
 //                     ^^^^^^^^ reference local34
   }
@@ -1472,13 +1487,16 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                ^^^^^^^ reference scala/collection/immutable/List#isEmpty().
       Some(try stackHead.visitEnd(i) catch reject(i), i + 1)
 //    ^^^^ reference scala/Some.
+//         reference scala/Some.apply().
 //             ^^^^^^^^^ reference ujson/CharParser#tryCloseCollection().(stackHead)
 //                       ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
 //                                ^ reference ujson/CharParser#tryCloseCollection().(i)
 //                                         ^^^^^^ reference ujson/CharParser#reject().
 //                                                ^ reference ujson/CharParser#tryCloseCollection().(i)
+//                                                   reference scala/Function1#apply().
 //                                                    ^ reference ujson/CharParser#tryCloseCollection().(i)
 //                                                      ^ reference scala/Int#`+`(+4).
+//                                                           reference scala/Tuple2.apply().
     } else {
       val ctxt2 = stackTail.head.narrow
 //        ^^^^^ definition local35
@@ -1494,6 +1512,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                                                ^ reference ujson/CharParser#tryCloseCollection().(i)
 //                                                         ^^^^^^ reference ujson/CharParser#reject().
 //                                                                ^ reference ujson/CharParser#tryCloseCollection().(i)
+//                                                                   reference scala/Function1#apply().
       None
 //    ^^^^ reference scala/None.
 
@@ -1540,6 +1559,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //          ^ reference scala/Int#`<`(+2).
 //                 ^^^ reference ujson/CharParser#die().
 //                     ^ reference local36
+//                         reference scala/StringContext.apply().
 //                        ^ reference scala/StringContext#s().
 //                                          ^ reference local37
       if (c == '\\' || c > 127) return -1 - j
@@ -1591,6 +1611,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //          ^ reference scala/Int#`<`(+2).
 //                 ^^^ reference ujson/CharParser#die().
 //                     ^ reference local38
+//                         reference scala/StringContext.apply().
 //                        ^ reference scala/StringContext#s().
 //                                          ^ reference local39
       else if (c == '\\') {
@@ -1662,6 +1683,7 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
 //                  ^^^ reference ujson/CharParser#die().
 //                      ^ reference local38
 //                        ^ reference scala/Int#`+`(+4).
+//                              reference scala/StringContext.apply().
 //                             ^ reference scala/StringContext#s().
         }
       } else {

--- a/tests/snapshots/src/main/generated/minimized/MinimizedScalaMain.scala
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedScalaMain.scala
@@ -55,6 +55,7 @@ object MinimizedScalaMain {
 //                                                reference minimized/ParameterizedTypes#`<init>`().
             .app(42, "42") +
 //           ^^^ reference minimized/ParameterizedTypes#app().
+//                  reference scala/Predef.int2Integer().
 //                         ^ reference java/lang/String#`+`().
           RawTypes.x.toString + 
 //        ^^^^^^^^ reference minimized/RawTypes#

--- a/tests/snapshots/src/main/generated/minimized/MinimizedScalaSynthetic.scala
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedScalaSynthetic.scala
@@ -1,0 +1,93 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+import scala.concurrent.ExecutionContext.Implicits.global
+//     ^^^^^ reference scala/
+//           ^^^^^^^^^^ reference scala/concurrent/
+//                      ^^^^^^^^^^^^^^^^ reference scala/concurrent/ExecutionContext.
+//                                       ^^^^^^^^^ reference scala/concurrent/ExecutionContext.Implicits.
+//                                                 ^^^^^^ reference scala/concurrent/ExecutionContext.Implicits.global().
+import scala.concurrent.Future
+//     ^^^^^ reference scala/
+//           ^^^^^^^^^^ reference scala/concurrent/
+//                      ^^^^^^ reference scala/concurrent/Future.
+//                      ^^^^^^ reference scala/concurrent/Future#
+
+class MinimizedScalaSynthetic {
+//    ^^^^^^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic# class MinimizedScalaSynthetic
+//                             definition minimized/MinimizedScalaSynthetic#`<init>`(). def this()
+  def everything(): Unit = Future(1)
+//    ^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#everything(). def everything(): Unit
+//                  ^^^^ reference scala/Unit#
+//                         ^^^^^^ reference scala/concurrent/Future.
+//                                reference scala/concurrent/Future.apply().
+//                                   reference scala/concurrent/ExecutionContext.Implicits.global().
+  def applyTree(): Unit = Future.apply[Int](1)
+//    ^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#applyTree(). def applyTree(): Unit
+//                 ^^^^ reference scala/Unit#
+//                        ^^^^^^ reference scala/concurrent/Future.
+//                               ^^^^^ reference scala/concurrent/Future.apply().
+//                                     ^^^ reference scala/Int#
+//                                             reference scala/concurrent/ExecutionContext.Implicits.global().
+  def applyTree2(): Unit = List.apply[Int](1).sorted
+//    ^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#applyTree2(). def applyTree2(): Unit
+//                  ^^^^ reference scala/Unit#
+//                         ^^^^ reference scala/package.List.
+//                              ^^^^^ reference scala/collection/IterableFactory#apply().
+//                                    ^^^ reference scala/Int#
+//                                            ^^^^^^ reference scala/collection/immutable/StrictOptimizedSeqOps#sorted().
+//                                                   reference scala/math/Ordering.Int.
+  def selectTree(): Unit = Future[Int](1)
+//    ^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#selectTree(). def selectTree(): Unit
+//                  ^^^^ reference scala/Unit#
+//                         ^^^^^^ reference scala/concurrent/Future.
+//                                reference scala/concurrent/Future.apply().
+//                                ^^^ reference scala/Int#
+//                                        reference scala/concurrent/ExecutionContext.Implicits.global().
+  def typeApplyTree(): Unit = Future.apply(1)
+//    ^^^^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#typeApplyTree(). def typeApplyTree(): Unit
+//                     ^^^^ reference scala/Unit#
+//                            ^^^^^^ reference scala/concurrent/Future.
+//                                   ^^^^^ reference scala/concurrent/Future.apply().
+//                                            reference scala/concurrent/ExecutionContext.Implicits.global().
+  def forComprehensions(): Unit =
+//    ^^^^^^^^^^^^^^^^^ definition minimized/MinimizedScalaSynthetic#forComprehensions(). def forComprehensions(): Unit
+//                         ^^^^ reference scala/Unit#
+    for {
+      x <- Future(1)
+//    ^ definition local0 x: Int
+//         ^^^^^^ reference scala/concurrent/Future.
+//                reference scala/concurrent/Future.apply().
+      y <- Future.successful(1)
+//    ^ definition local1 y: Int
+//         ^^^^^^ reference scala/concurrent/Future.
+//                ^^^^^^^^^^ reference scala/concurrent/Future.successful().
+      if y < 2
+//       ^ reference local1
+//         ^ reference scala/Int#`<`(+3).
+      z <- Future.apply[Int](1)
+//    ^ definition local2 z: Int
+//         ^^^^^^ reference scala/concurrent/Future.
+//                ^^^^^ reference scala/concurrent/Future.apply().
+//                      ^^^ reference scala/Int#
+    } yield x + y + z
+//          ^ reference local0
+//            ^ reference scala/Int#`+`(+4).
+//              ^ reference local1
+//                ^ reference scala/Int#`+`(+4).
+//                  ^ reference local2
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+//                    reference scala/concurrent/Future#flatMap().
+//                    reference local0
+//                    reference scala/concurrent/Future#withFilter().
+//                    reference local1
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+//                    reference scala/concurrent/Future#flatMap().
+//                    reference local1
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+//                    reference scala/concurrent/Future#map().
+//                    reference local2
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+//                    reference scala/concurrent/ExecutionContext.Implicits.global().
+}

--- a/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
+++ b/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
@@ -50,6 +50,8 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //                                              ^^^^ reference local1
 //                                                    ^^^ reference local0
 //                                                        ^^^^^^^^^^ reference upickle/core/ObjArrVisitor#subVisitor().
+//                                                                         reference scala/collection/IterableOnceOps#foreach().
+//                                                                         reference local1
     ctx.visitEnd(-1)
 //  ^^^ reference local0
 //      ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
@@ -94,6 +96,8 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //                                    ^^^ reference local3
 //                                        ^^^^^^^^^^ reference upickle/core/ObjArrVisitor#subVisitor().
     }
+//    reference scala/collection/IterableOnceOps#foreach().
+//    reference local4
     ctx.visitEnd(-1)
 //  ^^^ reference local3
 //      ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
@@ -153,6 +157,8 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //                                           ^^ reference ujson/AstTransformer#AstObjVisitor#vs.
 //                                              ^^ reference scala/collection/mutable/Growable#`+=`().
 //                                                  ^^^ reference ujson/AstTransformer#AstObjVisitor#key().
+//                                                      reference scala/Predef.
+//                                                      reference scala/Predef.ArrowAssoc().
 //                                                      ^^ reference scala/Predef.ArrowAssoc#`->`().
 //                                                         ^ reference ujson/AstTransformer#AstObjVisitor#visitValue().(v)
 
@@ -161,6 +167,7 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //               ^^^^^ definition ujson/AstTransformer#AstObjVisitor#visitEnd().(index)
 //                      ^^^ reference scala/Int#
 //                             ^^^^^ reference ujson/AstTransformer#AstObjVisitor#build.
+//                                   reference scala/Function1#apply().
 //                                   ^^ reference ujson/AstTransformer#AstObjVisitor#vs.
 //                                      ^^^^^^ reference scala/collection/mutable/Builder#result().
   }
@@ -205,6 +212,7 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //               ^^^^^ definition ujson/AstTransformer#AstArrVisitor#visitEnd().(index)
 //                      ^^^ reference scala/Int#
 //                             ^^^^^ reference ujson/AstTransformer#AstArrVisitor#build.
+//                                   reference scala/Function1#apply().
 //                                   ^^ reference ujson/AstTransformer#AstArrVisitor#vs.
 //                                      ^^^^^^ reference scala/collection/mutable/Builder#result().
   }

--- a/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
+++ b/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
@@ -213,6 +213,9 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                                               ^^^^^^ reference upickle/core/Util.reject().
 //                                                                                                      ^^^^ reference local14
 //                                                                                                           ^^^^^ reference ujson/IndexedValue#index().
+//                                                                                                                  reference scala/collection/IterableOnceOps#foreach().
+//                                                                                                                  reference local14
+//                                                                                                                  reference scala/Function1#apply().
         ctx.visitEnd(i)
 //      ^^^ reference local13
 //          ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
@@ -238,6 +241,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                          ^ reference local16
 //                                                   ^^^^^^ reference upickle/core/Util.reject().
 //                                                          ^ reference local16
+//                                                             reference scala/Function1#apply().
 
           ctx.visitKeyValue(keyVisitor.visitString(k, i))
 //        ^^^ reference local18
@@ -258,7 +262,12 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                              ^^^^^^ reference upickle/core/Util.reject().
 //                                                                                     ^^^^ reference local22
 //                                                                                          ^^^^^ reference ujson/IndexedValue#index().
+//                                                                                                 reference scala/Function1#apply().
         }
+//        reference scala/collection/IterableOps#withFilter().
+//        reference local19
+//        reference scala/collection/WithFilter#foreach().
+//        reference local20
         ctx.visitEnd(i)
 //      ^^^ reference local18
 //          ^^^^^^^^ reference upickle/core/ObjArrVisitor#visitEnd().
@@ -268,6 +277,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //        ^^^^^^ reference upickle/core/Util.reject().
 //               ^ reference ujson/IndexedValue.transform().(j)
 //                 ^^^^^ reference ujson/IndexedValue#index().
+//                        reference scala/Function1#apply().
 
 
   object Builder extends JsVisitor[IndexedValue, IndexedValue]{
@@ -316,6 +326,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                           ^^^ reference ujson/IndexedValue.Arr#
 //                                                 ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                                              ^^^ reference ujson/IndexedValue.Arr.
+//                                                                  reference ujson/IndexedValue.Arr.apply().
 //                                                                  ^ reference ujson/IndexedValue.Builder.visitArray().(i)
 //                                                                     ^^^ reference local25
 //                                                                         ^^^^^ reference scala/collection/IterableOnceOps#toSeq().
@@ -384,6 +395,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                           ^^^ reference ujson/IndexedValue.Obj#
 //                                                 ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                                              ^^^ reference ujson/IndexedValue.Obj.
+//                                                                  reference ujson/IndexedValue.Obj.apply().
 //                                                                  ^ reference ujson/IndexedValue.Builder.visitObject().(i)
 //                                                                     ^^^ reference local32
 //                                                                         ^^^^^ reference scala/collection/IterableOnceOps#toSeq().
@@ -395,6 +407,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                   ^^^ reference scala/Int#
 //                          ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                       ^^^^ reference ujson/IndexedValue.Null.
+//                                            reference ujson/IndexedValue.Null.apply().
 //                                            ^ reference ujson/IndexedValue.Builder.visitNull().(i)
 
     def visitFalse(i: Int) = IndexedValue.False(i)
@@ -403,6 +416,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                    ^^^ reference scala/Int#
 //                           ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                        ^^^^^ reference ujson/IndexedValue.False.
+//                                              reference ujson/IndexedValue.False.apply().
 //                                              ^ reference ujson/IndexedValue.Builder.visitFalse().(i)
 
     def visitTrue(i: Int) = IndexedValue.True(i)
@@ -411,6 +425,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                   ^^^ reference scala/Int#
 //                          ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                       ^^^^ reference ujson/IndexedValue.True.
+//                                            reference ujson/IndexedValue.True.apply().
 //                                            ^ reference ujson/IndexedValue.Builder.visitTrue().(i)
 
     def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = IndexedValue.Num(i, s, decIndex, expIndex)
@@ -425,6 +440,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                                ^^^ reference scala/Int#
 //                                                                                       ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                                                                                    ^^^ reference ujson/IndexedValue.Num.
+//                                                                                                        reference ujson/IndexedValue.Num.apply().
 //                                                                                                        ^ reference ujson/IndexedValue.Builder.visitFloat64StringParts().(i)
 //                                                                                                           ^ reference ujson/IndexedValue.Builder.visitFloat64StringParts().(s)
 //                                                                                                              ^^^^^^^^ reference ujson/IndexedValue.Builder.visitFloat64StringParts().(decIndex)
@@ -437,6 +453,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                          ^^^ reference scala/Int#
 //                                                 ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                                              ^^^^^^ reference ujson/IndexedValue.NumRaw.
+//                                                                     reference ujson/IndexedValue.NumRaw.apply().
 //                                                                     ^ reference ujson/IndexedValue.Builder.visitFloat64().(i)
 //                                                                        ^ reference ujson/IndexedValue.Builder.visitFloat64().(d)
 
@@ -448,6 +465,7 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                      ^^^ reference scala/Int#
 //                                             ^^^^^^^^^^^^ reference ujson/IndexedValue.
 //                                                          ^^^ reference ujson/IndexedValue.Str.
+//                                                              reference ujson/IndexedValue.Str.apply().
 //                                                              ^ reference ujson/IndexedValue.Builder.visitString().(i)
 //                                                                 ^ reference ujson/IndexedValue.Builder.visitString().(s)
   }

--- a/tests/snapshots/src/main/generated/ujson/JsVisitor.scala
+++ b/tests/snapshots/src/main/generated/ujson/JsVisitor.scala
@@ -179,6 +179,7 @@ trait JsVisitor[-T, +J] extends Visitor[T, J]{
 //                       ^^^^^^^^^^ reference upickle/core/ObjArrVisitor#subVisitor().
 //                                  ^^^^^^^^^^ reference upickle/core/Visitor#visitInt32().
 //                                             ^^^^^ reference ujson/JsVisitor#visitBinary().(bytes)
+//                                                   reference scala/Array#apply().
 //                                                   ^^^^^^ reference ujson/JsVisitor#visitBinary().(offset)
 //                                                          ^ reference scala/Int#`+`(+4).
 //                                                            ^ reference local3

--- a/tests/snapshots/src/main/generated/ujson/Readable.scala
+++ b/tests/snapshots/src/main/generated/ujson/Readable.scala
@@ -166,6 +166,7 @@ trait ReadableLowPri{
 //                                 ^ reference local5
 //                                      ^ reference local5
 //                                          ^^^^ reference ujson/ReadableLowPri#fromReadable().(conv)
+//                                               reference scala/Function1#apply().
 //                                               ^ reference ujson/ReadableLowPri#fromReadable().(s)
 //                                                  ^^^^^^^^^^^^^^^^ reference geny/Readable#readBytesThrough().
 //                                                                   ^^^^^^^^^^^^^^^^^ reference ujson/InputStreamParser.

--- a/tests/snapshots/src/main/generated/ujson/Transformer.scala
+++ b/tests/snapshots/src/main/generated/ujson/Transformer.scala
@@ -25,5 +25,6 @@ trait Transformer[I] {
 //                        ^ reference ujson/Transformer#[I]
 //                             ^^^^^^^^ reference ujson/Readable.
 //                                      ^^^^^^^^^^^^^^^ reference ujson/Readable.fromTransformer.
+//                                                      reference ujson/Readable.fromTransformer.apply().
 //                                                      ^ reference ujson/Transformer#transformable().(j)
 }

--- a/tests/snapshots/src/main/generated/ujson/Value.scala
+++ b/tests/snapshots/src/main/generated/ujson/Value.scala
@@ -37,6 +37,7 @@ sealed trait Value extends Readable with geny.Writable{
   override def httpContentType = Some("application/json")
 //             ^^^^^^^^^^^^^^^ definition ujson/Value#httpContentType().
 //                               ^^^^ reference scala/Some.
+//                                    reference scala/Some.apply().
   def value: Any
 //    ^^^^^ definition ujson/Value#value().
 //           ^^^ reference scala/Any#
@@ -55,6 +56,7 @@ sealed trait Value extends Readable with geny.Writable{
     case _ => throw Value.InvalidData(this, "Expected ujson.Str")
 //                  ^^^^^ reference ujson/Value.
 //                        ^^^^^^^^^^^ reference ujson/Value.InvalidData.
+//                                    reference ujson/Value.InvalidData.apply().
   }
 
   /**
@@ -66,6 +68,7 @@ sealed trait Value extends Readable with geny.Writable{
 //       ^^^ reference ujson/Str.
 //           ^^^^^ definition local1
 //                     ^^^^ reference scala/Some.
+//                          reference scala/Some.apply().
 //                          ^^^^^ reference local1
     case _ => None
 //            ^^^^ reference scala/None.
@@ -85,6 +88,7 @@ sealed trait Value extends Readable with geny.Writable{
     case _ => throw Value.InvalidData(this, "Expected ujson.Obj")
 //                  ^^^^^ reference ujson/Value.
 //                        ^^^^^^^^^^^ reference ujson/Value.InvalidData.
+//                                    reference ujson/Value.InvalidData.apply().
   }
   /**
     * Returns an Optional key/value map of this [[Value]] in case this [[Value]] is a 'Obj'.
@@ -95,6 +99,7 @@ sealed trait Value extends Readable with geny.Writable{
 //       ^^^ reference ujson/Obj.
 //           ^^^^^ definition local3
 //                     ^^^^ reference scala/Some.
+//                          reference scala/Some.apply().
 //                          ^^^^^ reference local3
     case _ => None
 //            ^^^^ reference scala/None.
@@ -113,6 +118,7 @@ sealed trait Value extends Readable with geny.Writable{
     case _ => throw Value.InvalidData(this, "Expected ujson.Arr")
 //                  ^^^^^ reference ujson/Value.
 //                        ^^^^^^^^^^^ reference ujson/Value.InvalidData.
+//                                    reference ujson/Value.InvalidData.apply().
   }
   /**
     * Returns The optional elements of this [[Value]] in case this [[Value]] is a 'Arr'.
@@ -123,6 +129,7 @@ sealed trait Value extends Readable with geny.Writable{
 //       ^^^ reference ujson/Arr.
 //           ^^^^^ definition local5
 //                     ^^^^ reference scala/Some.
+//                          reference scala/Some.apply().
 //                          ^^^^^ reference local5
     case _ => None
 //            ^^^^ reference scala/None.
@@ -141,6 +148,7 @@ sealed trait Value extends Readable with geny.Writable{
     case _ => throw Value.InvalidData(this, "Expected ujson.Num")
 //                  ^^^^^ reference ujson/Value.
 //                        ^^^^^^^^^^^ reference ujson/Value.InvalidData.
+//                                    reference ujson/Value.InvalidData.apply().
   }
   /**
     * Returns an Option[Double] in case this [[Value]] is a 'Num'.
@@ -151,6 +159,7 @@ sealed trait Value extends Readable with geny.Writable{
 //       ^^^ reference ujson/Num.
 //           ^^^^^ definition local7
 //                     ^^^^ reference scala/Some.
+//                          reference scala/Some.apply().
 //                          ^^^^^ reference local7
     case _ => None
 //            ^^^^ reference scala/None.
@@ -164,11 +173,13 @@ sealed trait Value extends Readable with geny.Writable{
     case ujson.Bool(value) => value
 //       ^^^^^ reference ujson/
 //             ^^^^ reference ujson/Bool.
+//                  reference ujson/Bool.unapply().
 //                  ^^^^^ definition local8
 //                            ^^^^^ reference local8
     case _ => throw Value.InvalidData(this, "Expected ujson.Bool")
 //                  ^^^^^ reference ujson/Value.
 //                        ^^^^^^^^^^^ reference ujson/Value.InvalidData.
+//                                    reference ujson/Value.InvalidData.apply().
   }
   /**
     * Returns an Optional `Boolean` value of this [[Value]] in case this [[Value]] is a 'Bool'.
@@ -177,8 +188,10 @@ sealed trait Value extends Readable with geny.Writable{
 //    ^^^^^^^ definition ujson/Value#boolOpt().
     case Bool(value) => Some(value)
 //       ^^^^ reference ujson/Bool.
+//            reference ujson/Bool.unapply().
 //            ^^^^^ definition local9
 //                      ^^^^ reference scala/Some.
+//                           reference scala/Some.apply().
 //                           ^^^^^ reference local9
     case _ => None
 //            ^^^^ reference scala/None.
@@ -201,6 +214,7 @@ sealed trait Value extends Readable with geny.Writable{
 //                   ^^^^^^^^ reference ujson/Value.Selector#
 //                              ^^^^^ reference ujson/Value#
 //                                      ^ reference ujson/Value#apply().(s)
+//                                        reference ujson/Value.Selector#apply().
   def update(s: Value.Selector, v: Value): Unit = s(this) = v
 //    ^^^^^^ definition ujson/Value#update().
 //           ^ definition ujson/Value#update().(s)
@@ -210,6 +224,7 @@ sealed trait Value extends Readable with geny.Writable{
 //                                 ^^^^^ reference ujson/Value#
 //                                         ^^^^ reference scala/Unit#
 //                                                ^ reference ujson/Value#update().(s)
+//                                                  reference ujson/Value.Selector#update().
 //                                                          ^ reference ujson/Value#update().(v)
 
   /**
@@ -229,8 +244,11 @@ sealed trait Value extends Readable with geny.Writable{
 //                                          ^^^^^ reference ujson/Value#
 //                                                  ^^^^ reference scala/Unit#
 //                                                         ^ reference ujson/Value#update(+1).(s)
+//                                                           reference ujson/Value.Selector#update().
 //                                                                   ^ reference ujson/Value#update(+1).(f)
+//                                                                     reference scala/Function1#apply().
 //                                                                     ^ reference ujson/Value#update(+1).(s)
+//                                                                       reference ujson/Value.Selector#apply().
 
   def transform[T](f: Visitor[_, T]) = Value.transform(this, f)
 //    ^^^^^^^^^ definition ujson/Value#transform().
@@ -252,6 +270,7 @@ sealed trait Value extends Readable with geny.Writable{
 //                                            ^^^^^^^ reference scala/Boolean#
 //                                                                    ^^^^^^^^^ reference ujson/Value#transform().
 //                                                                              ^^^^^^^^^^^^^^ reference ujson/StringRenderer.
+//                                                                                             reference ujson/StringRenderer.apply().
 //                                                                                             ^^^^^^ reference ujson/Value#render().(indent)
 //                                                                                                     ^^^^^^^^^^^^^ reference ujson/Value#render().(escapeUnicode)
 //                                                                                                                     ^^^^^^^^ reference java/io/StringWriter#toString().
@@ -333,6 +352,7 @@ object Value extends AstTransformer[Value]{
 //                         ^^^^^ reference ujson/Value.Value#
 //                                 ^ reference ujson/Value.Selector.IntSelector#apply().(x)
 //                                   ^^^ reference ujson/Value#arr().
+//                                       reference scala/collection/mutable/ArrayBuffer#apply().
 //                                       ^ reference ujson/Value.Selector.IntSelector#i.
       def update(x: Value, y: Value) = x.arr(i) = y
 //        ^^^^^^ definition ujson/Value.Selector.IntSelector#update().
@@ -342,6 +362,7 @@ object Value extends AstTransformer[Value]{
 //                            ^^^^^ reference ujson/Value.Value#
 //                                     ^ reference ujson/Value.Selector.IntSelector#update().(x)
 //                                       ^^^ reference ujson/Value#arr().
+//                                           reference scala/collection/mutable/ArrayBuffer#update().
 //                                           ^ reference ujson/Value.Selector.IntSelector#i.
 //                                                ^ reference ujson/Value.Selector.IntSelector#update().(y)
     }
@@ -359,6 +380,7 @@ object Value extends AstTransformer[Value]{
 //                         ^^^^^ reference ujson/Value.Value#
 //                                 ^ reference ujson/Value.Selector.StringSelector#apply().(x)
 //                                   ^^^ reference ujson/Value#obj().
+//                                       reference scala/collection/MapOps#apply().
 //                                       ^ reference ujson/Value.Selector.StringSelector#i.
       def update(x: Value, y: Value) = x.obj(i) = y
 //        ^^^^^^ definition ujson/Value.Selector.StringSelector#update().
@@ -368,6 +390,7 @@ object Value extends AstTransformer[Value]{
 //                            ^^^^^ reference ujson/Value.Value#
 //                                     ^ reference ujson/Value.Selector.StringSelector#update().(x)
 //                                       ^^^ reference ujson/Value#obj().
+//                                           reference scala/collection/mutable/LinkedHashMap#update().
 //                                           ^ reference ujson/Value.Selector.StringSelector#i.
 //                                                ^ reference ujson/Value.Selector.StringSelector#update().(y)
     }
@@ -478,8 +501,12 @@ object Value extends AstTransformer[Value]{
 //                                                           ^^^ reference ujson/Value.Arr.
 //                                                               ^^^^ reference ujson/Arr.from().
 //                                                                    ^^^^^ reference ujson/Value.JsonableSeq().(items)
+//                                                                          reference scala/collection/IterableOnce.
+//                                                                          reference scala/collection/IterableOnce.iterableOnceExtensionMethods().
 //                                                                          ^^^ reference scala/collection/IterableOnceExtensionMethods#map().
 //                                                                              ^ reference ujson/Value.JsonableSeq().(f)
+//                                                                                  reference scala/Predef.
+//                                                                                  reference scala/Predef.$conforms().
   implicit def JsonableDict[T](items: TraversableOnce[(String, T)])
 //             ^^^^^^^^^^^^ definition ujson/Value.JsonableDict().
 //                          ^ definition ujson/Value.JsonableDict().[T]
@@ -495,11 +522,14 @@ object Value extends AstTransformer[Value]{
 //                                                            ^^^ reference ujson/Value.Obj.
 //                                                                ^^^^ reference ujson/Obj.from().
 //                                                                     ^^^^^ reference ujson/Value.JsonableDict().(items)
+//                                                                           reference scala/collection/IterableOnce.
+//                                                                           reference scala/collection/IterableOnce.iterableOnceExtensionMethods().
 //                                                                           ^^^ reference scala/collection/IterableOnceExtensionMethods#map().
 //                                                                               ^ definition local10
 //                                                                                     ^ reference local10
 //                                                                                       ^^ reference scala/Tuple2#_1.
 //                                                                                           ^ reference ujson/Value.JsonableDict().(f)
+//                                                                                             reference scala/Function1#apply().
 //                                                                                             ^ reference local10
 //                                                                                               ^^ reference scala/Tuple2#_2.
   implicit def JsonableBoolean(i: Boolean): Bool = if (i) ujson.True else ujson.False
@@ -518,6 +548,7 @@ object Value extends AstTransformer[Value]{
 //                             ^^^^ reference scala/Byte#
 //                                    ^^^ reference ujson/Value.Num#
 //                                          ^^^ reference ujson/Value.Num.
+//                                              reference ujson/Num.apply().
 //                                              ^ reference scala/Byte#toDouble().
   implicit def JsonableShort(i: Short): Num = Num(i)
 //             ^^^^^^^^^^^^^ definition ujson/Value.JsonableShort().
@@ -525,6 +556,7 @@ object Value extends AstTransformer[Value]{
 //                              ^^^^^ reference scala/Short#
 //                                      ^^^ reference ujson/Value.Num#
 //                                            ^^^ reference ujson/Value.Num.
+//                                                reference ujson/Num.apply().
 //                                                ^ reference scala/Short#toDouble().
   implicit def JsonableInt(i: Int): Num = Num(i)
 //             ^^^^^^^^^^^ definition ujson/Value.JsonableInt().
@@ -532,6 +564,7 @@ object Value extends AstTransformer[Value]{
 //                            ^^^ reference scala/Int#
 //                                  ^^^ reference ujson/Value.Num#
 //                                        ^^^ reference ujson/Value.Num.
+//                                            reference ujson/Num.apply().
 //                                            ^ reference scala/Int#toDouble().
   implicit def JsonableLong(i: Long): Str = Str(i.toString)
 //             ^^^^^^^^^^^^ definition ujson/Value.JsonableLong().
@@ -539,6 +572,7 @@ object Value extends AstTransformer[Value]{
 //                             ^^^^ reference scala/Long#
 //                                    ^^^ reference ujson/Value.Str#
 //                                          ^^^ reference ujson/Value.Str.
+//                                              reference ujson/Str.apply().
 //                                              ^ reference ujson/Value.JsonableLong().(i)
 //                                                ^^^^^^^^ reference scala/Any#toString().
   implicit def JsonableFloat(i: Float): Num = Num(i)
@@ -547,6 +581,7 @@ object Value extends AstTransformer[Value]{
 //                              ^^^^^ reference scala/Float#
 //                                      ^^^ reference ujson/Value.Num#
 //                                            ^^^ reference ujson/Value.Num.
+//                                                reference ujson/Num.apply().
 //                                                ^ reference scala/Float#toDouble().
   implicit def JsonableDouble(i: Double): Num = Num(i)
 //             ^^^^^^^^^^^^^^ definition ujson/Value.JsonableDouble().
@@ -554,6 +589,7 @@ object Value extends AstTransformer[Value]{
 //                               ^^^^^^ reference scala/Double#
 //                                        ^^^ reference ujson/Value.Num#
 //                                              ^^^ reference ujson/Value.Num.
+//                                                  reference ujson/Num.apply().
 //                                                  ^ reference ujson/Value.JsonableDouble().(i)
   implicit def JsonableNull(i: Null): Null.type = Null
 //             ^^^^^^^^^^^^ definition ujson/Value.JsonableNull().
@@ -567,6 +603,7 @@ object Value extends AstTransformer[Value]{
 //                               ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                              ^^^ reference ujson/Value.Str#
 //                                                    ^^^ reference ujson/Value.Str.
+//                                                        reference ujson/Str.apply().
 //                                                        ^ reference ujson/Value.JsonableString().(s)
 //                                                          ^^^^^^^^ reference java/lang/Object#toString().
 
@@ -640,7 +677,10 @@ object Value extends AstTransformer[Value]{
 //                                                                         ^^ definition local15
 //                                                                               ^^^^^ reference ujson/
 //                                                                                     ^^^ reference ujson/Arr.
+//                                                                                         reference ujson/Arr.apply(+1).
 //                                                                                         ^^ reference local15
+//                                                                                              reference scala/collection/mutable/ArrayBuffer.
+//                                                                                              reference scala/collection/IterableFactory#iterableFactory().
 
   def visitObject(length: Int, index: Int) = new AstObjVisitor[mutable.LinkedHashMap[String, Value]](xs => ujson.Obj(xs))
 //    ^^^^^^^^^^^ definition ujson/Value.visitObject().
@@ -657,7 +697,10 @@ object Value extends AstTransformer[Value]{
 //                                                                                                   ^^ definition local16
 //                                                                                                         ^^^^^ reference ujson/
 //                                                                                                               ^^^ reference ujson/Obj.
+//                                                                                                                   reference ujson/Obj.apply(+2).
 //                                                                                                                   ^^ reference local16
+//                                                                                                                        reference scala/collection/mutable/LinkedHashMap.
+//                                                                                                                        reference scala/collection/MapFactory#mapFactory().
 
   def visitNull(index: Int) = ujson.Null
 //    ^^^^^^^^^ definition ujson/Value.visitNull().
@@ -693,6 +736,7 @@ object Value extends AstTransformer[Value]{
     ujson.Num(
 //  ^^^^^ reference ujson/
 //        ^^^ reference ujson/Num.
+//            reference ujson/Num.apply().
       if (decIndex != -1 || expIndex != -1) s.toString.toDouble
 //        ^^^^^^^^ reference ujson/Value.visitFloat64StringParts().(decIndex)
 //                 ^^ reference scala/Int#`!=`(+3).
@@ -701,6 +745,7 @@ object Value extends AstTransformer[Value]{
 //                                   ^^ reference scala/Int#`!=`(+3).
 //                                          ^ reference ujson/Value.visitFloat64StringParts().(s)
 //                                            ^^^^^^^^ reference java/lang/Object#toString().
+//                                                     reference scala/Predef.augmentString().
 //                                                     ^^^^^^^^ reference scala/collection/StringOps#toDouble().
       else Util.parseIntegralNum(s, decIndex, expIndex, index)
 //         ^^^^ reference upickle/core/Util.
@@ -720,6 +765,7 @@ object Value extends AstTransformer[Value]{
 //                                            ^^^ reference scala/Int#
 //                                                   ^^^^^ reference ujson/
 //                                                         ^^^ reference ujson/Num.
+//                                                             reference ujson/Num.apply().
 //                                                             ^ reference ujson/Value.visitFloat64().(d)
 
   def visitString(s: CharSequence, index: Int) = ujson.Str(s.toString)
@@ -730,6 +776,7 @@ object Value extends AstTransformer[Value]{
 //                                        ^^^ reference scala/Int#
 //                                               ^^^^^ reference ujson/
 //                                                     ^^^ reference ujson/Str.
+//                                                         reference ujson/Str.apply().
 //                                                         ^ reference ujson/Value.visitString().(s)
 //                                                           ^^^^^^^^ reference java/lang/Object#toString().
 
@@ -751,6 +798,7 @@ object Value extends AstTransformer[Value]{
     extends Exception(s"$msg (data: $data)")
 //          ^^^^^^^^^ reference scala/package.Exception#
 //                    reference java/lang/Exception#`<init>`(+1).
+//                     reference scala/StringContext.apply().
 //                    ^ reference scala/StringContext#s().
 //                       ^^^ reference ujson/Value.InvalidData#`<init>`().(msg)
 //                                   ^^^^ reference ujson/Value.InvalidData#`<init>`().(data)
@@ -785,9 +833,13 @@ object Obj{
 //                                                            ^^^ reference ujson/Obj#
     Obj(mutable.LinkedHashMap(items.toSeq:_*))
 //  ^^^ reference ujson/Obj.
+//      reference ujson/Obj.apply(+2).
 //      ^^^^^^^ reference scala/collection/mutable/
 //              ^^^^^^^^^^^^^ reference scala/collection/mutable/LinkedHashMap.
+//                            reference scala/collection/MapFactory#apply().
 //                            ^^^^^ reference ujson/Obj.from().(items)
+//                                  reference scala/collection/IterableOnce.
+//                                  reference scala/collection/IterableOnce.iterableOnceExtensionMethods().
 //                                  ^^^^^ reference scala/collection/IterableOnceExtensionMethods#toSeq().
   }
   // Weird telescoped version of `apply(items: (String, Value)*)`, to avoid
@@ -821,6 +873,7 @@ object Obj{
 //          ^^^^ reference ujson/Obj.apply().(item)
 //               ^^ reference scala/Tuple2#_1.
 //                   ^^^^ reference ujson/Obj.apply().(conv)
+//                        reference scala/Function1#apply().
 //                        ^^^^ reference ujson/Obj.apply().(item)
 //                             ^^ reference scala/Tuple2#_2.
     for (i <- items) map.put(i._1, i._2)
@@ -832,8 +885,11 @@ object Obj{
 //                             ^^ reference scala/Tuple2#_1.
 //                                 ^ reference local18
 //                                   ^^ reference scala/Tuple2#_2.
+//                                       reference scala/collection/IterableOnceOps#foreach().
+//                                       reference local18
     Obj(map)
 //  ^^^ reference ujson/Obj.
+//      reference ujson/Obj.apply(+2).
 //      ^^^ reference local17
   }
 
@@ -841,6 +897,7 @@ object Obj{
 //    ^^^^^ definition ujson/Obj.apply(+1).
 //             ^^^ reference ujson/Obj#
 //                   ^^^ reference ujson/Obj.
+//                       reference ujson/Obj.apply(+2).
 //                           ^^^^^^^ reference scala/collection/mutable/
 //                                   ^^^^^^^^^^^^^ reference scala/collection/mutable/LinkedHashMap#
 //                                                 ^^^^^^ reference scala/Predef.String#
@@ -876,17 +933,21 @@ object Arr{
 //                                           reference scala/collection/mutable/ArrayBuffer#`<init>`(+1).
     items.foreach{ item =>
 //  ^^^^^ reference ujson/Arr.from().(items)
+//        reference scala/collection/IterableOnce.
+//        reference scala/collection/IterableOnce.iterableOnceExtensionMethods().
 //        ^^^^^^^ reference scala/collection/IterableOnceExtensionMethods#foreach().
 //                 ^^^^ definition local20
       buf += (conv(item): Value)
 //    ^^^ reference local19
 //        ^^ reference scala/collection/mutable/Growable#`+=`().
 //            ^^^^ reference ujson/Arr.from().(conv)
+//                 reference scala/Function1#apply().
 //                 ^^^^ reference local20
 //                        ^^^^^ reference ujson/Value#
     }
     Arr(buf)
 //  ^^^ reference ujson/Arr.
+//      reference ujson/Arr.apply(+1).
 //      ^^^ reference local19
   }
 
@@ -914,6 +975,7 @@ object Arr{
     }
     Arr(buf)
 //  ^^^ reference ujson/Arr.
+//      reference ujson/Arr.apply(+1).
 //      ^^^ reference local21
   }
 }
@@ -950,6 +1012,7 @@ object Bool{
 //                         ^^^^^^ reference scala/Option#
 //                                ^^^^^^^ reference scala/Boolean#
 //                                           ^^^^ reference scala/Some.
+//                                                reference scala/Some.apply().
 //                                                ^^^^ reference ujson/Bool.unapply().(bool)
 //                                                     ^^^^^ reference ujson/Bool#value().
 }

--- a/tests/snapshots/src/main/generated/ujson/package.scala
+++ b/tests/snapshots/src/main/generated/ujson/package.scala
@@ -107,6 +107,7 @@ package object ujson{
 //  ^^^^^^^^^ reference ujson/package.transform().
 //            ^ reference ujson/package.writeTo().(t)
 //               ^^^^^^^^ reference ujson/Renderer.
+//                        reference ujson/Renderer.apply().
 //                        ^^^ reference ujson/package.writeTo().(out)
 //                             ^^^^^^ reference ujson/package.writeTo().(indent)
 //                                     ^^^^^^^^^^^^^ reference ujson/package.writeTo().(escapeUnicode)
@@ -227,6 +228,7 @@ package object ujson{
 //  ^^^^^^^^^ reference ujson/package.transform().
 //            ^ reference ujson/package.reformatTo().(s)
 //               ^^^^^^^^ reference ujson/Renderer.
+//                        reference ujson/Renderer.apply().
 //                        ^^^ reference ujson/package.reformatTo().(out)
 //                             ^^^^^^ reference ujson/package.reformatTo().(indent)
 //                                     ^^^^^^^^^^^^^ reference ujson/package.reformatTo().(escapeUnicode)

--- a/tests/snapshots/src/main/scala/tests/MinimizedLsifSnapshotGenerator.scala
+++ b/tests/snapshots/src/main/scala/tests/MinimizedLsifSnapshotGenerator.scala
@@ -20,14 +20,29 @@ class MinimizedLsifSnapshotGenerator extends SnapshotGenerator {
   }
   def onFinished(context: SnapshotContext): Unit = ()
   override def run(context: SnapshotContext, handler: SnapshotHandler): Unit = {
+    onTargetroot(
+      context,
+      handler,
+      AbsolutePath(BuildInfo.minimizedJavaTargetroot),
+      AbsolutePath(BuildInfo.minimizedJavaSourceDirectory)
+    )
+    onTargetroot(
+      context,
+      handler,
+      AbsolutePath(BuildInfo.minimizedScalaTargetroot),
+      AbsolutePath(BuildInfo.minimizedScalaSourceDirectory)
+    )
+  }
+  def onTargetroot(
+      context: SnapshotContext,
+      handler: SnapshotHandler,
+      targetroot: AbsolutePath,
+      sourceDirectory: AbsolutePath
+  ): Unit = {
     val sourceroot = AbsolutePath(BuildInfo.sourceroot)
     val lsifOutput = Files.createTempDirectory("lsif-java").resolve("dump.lsif")
     val snapshotOutput = AbsolutePath(Files.createTempDirectory("lsif-java"))
     try {
-      val javaTargetroot = AbsolutePath(BuildInfo.minimizedJavaTargetroot)
-      val javaSourceDirectory = AbsolutePath(
-        BuildInfo.minimizedJavaSourceDirectory
-      )
       run(
         List(
           "index-semanticdb",
@@ -36,7 +51,7 @@ class MinimizedLsifSnapshotGenerator extends SnapshotGenerator {
           "--output",
           lsifOutput.toString,
           "--targetroot",
-          javaTargetroot.toString()
+          targetroot.toString()
         )
       )
       run(
@@ -57,7 +72,7 @@ class MinimizedLsifSnapshotGenerator extends SnapshotGenerator {
           val relativeToSourceroot = file.toRelative(snapshotOutput)
           val absoluteSource = sourceroot.resolve(relativeToSourceroot)
           val relativeToSourceDirectory = absoluteSource
-            .toRelative(javaSourceDirectory)
+            .toRelative(sourceDirectory)
           val expectOutput = AbsolutePath(
             context.expectDirectory.resolve(relativeToSourceDirectory.toNIO)
           )


### PR DESCRIPTION
Previously, lsif-java only indexed the "Occurrences" section of a
SemanticDB `TextDocument`. Now, we additionall index the "Synthetics"
section, which includes inferred expression from Scala implicits, for
comprehensions, `.apply` methods and more. The benefit of this fix is
that "find references" on an implicit or an `apply` method now shows
usages where those symbols got inferred (the user didn't explicitly
write a reference to them).

It could be that this fix alone is not sufficient to enable "find
references" to show results on Sourcegraph. The Sourcegraph backend
will also need to accept offset ranges with zero length.

Fixes #340