### PR TITLE
Update `snapshot` command to fallback to the `.documentation` field

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/commands/SnapshotLsifCommand.scala
@@ -143,13 +143,7 @@ object SnapshotLsifCommand {
                 resultSetId <- lsif.next.get(o.getId).toList
                 hoverId <- lsif.hoverEdges.get(resultSetId).toList
                 hover <- lsif.hoverVertexes.get(hoverId).toList
-                line <- hover
-                  .getContents
-                  .getValue
-                  .linesIterator
-                  .dropWhile(!_.startsWith("```"))
-                  .drop(1)
-                  .takeWhile(_ != "```")
+                line <- signatureLines(hover.getContents.getValue)
               } yield line
             ).mkString("\n")
           val symInfo = SymbolInformation
@@ -162,6 +156,14 @@ object SnapshotLsifCommand {
         }
       }
     lsif.documents.values.map(_.build()).toList
+  }
+
+  def signatureLines(documentation: String): Iterator[String] = {
+    documentation
+      .linesIterator
+      .dropWhile(!_.startsWith("```"))
+      .drop(1)
+      .takeWhile(_ != "```")
   }
 
   class IndexedLsif(

--- a/tests/unit/src/test/scala/tests/SemanticdbPrintersSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticdbPrintersSuite.scala
@@ -1,7 +1,9 @@
 package tests
 
 import com.sourcegraph.lsif_java.SemanticdbPrinters
+import com.sourcegraph.semanticdb_javac.Semanticdb.Documentation
 import com.sourcegraph.semanticdb_javac.Semanticdb.Range
+import com.sourcegraph.semanticdb_javac.Semanticdb.SymbolInformation
 import com.sourcegraph.semanticdb_javac.Semanticdb.SymbolOccurrence
 import com.sourcegraph.semanticdb_javac.Semanticdb.SymbolOccurrence.Role
 import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
@@ -80,6 +82,44 @@ class SemanticdbPrintersSuite extends FunSuite {
          |→→→Qux()
          |// ^^^ definition foo/Indexer#Qux().
          |}
+         |""".stripMargin
+    )
+  }
+
+  test("documentation") {
+    val doc = TextDocument
+      .newBuilder()
+      .setText("fun main() {}\n")
+      .addOccurrences(
+        SymbolOccurrence
+          .newBuilder()
+          .setSymbol("main().")
+          .setRange(
+            Range
+              .newBuilder()
+              .setStartLine(0)
+              .setStartCharacter(4)
+              .setEndLine(0)
+              .setEndCharacter(8)
+          )
+          .setRole(Role.DEFINITION)
+      )
+      .addSymbols(
+        SymbolInformation
+          .newBuilder()
+          .setSymbol("main().")
+          .setDocumentation(
+            Documentation
+              .newBuilder()
+              .setMessage("```kt\nfun main(): kotlin.Unit\n```")
+          )
+      )
+      .build()
+
+    assertNoDiff(
+      SemanticdbPrinters.printTextDocument(doc),
+      """|fun main() {}
+         |//  ^^^^ definition main(). fun main(): kotlin.Unit
          |""".stripMargin
     )
   }


### PR DESCRIPTION
Previously, the `snapshot` command only used the `.signature` field
while the `snapshot-lsif` command extracted the signature from the
markdown documentation. This change makes the `snapshot` command have
the same behavior as `snapshot-lsif`.