### PR TITLE
Emit additional occurrences for synthetic Scala symbols

### DIFF
--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/SemanticdbPrinters.scala
@@ -17,7 +17,9 @@ object SemanticdbPrinters {
       comments: CommentSyntax = CommentSyntax.default
   ): String = {
     val occurrencesByLine = LsifTextDocument
-      .sortedSymbolOccurrences(doc)
+      .sortedSymbolOccurrences(
+        LsifTextDocument.manifestOccurrencesForSyntheticSymbols(doc)
+      )
       .asScala
       .groupBy(_.getRange.getStartLine)
     val out = new StringBuilder()

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifTextDocument.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifTextDocument.java
@@ -1,11 +1,10 @@
 package com.sourcegraph.lsif_semanticdb;
 
 import com.sourcegraph.semanticdb_javac.Semanticdb;
+import com.sourcegraph.semanticdb_javac.SemanticdbSymbols;
+
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /** Wrapper around a SemanticDB TextDocument with LSIF-related utilities. */
 public class LsifTextDocument {
@@ -74,9 +73,75 @@ public class LsifTextDocument {
   }
 
   private void setSemanticdb(Semanticdb.TextDocument semanticdb) {
-    this.semanticdb = semanticdb;
+    this.semanticdb = manifestOccurrencesForSyntheticSymbols(semanticdb);
     for (Semanticdb.SymbolInformation info : semanticdb.getSymbolsList()) {
       symbols.put(info.getSymbol(), info);
     }
+  }
+
+  public static Semanticdb.TextDocument manifestOccurrencesForSyntheticSymbols(
+      Semanticdb.TextDocument semanticdb) {
+    if (semanticdb.getLanguage() != Semanticdb.Language.SCALA) {
+      // It's only semanticdb-scalac that emits SymbolInformation for symbols that have no
+      // definition occurrences.
+      return semanticdb;
+    }
+    Semanticdb.TextDocument.Builder builder = Semanticdb.TextDocument.newBuilder(semanticdb);
+    HashMap<String, Semanticdb.SymbolOccurrence> definitionOccurrences = new HashMap<>();
+    for (Semanticdb.SymbolOccurrence occ : semanticdb.getOccurrencesList()) {
+      if (occ.getRole() == Semanticdb.SymbolOccurrence.Role.DEFINITION) {
+        definitionOccurrences.put(occ.getSymbol(), occ);
+      }
+    }
+    for (Semanticdb.SymbolInformation info : semanticdb.getSymbolsList()) {
+      Semanticdb.SymbolOccurrence definition = definitionOccurrences.get(info.getSymbol());
+      if (definition != null) {
+        continue;
+      }
+      for (String alternativeSymbol : alternativeSymbols(info)) {
+        Semanticdb.SymbolOccurrence alternativeDefinition =
+            definitionOccurrences.get(alternativeSymbol);
+        if (alternativeDefinition != null) {
+          builder.addOccurrences(
+              Semanticdb.SymbolOccurrence.newBuilder(alternativeDefinition)
+                  .setSymbol(info.getSymbol()));
+          break;
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  public static final Set<String> syntheticCaseClassMethodNames =
+      new HashSet<>(Arrays.asList("copy", "productElement", "productElementName"));
+  public static final Set<String> syntheticCompanionObjectNames =
+      new HashSet<>(Arrays.asList("apply", "copy"));
+
+  public static List<String> alternativeSymbols(Semanticdb.SymbolInformation info) {
+    ArrayList<String> alternatives = new ArrayList<>();
+    SymbolDescriptor sym = SymbolDescriptor.parseFromSymbol(info.getSymbol());
+    switch (sym.descriptor.kind) {
+      case Method:
+        if (sym.descriptor.name.endsWith("_=")) {
+          String newName = sym.descriptor.name.substring(0, sym.descriptor.name.length() - 2);
+          alternatives.add(SemanticdbSymbols.global(sym.owner, sym.descriptor.withName(newName)));
+        } else if (syntheticCaseClassMethodNames.contains(sym.descriptor.name)) {
+          alternatives.add(sym.owner);
+        } else if (syntheticCompanionObjectNames.contains(sym.descriptor.name)) {
+          alternatives.add(sym.owner);
+          SymbolDescriptor owner = SymbolDescriptor.parseFromSymbol(sym.owner);
+          alternatives.add(
+              SemanticdbSymbols.global(
+                  owner.owner, owner.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Type)));
+        }
+        break;
+      case Term:
+        alternatives.add(
+            SemanticdbSymbols.global(
+                sym.owner, sym.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Type)));
+        break;
+      default:
+    }
+    return alternatives;
   }
 }

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
@@ -79,6 +79,14 @@ public final class SemanticdbSymbols {
       this.disambiguator = disambiguator;
     }
 
+    public Descriptor withName(String newName) {
+      return new Descriptor(kind, newName, disambiguator);
+    }
+
+    public Descriptor withKind(Kind newKind) {
+      return new Descriptor(newKind, name, disambiguator);
+    }
+
     public static Descriptor local(String name) {
       return new Descriptor(Kind.Local, name);
     }

--- a/tests/minimized-scala/src/main/scala/minimized/Issue396.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/Issue396.scala
@@ -1,0 +1,9 @@
+package minimized
+
+case class Issue396(a: Int)
+object Issue396App {
+  println(Issue396)
+  Issue396.apply(42).copy(a = 41)
+  Issue396.apply(42).productElement(0)
+  Issue396.apply(42).productElementName(0)
+}

--- a/tests/minimized-scala/src/main/scala/minimized/Issue397.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/Issue397.scala
@@ -1,0 +1,6 @@
+package minimized
+
+class Issue397 {
+  var blah = Set("abc")
+  blah = Set.empty[String]
+}

--- a/tests/snapshots/src/main/generated/BaseByteRenderer.scala
+++ b/tests/snapshots/src/main/generated/BaseByteRenderer.scala
@@ -23,6 +23,7 @@ import upickle.core.{ArrVisitor, ObjVisitor}
   */
 class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
 //    ^^^^^^^^^^^^^^^^ definition ujson/BaseByteRenderer# class BaseByteRenderer[T <: Output]
+//    ^^^^^^^^^^^^^^^^ definition ujson/BaseByteRenderer. object BaseByteRenderer
 //                     ^ definition ujson/BaseByteRenderer#[T] T <: Output
 //                          ^^^^^^^ reference upickle/
 //                                  ^^^^ reference upickle/core/
@@ -65,11 +66,13 @@ class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
 
   private[this] var depth: Int = 0
 //                  ^^^^^ definition ujson/BaseByteRenderer#depth(). private[this] var depth: Int
+//                  ^^^^^ definition ujson/BaseByteRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
 //                         ^^^ reference scala/Int#
 
 
   private[this] var commaBuffered = false
 //                  ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#commaBuffered(). private[this] var commaBuffered: Boolean
+//                  ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
 
   def flushBuffer() = {
 //    ^^^^^^^^^^^ definition ujson/BaseByteRenderer#flushBuffer(). def flushBuffer(): Unit

--- a/tests/snapshots/src/main/generated/BaseCharRenderer.scala
+++ b/tests/snapshots/src/main/generated/BaseCharRenderer.scala
@@ -23,6 +23,7 @@ import upickle.core.{ArrVisitor, ObjVisitor}
   */
 class BaseCharRenderer[T <: upickle.core.CharOps.Output]
 //    ^^^^^^^^^^^^^^^^ definition ujson/BaseCharRenderer# class BaseCharRenderer[T <: Output]
+//    ^^^^^^^^^^^^^^^^ definition ujson/BaseCharRenderer. object BaseCharRenderer
 //                     ^ definition ujson/BaseCharRenderer#[T] T <: Output
 //                          ^^^^^^^ reference upickle/
 //                                  ^^^^ reference upickle/core/
@@ -65,11 +66,13 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output]
 
   private[this] var depth: Int = 0
 //                  ^^^^^ definition ujson/BaseCharRenderer#depth(). private[this] var depth: Int
+//                  ^^^^^ definition ujson/BaseCharRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
 //                         ^^^ reference scala/Int#
 
 
   private[this] var commaBuffered = false
 //                  ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#commaBuffered(). private[this] var commaBuffered: Boolean
+//                  ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
 
   def flushBuffer() = {
 //    ^^^^^^^^^^^ definition ujson/BaseCharRenderer#flushBuffer(). def flushBuffer(): Unit

--- a/tests/snapshots/src/main/generated/minimized/Issue396.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue396.scala
@@ -1,0 +1,32 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+case class Issue396(a: Int)
+//         ^^^^^^^^ definition minimized/Issue396# case class Issue396(a: Int)
+//         ^^^^^^^^ definition minimized/Issue396#copy(). def copy(a: Int): Issue396
+//         ^^^^^^^^ definition minimized/Issue396#productElement(). def productElement(x$1: Int): Any
+//         ^^^^^^^^ definition minimized/Issue396. object Issue396
+//         ^^^^^^^^ definition minimized/Issue396.apply(). def apply(a: Int): Issue396
+//         ^^^^^^^^ definition minimized/Issue396#productElementName(). def productElementName(x$1: Int): String
+//                  definition minimized/Issue396#`<init>`(). def this(a: Int)
+//                  ^ definition minimized/Issue396#a. val a: Int
+//                     ^^^ reference scala/Int#
+object Issue396App {
+//     ^^^^^^^^^^^ definition minimized/Issue396App. object Issue396App
+  println(Issue396)
+//^^^^^^^ reference scala/Predef.println(+1).
+//        ^^^^^^^^ reference minimized/Issue396.
+  Issue396.apply(42).copy(a = 41)
+//^^^^^^^^ reference minimized/Issue396.
+//         ^^^^^ reference minimized/Issue396.apply().
+//                   ^^^^ reference minimized/Issue396#copy().
+//                        ^ reference minimized/Issue396#copy().(a)
+  Issue396.apply(42).productElement(0)
+//^^^^^^^^ reference minimized/Issue396.
+//         ^^^^^ reference minimized/Issue396.apply().
+//                   ^^^^^^^^^^^^^^ reference minimized/Issue396#productElement().
+  Issue396.apply(42).productElementName(0)
+//^^^^^^^^ reference minimized/Issue396.
+//         ^^^^^ reference minimized/Issue396.apply().
+//                   ^^^^^^^^^^^^^^^^^^ reference minimized/Issue396#productElementName().
+}

--- a/tests/snapshots/src/main/generated/minimized/Issue397.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue397.scala
@@ -1,0 +1,17 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+class Issue397 {
+//    ^^^^^^^^ definition minimized/Issue397# class Issue397
+//              definition minimized/Issue397#`<init>`(). def this()
+  var blah = Set("abc")
+//    ^^^^ definition minimized/Issue397#blah(). var blah: Set[String]
+//    ^^^^ definition minimized/Issue397#`blah_=`(). var blah_=(x$1: Set[String]): Unit
+//           ^^^ reference scala/Predef.Set.
+//               reference scala/collection/IterableFactory#apply().
+  blah = Set.empty[String]
+//^^^^ reference minimized/Issue397#`blah_=`().
+//       ^^^ reference scala/Predef.Set.
+//           ^^^^^ reference scala/collection/immutable/Set.empty().
+//                 ^^^^^^ reference scala/Predef.String#
+}

--- a/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
@@ -6,6 +6,11 @@ package minimized
 
 case class MinimizedCaseClass(value: String) {
 //         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass# case class MinimizedCaseClass(value: String)
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass.apply(). def apply(value: String): MinimizedCaseClass
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass#productElement(). def productElement(x$1: Int): Any
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass. object MinimizedCaseClass
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass#productElementName(). def productElementName(x$1: Int): String
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass#copy(). def copy(value: String): MinimizedCaseClass
 //                            definition minimized/MinimizedCaseClass#`<init>`(). def this(value: String)
 //                            ^^^^^ definition minimized/MinimizedCaseClass#value. val value: String
 //                                   ^^^^^^ reference scala/Predef.String#

--- a/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
+++ b/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
@@ -119,6 +119,7 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 
     private[this] var key: String = null
 //                    ^^^ definition ujson/AstTransformer#AstObjVisitor#key(). private[this] var key: String
+//                    ^^^ definition ujson/AstTransformer#AstObjVisitor#`key_=`(). private[this] var key_=(x$1: String): Unit
 //                         ^^^^^^ reference scala/Predef.String#
     private[this] val vs = factory.newBuilder
 //                    ^^ definition ujson/AstTransformer#AstObjVisitor#vs. private[this] val vs: Builder[(String, I), T]

--- a/tests/snapshots/src/main/generated/ujson/Exceptions.scala
+++ b/tests/snapshots/src/main/generated/ujson/Exceptions.scala
@@ -8,6 +8,11 @@ sealed trait ParsingFailedException extends Exception
 
 case class ParseException(clue: String, index: Int)
 //         ^^^^^^^^^^^^^^ definition ujson/ParseException# case class ParseException(clue: String, index: Int) extends Exception with ParsingFailedException
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException#productElementName(). def productElementName(x$1: Int): String
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException.apply(). def apply(clue: String, index: Int): ParseException
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException. object ParseException
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException#copy(). def copy(clue: String, index: Int): ParseException
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException#productElement(). def productElement(x$1: Int): Any
 //                        definition ujson/ParseException#`<init>`(). def this(clue: String, index: Int)
 //                        ^^^^ definition ujson/ParseException#clue. val clue: String
 //                              ^^^^^^ reference scala/Predef.String#
@@ -24,6 +29,11 @@ case class ParseException(clue: String, index: Int)
 
 case class IncompleteParseException(msg: String)
 //         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException# case class IncompleteParseException(msg: String) extends Exception with ParsingFailedException
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException#productElement(). def productElement(x$1: Int): Any
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException.apply(). def apply(msg: String): IncompleteParseException
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException#copy(). def copy(msg: String): IncompleteParseException
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException#productElementName(). def productElementName(x$1: Int): String
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException. object IncompleteParseException
 //                                  definition ujson/IncompleteParseException#`<init>`(). def this(msg: String)
 //                                  ^^^ definition ujson/IncompleteParseException#msg. val msg: String
 //                                       ^^^^^^ reference scala/Predef.String#

--- a/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
+++ b/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
@@ -43,6 +43,11 @@ object IndexedValue extends Transformer[IndexedValue]{
   
   case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue
 //           ^^^ definition ujson/IndexedValue.Str# case class Str(index: Int, value0: CharSequence) extends IndexedValue
+//           ^^^ definition ujson/IndexedValue.Str#copy(). def copy(index: Int, value0: CharSequence): Str
+//           ^^^ definition ujson/IndexedValue.Str.apply(). def apply(index: Int, value0: CharSequence): Str
+//           ^^^ definition ujson/IndexedValue.Str. object Str
+//           ^^^ definition ujson/IndexedValue.Str#productElement(). def productElement(x$1: Int): Any
+//           ^^^ definition ujson/IndexedValue.Str#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Str#`<init>`(). def this(index: Int, value0: CharSequence)
 //               ^^^^^ definition ujson/IndexedValue.Str#index. val index: Int
 //                      ^^^ reference scala/Int#
@@ -54,6 +59,10 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                                reference java/lang/Object#`<init>`().
   case class Obj(index: Int, value0: (java.lang.CharSequence, IndexedValue)*) extends IndexedValue
 //           ^^^ definition ujson/IndexedValue.Obj# case class Obj(index: Int, value0: (CharSequence, IndexedValue)*) extends IndexedValue
+//           ^^^ definition ujson/IndexedValue.Obj.apply(). def apply(index: Int, value0: (CharSequence, IndexedValue)*): Obj
+//           ^^^ definition ujson/IndexedValue.Obj#productElement(). def productElement(x$1: Int): Any
+//           ^^^ definition ujson/IndexedValue.Obj. object Obj
+//           ^^^ definition ujson/IndexedValue.Obj#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Obj#`<init>`(). def this(index: Int, value0: (CharSequence, IndexedValue)*)
 //               ^^^^^ definition ujson/IndexedValue.Obj#index. val index: Int
 //                      ^^^ reference scala/Int#
@@ -66,6 +75,10 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                                                 reference java/lang/Object#`<init>`().
   case class Arr(index: Int, value: IndexedValue*) extends IndexedValue
 //           ^^^ definition ujson/IndexedValue.Arr# case class Arr(index: Int, value: IndexedValue*) extends IndexedValue
+//           ^^^ definition ujson/IndexedValue.Arr#productElementName(). def productElementName(x$1: Int): String
+//           ^^^ definition ujson/IndexedValue.Arr#productElement(). def productElement(x$1: Int): Any
+//           ^^^ definition ujson/IndexedValue.Arr. object Arr
+//           ^^^ definition ujson/IndexedValue.Arr.apply(). def apply(index: Int, value: IndexedValue*): Arr
 //               definition ujson/IndexedValue.Arr#`<init>`(). def this(index: Int, value: IndexedValue*)
 //               ^^^^^ definition ujson/IndexedValue.Arr#index. val index: Int
 //                      ^^^ reference scala/Int#
@@ -75,6 +88,11 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                      reference java/lang/Object#`<init>`().
   case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends IndexedValue
 //           ^^^ definition ujson/IndexedValue.Num# case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends IndexedValue
+//           ^^^ definition ujson/IndexedValue.Num. object Num
+//           ^^^ definition ujson/IndexedValue.Num#copy(). def copy(index: Int, s: CharSequence, decIndex: Int, expIndex: Int): Num
+//           ^^^ definition ujson/IndexedValue.Num#productElement(). def productElement(x$1: Int): Any
+//           ^^^ definition ujson/IndexedValue.Num#productElementName(). def productElementName(x$1: Int): String
+//           ^^^ definition ujson/IndexedValue.Num.apply(). def apply(index: Int, s: CharSequence, decIndex: Int, expIndex: Int): Num
 //               definition ujson/IndexedValue.Num#`<init>`(). def this(index: Int, s: CharSequence, decIndex: Int, expIndex: Int)
 //               ^^^^^ definition ujson/IndexedValue.Num#index. val index: Int
 //                      ^^^ reference scala/Int#
@@ -88,6 +106,11 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                                                               reference java/lang/Object#`<init>`().
   case class NumRaw(index: Int, d: Double) extends IndexedValue
 //           ^^^^^^ definition ujson/IndexedValue.NumRaw# case class NumRaw(index: Int, d: Double) extends IndexedValue
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw#copy(). def copy(index: Int, d: Double): NumRaw
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw. object NumRaw
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw#productElement(). def productElement(x$1: Int): Any
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw.apply(). def apply(index: Int, d: Double): NumRaw
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw#productElementName(). def productElementName(x$1: Int): String
 //                  definition ujson/IndexedValue.NumRaw#`<init>`(). def this(index: Int, d: Double)
 //                  ^^^^^ definition ujson/IndexedValue.NumRaw#index. val index: Int
 //                         ^^^ reference scala/Int#
@@ -97,6 +120,11 @@ object IndexedValue extends Transformer[IndexedValue]{
 //                                                              reference java/lang/Object#`<init>`().
   case class False(index: Int) extends IndexedValue{
 //           ^^^^^ definition ujson/IndexedValue.False# case class False(index: Int) extends IndexedValue
+//           ^^^^^ definition ujson/IndexedValue.False. object False
+//           ^^^^^ definition ujson/IndexedValue.False#productElementName(). def productElementName(x$1: Int): String
+//           ^^^^^ definition ujson/IndexedValue.False.apply(). def apply(index: Int): False
+//           ^^^^^ definition ujson/IndexedValue.False#productElement(). def productElement(x$1: Int): Any
+//           ^^^^^ definition ujson/IndexedValue.False#copy(). def copy(index: Int): False
 //                 definition ujson/IndexedValue.False#`<init>`(). def this(index: Int)
 //                 ^^^^^ definition ujson/IndexedValue.False#index. val index: Int
 //                        ^^^ reference scala/Int#
@@ -107,6 +135,11 @@ object IndexedValue extends Transformer[IndexedValue]{
   }
   case class True(index: Int) extends IndexedValue{
 //           ^^^^ definition ujson/IndexedValue.True# case class True(index: Int) extends IndexedValue
+//           ^^^^ definition ujson/IndexedValue.True#productElement(). def productElement(x$1: Int): Any
+//           ^^^^ definition ujson/IndexedValue.True. object True
+//           ^^^^ definition ujson/IndexedValue.True#copy(). def copy(index: Int): True
+//           ^^^^ definition ujson/IndexedValue.True.apply(). def apply(index: Int): True
+//           ^^^^ definition ujson/IndexedValue.True#productElementName(). def productElementName(x$1: Int): String
 //                definition ujson/IndexedValue.True#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.True#index. val index: Int
 //                       ^^^ reference scala/Int#
@@ -117,6 +150,11 @@ object IndexedValue extends Transformer[IndexedValue]{
   }
   case class Null(index: Int) extends IndexedValue{
 //           ^^^^ definition ujson/IndexedValue.Null# case class Null(index: Int) extends IndexedValue
+//           ^^^^ definition ujson/IndexedValue.Null#copy(). def copy(index: Int): Null
+//           ^^^^ definition ujson/IndexedValue.Null#productElement(). def productElement(x$1: Int): Any
+//           ^^^^ definition ujson/IndexedValue.Null#productElementName(). def productElementName(x$1: Int): String
+//           ^^^^ definition ujson/IndexedValue.Null.apply(). def apply(index: Int): Null
+//           ^^^^ definition ujson/IndexedValue.Null. object Null
 //                definition ujson/IndexedValue.Null#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.Null#index. val index: Int
 //                       ^^^ reference scala/Int#

--- a/tests/snapshots/src/main/generated/ujson/Readable.scala
+++ b/tests/snapshots/src/main/generated/ujson/Readable.scala
@@ -33,6 +33,11 @@ object Readable extends ReadableLowPri{
 //                                     reference java/lang/Object#`<init>`().
   case class fromTransformer[T](t: T, w: Transformer[T]) extends Readable{
 //           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer# case class fromTransformer(t: T, w: Transformer[T])[T] extends Readable
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer#copy(). def copy(t: T, w: Transformer[T]): fromTransformer[T]
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer#productElement(). def productElement(x$1: Int): Any
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer.apply(). def apply(t: T, w: Transformer[T]): fromTransformer[T]
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer. object fromTransformer
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer#productElementName(). def productElementName(x$1: Int): String
 //                           ^ definition ujson/Readable.fromTransformer#[T] T
 //                              definition ujson/Readable.fromTransformer#`<init>`(). def this(t: T, w: Transformer[T])
 //                              ^ definition ujson/Readable.fromTransformer#t. val t: T

--- a/tests/snapshots/src/main/generated/ujson/Renderer.scala
+++ b/tests/snapshots/src/main/generated/ujson/Renderer.scala
@@ -21,6 +21,11 @@ import scala.annotation.switch
 
 case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
 //         ^^^^^^^^^^^^^ definition ujson/BytesRenderer# case class BytesRenderer(indent: Int, escapeUnicode: Boolean) extends BaseByteRenderer[ByteArrayOutputStream]
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#productElement(). def productElement(x$1: Int): Any
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#productElementName(). def productElementName(x$1: Int): String
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer. object BytesRenderer
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#copy(). def copy(indent: Int, escapeUnicode: Boolean): BytesRenderer
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer.apply(). def apply(indent: Int, escapeUnicode: Boolean): BytesRenderer
 //                       definition ujson/BytesRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                       ^^^^^^ definition ujson/BytesRenderer#indent. val indent: Int
 //                               ^^^ reference scala/Int#
@@ -38,6 +43,11 @@ case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
 
 case class StringRenderer(indent: Int = -1,
 //         ^^^^^^^^^^^^^^ definition ujson/StringRenderer# case class StringRenderer(indent: Int, escapeUnicode: Boolean) extends BaseCharRenderer[StringWriter]
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer. object StringRenderer
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer#copy(). def copy(indent: Int, escapeUnicode: Boolean): StringRenderer
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer.apply(). def apply(indent: Int, escapeUnicode: Boolean): StringRenderer
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer#productElement(). def productElement(x$1: Int): Any
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer#productElementName(). def productElementName(x$1: Int): String
 //                        definition ujson/StringRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                        ^^^^^^ definition ujson/StringRenderer#indent. val indent: Int
 //                                ^^^ reference scala/Int#
@@ -56,6 +66,11 @@ case class StringRenderer(indent: Int = -1,
 
 case class Renderer(out: java.io.Writer,
 //         ^^^^^^^^ definition ujson/Renderer# case class Renderer(out: Writer, indent: Int, escapeUnicode: Boolean) extends BaseCharRenderer[Writer]
+//         ^^^^^^^^ definition ujson/Renderer. object Renderer
+//         ^^^^^^^^ definition ujson/Renderer.apply(). def apply(out: Writer, indent: Int, escapeUnicode: Boolean): Renderer
+//         ^^^^^^^^ definition ujson/Renderer#productElementName(). def productElementName(x$1: Int): String
+//         ^^^^^^^^ definition ujson/Renderer#copy(). def copy(out: Writer, indent: Int, escapeUnicode: Boolean): Renderer
+//         ^^^^^^^^ definition ujson/Renderer#productElement(). def productElement(x$1: Int): Any
 //                  definition ujson/Renderer#`<init>`(). def this(out: Writer, indent: Int, escapeUnicode: Boolean)
 //                  ^^^ definition ujson/Renderer#out. val out: Writer
 //                       ^^^^ reference java/

--- a/tests/snapshots/src/main/generated/ujson/Value.scala
+++ b/tests/snapshots/src/main/generated/ujson/Value.scala
@@ -743,6 +743,11 @@ object Value extends AstTransformer[Value]{
     */
   case class InvalidData(data: Value, msg: String)
 //           ^^^^^^^^^^^ definition ujson/Value.InvalidData# case class InvalidData(data: Value, msg: String) extends Exception
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData#copy(). def copy(data: Value, msg: String): InvalidData
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData. object InvalidData
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData.apply(). def apply(data: Value, msg: String): InvalidData
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData#productElementName(). def productElementName(x$1: Int): String
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData#productElement(). def productElement(x$1: Int): Any
 //                       definition ujson/Value.InvalidData#`<init>`(). def this(data: Value, msg: String)
 //                       ^^^^ definition ujson/Value.InvalidData#data. val data: Value
 //                             ^^^^^ reference ujson/Value.Value#
@@ -758,6 +763,11 @@ object Value extends AstTransformer[Value]{
 
 case class Str(value: String) extends Value
 //         ^^^ definition ujson/Str# case class Str(value: String) extends Value
+//         ^^^ definition ujson/Str#productElement(). def productElement(x$1: Int): Any
+//         ^^^ definition ujson/Str#copy(). def copy(value: String): Str
+//         ^^^ definition ujson/Str. object Str
+//         ^^^ definition ujson/Str#productElementName(). def productElementName(x$1: Int): String
+//         ^^^ definition ujson/Str.apply(). def apply(value: String): Str
 //             definition ujson/Str#`<init>`(). def this(value: String)
 //             ^^^^^ definition ujson/Str#value. val value: String
 //                    ^^^^^^ reference scala/Predef.String#
@@ -765,6 +775,9 @@ case class Str(value: String) extends Value
 //                                          reference java/lang/Object#`<init>`().
 case class Obj(value: mutable.LinkedHashMap[String, Value]) extends Value
 //         ^^^ definition ujson/Obj# case class Obj(value: LinkedHashMap[String, Value]) extends Value
+//         ^^^ definition ujson/Obj#productElementName(). def productElementName(x$1: Int): String
+//         ^^^ definition ujson/Obj#productElement(). def productElement(x$1: Int): Any
+//         ^^^ definition ujson/Obj#copy(). def copy(value: LinkedHashMap[String, Value]): Obj
 //             definition ujson/Obj#`<init>`(). def this(value: LinkedHashMap[String, Value])
 //             ^^^^^ definition ujson/Obj#value. val value: LinkedHashMap[String, Value]
 //                    ^^^^^^^ reference scala/collection/mutable/
@@ -776,6 +789,7 @@ case class Obj(value: mutable.LinkedHashMap[String, Value]) extends Value
 // reference java/lang/Object#`<init>`().
 object Obj{
 //     ^^^ definition ujson/Obj. object Obj
+//     ^^^ definition ujson/Obj.apply(+2). def apply(value: LinkedHashMap[String, Value]): Obj
   implicit def from(items: TraversableOnce[(String, Value)]): Obj = {
 //             ^^^^ definition ujson/Obj.from(). implicit def from(items: TraversableOnce[(String, Value)]): Obj
 //                  ^^^^^ definition ujson/Obj.from().(items) items: TraversableOnce[(String, Value)]
@@ -849,6 +863,9 @@ object Obj{
 }
 case class Arr(value: ArrayBuffer[Value]) extends Value
 //         ^^^ definition ujson/Arr# case class Arr(value: ArrayBuffer[Value]) extends Value
+//         ^^^ definition ujson/Arr#productElement(). def productElement(x$1: Int): Any
+//         ^^^ definition ujson/Arr#productElementName(). def productElementName(x$1: Int): String
+//         ^^^ definition ujson/Arr#copy(). def copy(value: ArrayBuffer[Value]): Arr
 //             definition ujson/Arr#`<init>`(). def this(value: ArrayBuffer[Value])
 //             ^^^^^ definition ujson/Arr#value. val value: ArrayBuffer[Value]
 //                    ^^^^^^^^^^^ reference scala/collection/mutable/ArrayBuffer#
@@ -858,6 +875,7 @@ case class Arr(value: ArrayBuffer[Value]) extends Value
 // reference java/lang/Object#`<init>`().
 object Arr{
 //     ^^^ definition ujson/Arr. object Arr
+//     ^^^ definition ujson/Arr.apply(+1). def apply(value: ArrayBuffer[Value]): Arr
   implicit def from[T](items: TraversableOnce[T])(implicit conv: T => Value): Arr = {
 //             ^^^^ definition ujson/Arr.from(). implicit def from(items: TraversableOnce[T])(conv: (T) => Value): Arr
 //                  ^ definition ujson/Arr.from().[T] T
@@ -919,6 +937,11 @@ object Arr{
 }
 case class Num(value: Double) extends Value
 //         ^^^ definition ujson/Num# case class Num(value: Double) extends Value
+//         ^^^ definition ujson/Num#productElement(). def productElement(x$1: Int): Any
+//         ^^^ definition ujson/Num#copy(). def copy(value: Double): Num
+//         ^^^ definition ujson/Num.apply(). def apply(value: Double): Num
+//         ^^^ definition ujson/Num#productElementName(). def productElementName(x$1: Int): String
+//         ^^^ definition ujson/Num. object Num
 //             definition ujson/Num#`<init>`(). def this(value: Double)
 //             ^^^^^ definition ujson/Num#value. val value: Double
 //                    ^^^^^^ reference scala/Double#
@@ -955,6 +978,7 @@ object Bool{
 }
 case object False extends Bool{
 //          ^^^^^ definition ujson/False. case object False
+//          ^^^^^ definition ujson/False.productElement(). def productElement(x$1: Int): Any
 //                        ^^^^ reference ujson/Bool#
 //                             reference ujson/Bool#`<init>`().
   def value = false
@@ -962,6 +986,7 @@ case object False extends Bool{
 }
 case object True extends Bool{
 //          ^^^^ definition ujson/True. case object True
+//          ^^^^ definition ujson/True.productElement(). def productElement(x$1: Int): Any
 //                       ^^^^ reference ujson/Bool#
 //                            reference ujson/Bool#`<init>`().
   def value = true
@@ -969,6 +994,7 @@ case object True extends Bool{
 }
 case object Null extends Value{
 //          ^^^^ definition ujson/Null. case object Null
+//          ^^^^ definition ujson/Null.productElement(). def productElement(x$1: Int): Any
 //                       ^^^^^ reference ujson/Value#
 //                             reference java/lang/Object#`<init>`().
   def value = null


### PR DESCRIPTION
Fixes #397
Fixes #396

Previously, "goto defintion" did not work for synthetic symbols such as
case class companion objects or var setter methods. Now, lsif-java emits
synthetic occurrences for  these symbols so that "goto definition" works
as expected.