### PR TITLE
Update documentation

### DIFF
--- a/auto-indexing/Dockerfile
+++ b/auto-indexing/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get install --yes maven npm
 RUN curl -fLo /coursier https://git.io/coursier-cli
 RUN chmod +x /coursier
 RUN npm install --global yarn
-RUN /coursier launch --contrib --ttl 0 lsif-java -- --help
+RUN /coursier bootstrap --standalone com.sourcegraph:lsif-java_2.13:0.6.11 -o /usr/local/bin/lsif-java

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,24 @@ tools that we're planning to support in the future.
 
 The most common way to use `lsif-java` is to run it from CI to upload LSIF
 indexes after merging a pull request. The easiest way to install `lsif-java` is
-to use the Java launcher.
+to use the Docker launcher.
+
+### Docker container
+
+Run the `lsif-java index`command from the `sourcegraph/lsif-java` Docker
+container.
+
+```sh
+$ docker run -v $(pwd):/home/gradle sourcegraph/lsif-java:latest lsif-java index
+$ src lsif upload # (optional) upload index to Sourcegraph
+```
+
+If everything went OK, a `dump.lsif` file should exist after the command has
+finished indexing the project.
+
+> The Docker container re-downloads all dependencies on every run, which can be
+> slow for large projects. Consider using the [Java launcher](#java-launcher)
+> instead to re-use the existing build cache of your project.
 
 ### Java launcher
 
@@ -104,7 +121,7 @@ libraryDependencies += "com.sourcegraph" %% "lsif-java" % "@STABLE_VERSION@"
 
 ## Run `lsif-java index`
 
-> The `index` command is only supported for Gradle and Maven, see
+> The `index` command is only supported for Gradle, Maven and sbt. See
 > [Supported build tools](#supported-build-tools) for more details about other
 > build tools.
 
@@ -113,7 +130,7 @@ This command should automatically infer the structure of your codebase and
 configure your build tool to generate LSIF.
 
 ```sh
-# At the root of a Gradle or Maven codebase.
+# At the root of a Gradle, Maven or sbt codebase.
 $ lsif-java index
 ...
 info: /path/to/dump.lsif
@@ -138,7 +155,7 @@ com.sourcegraph.lsif_java.LsifJava.printHelp(Console.out)
 | -------------------- | ------ | ----- | --- | ----------------------------------------------------------- |
 | Java                 | ✅     | ✅    | ✅  |                                                             |
 | Scala                | ✅     | ❌    | ✅  | [#302](https://github.com/sourcegraph/lsif-java/issues/302) |
-| Kotlin               | ❌     | ❌    | ❌  | [#304](https://github.com/sourcegraph/lsif-java/issues/304) |
+| Kotlin               | ✅     | ❌    | n/a | [#304](https://github.com/sourcegraph/lsif-java/issues/304) |
 
 ### Java
 
@@ -147,17 +164,17 @@ part of your regular compilation in the build tool. By using Java compiler APIs,
 `lsif-java` is able to generate accurate indexing information for a broad range
 of Java versions.
 
-| Java version | Support                        |
-| ------------ | ------------------------------ |
-| Java 7       | ❌                             |
-| Java 8       | ✅                             |
-| Java 11      | ✅                             |
-| Java 12      | Not tested in CI, but may work |
-| Java 13      | Not tested in CI, but may work |
-| Java 14      | Not tested in CI, but may work |
-| Java 15      | ✅                             |
-| Java 16      | Not tested in CI, but may work |
-| Java 17      | Not tested in CI, but may work |
+| Java version | Support                        | Tracking issue                                                                   |
+| ------------ | ------------------------------ | -------------------------------------------------------------------------------- |
+| Java 7       | ❌                             |                                                                                  |
+| Java 8       | ✅                             |                                                                                  |
+| Java 11      | ✅                             |                                                                                  |
+| Java 12      | Not tested in CI, but may work |                                                                                  |
+| Java 13      | Not tested in CI, but may work |                                                                                  |
+| Java 14      | Not tested in CI, but may work |                                                                                  |
+| Java 15      | ✅                             |                                                                                  |
+| Java 16      | ❌                             |                                                                                  |
+| Java 17      | ❌                             | [sourcegraph/lsif-java#263](https://github.com/sourcegraph/lsif-java/issues/263) |
 
 ### Scala
 
@@ -174,6 +191,13 @@ by [Metals](https://scalameta.org/metals), the Scala language server.
 
 > Scala.js and Scala Native have equal support as Scala on the JVM.
 
+### Kotlin
+
+The Kotlin support in lsif-java is the least mature compared to the Java and
+Scala support. Don't hesitate to report issues at
+https://github.com/sourcegraph/lsif-kotlin if you encounter issues using the
+Kotlin support.
+
 ## Supported build tools
 
 It's possible to use lsif-java with any Java build tool. Some build tools can be
@@ -188,7 +212,7 @@ free to subscribe to the tracking issues to receive updates on your build tool.
 | Build tool | Java | Scala | Kotlin | Tracking issue                                                                   |
 | ---------- | ---- | ----- | ------ | -------------------------------------------------------------------------------- |
 | Maven      | ✅   | ❌    | ❌     |                                                                                  |
-| Gradle     | ✅   | ✅    | ❌     |                                                                                  |
+| Gradle     | ✅   | ✅    | ✅     |                                                                                  |
 | sbt        | ✅   | ✅    | n/a    |                                                                                  |
 | Ant        | ❌   | ❌    | ❌     | [sourcegraph/lsif-java#305](https://github.com/sourcegraph/lsif-java/issues/305) |
 | Bazel      | ❌   | ❌    | ❌     | [sourcegraph/lsif-java#88](https://github.com/sourcegraph/lsif-java/issues/88)   |
@@ -214,8 +238,8 @@ projects. However, the following Gradle integrations are not yet supported:
 
 | Integration | Supported | Tracking issue                                                                   |
 | ----------- | --------- | -------------------------------------------------------------------------------- |
-| Android     | ❌        | [sourcegraph/lsif-java#304](https://github.com/sourcegraph/lsif-java/issues/304) |
-| Kotlin      | ❌        | [sourcegraph/lsif-java#177](https://github.com/sourcegraph/lsif-java/issues/177) |
+| Android     | ❌        | [sourcegraph/lsif-java#177](https://github.com/sourcegraph/lsif-java/issues/177) |
+| Kotlin      | ✅        |                                                                                  |
 | Scala       | ✅        |                                                                                  |
 
 ### Maven

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -27,10 +27,10 @@ class Button extends React.Component {
 }
 
 Button.defaultProps = {
-  target: "_self"
+  target: "_self",
 };
 
-const SplashContainer = props => (
+const SplashContainer = (props) => (
   <div className="homeContainer">
     <div className="homeSplashFade">
       <div className="wrapper homeWrapper">{props.children}</div>
@@ -38,14 +38,14 @@ const SplashContainer = props => (
   </div>
 );
 
-const ProjectTitle = props => (
+const ProjectTitle = (props) => (
   <h2 className="projectTitle">
     {siteConfig.title}
     <small>{siteConfig.tagline}</small>
   </h2>
 );
 
-const PromoSection = props => (
+const PromoSection = (props) => (
   <div className="section promoSection">
     <div className="promoRow">
       <div className="pluginRowBlock">{props.children}</div>
@@ -71,7 +71,7 @@ class HomeSplash extends React.Component {
   }
 }
 
-const Block = props => (
+const Block = (props) => (
   <Container
     padding={["bottom", "top"]}
     id={props.id}
@@ -81,30 +81,38 @@ const Block = props => (
   </Container>
 );
 
-const Features = props => {
+const Features = (props) => {
   const features = [
+    // {
+    //   title: "Multiple language versions",
+    //   content: "Works with Java 8, Java 11 and Java 15.",
+    //   image:
+    //     "https://user-images.githubusercontent.com/1408093/109818700-93378e00-7c33-11eb-8385-7ea88533cb87.png",
+    //   imageAlign: "left"
+    // },
     {
-      title: "Multiple language versions",
-      content: "Works with Java 8, Java 11 and Java 15. The latest bleeding edge Java version probably works as well.",
+      title: "Multiple languages",
+      content:
+        "Java, Scala and Kotlin are supported, including navigation between different languages.",
       image:
-        "https://user-images.githubusercontent.com/1408093/109818700-93378e00-7c33-11eb-8385-7ea88533cb87.png",
-      imageAlign: "left"
+        "https://user-images.githubusercontent.com/1408093/137899150-e8d92cdd-8bd2-4802-9cd2-288442708aff.png",
+      imageAlign: "left",
     },
     {
       title: "Multiple build tools",
       content:
-        "The build tools Gradle and Maven are supported. We plan to add support for more build tools in the future.",
+        "The build tools Gradle, Maven and sbt are supported. We plan to add support for more build tools in the future.",
       image:
-        "https://user-images.githubusercontent.com/1408093/109819002-e4478200-7c33-11eb-99d3-c42d84acda47.png",
-      imageAlign: "right"
+        "https://user-images.githubusercontent.com/1408093/137899144-cfc6fc1b-a7c0-4fd7-ac4b-be516e459123.png",
+      imageAlign: "right",
     },
     {
       title: "Simple installation",
       content:
-        "Run the `lsif-java` command-line tool at the root of your Gradle/Maven build to generate an LSIF index. No manual configuration needed.",
+        "Run the `lsif-java` command-line tool at the root of your Gradle/Maven/sbt build to generate an LSIF index. No manual configuration needed.",
       image:
         "https://user-images.githubusercontent.com/1408093/109820615-769c5580-7c35-11eb-9063-98e932c5d6c5.png",
-      imageAlign: "left"
+      imageAlign: "left",
     },
     {
       title: "Low overhead",
@@ -112,15 +120,15 @@ const Features = props => {
         "Indexing a repository should be roughly as fast as compiling all of the sources in the repository.",
       image:
         "https://user-images.githubusercontent.com/1408093/109820240-1dccbd00-7c35-11eb-8a87-6b1850687e28.png",
-      imageAlign: "right"
-    }
+      imageAlign: "right",
+    },
   ];
   return (
     <div
       className="productShowcaseSection paddingBottom"
       style={{ textAlign: "left" }}
     >
-      {features.map(feature => (
+      {features.map((feature) => (
         <Block key={feature.title}>{[feature]}</Block>
       ))}
     </div>


### PR DESCRIPTION
- Include Docker installation instructions. For many people it will be
  easier to use the Docker launcher instead of the Java-based one.
- Consistently mention sbt alongside Gradle/Maven.
- Consistently mention Kotlin alongside Java/Scala.
- Freshen up the landing page.