### PR TITLE
fix MD5 checksum computation

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/MD5.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/MD5.java
@@ -26,10 +26,7 @@ public final class MD5 {
   }
 
   public static String digest(CharSequence chars) throws NoSuchAlgorithmException {
-    CharBuffer buf = CharBuffer.wrap(chars);
-    byte[] bytes = StandardCharsets.UTF_8.encode(buf).array();
     MessageDigest md5 = MessageDigest.getInstance("MD5");
-    md5.digest(bytes);
-    return bytesToHex(md5.digest());
+    return bytesToHex(md5.digest(chars.toString().getBytes()));
   }
 }


### PR DESCRIPTION
The CharBuffer dance added about 30 null bytes to the then hashed file data, causing an incorrect MD5 checksum. This PR avoids this erroneous codepath to give us the correct checksum. Closes #391 

![image](https://user-images.githubusercontent.com/18282288/148967114-fe0cddd0-df5b-40ed-9736-bafe00c8a340.png)
