### PR TITLE
Support more synthetic Scala symbols

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifSemanticdb.java
@@ -338,7 +338,7 @@ public class LsifSemanticdb {
   }
 
   private boolean isIgnoredOverriddenSymbol(String symbol) {
-    // Skip java/lang/Object# since it's the parent of all classes
+    // Skip java/lang/Object# and similar symbols from Scala since it's the parent of all classes
     // making it noisy for "find implementations" results.
     return symbol.equals("java/lang/Object#");
   }

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifTextDocument.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifTextDocument.java
@@ -136,6 +136,24 @@ public class LsifTextDocument {
                   owner.owner, owner.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Type)));
         }
         break;
+      case Parameter:
+        SymbolDescriptor owner = SymbolDescriptor.parseFromSymbol(sym.owner);
+        if (owner.descriptor.name.equals("copy")) {
+          // case classes copy method parameter.
+          alternatives.add(
+              SemanticdbSymbols.global(
+                  owner.owner, sym.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Term)));
+        } else if (owner.descriptor.name.equals("apply")) {
+          // case class companion apply constructor parameter.
+          SymbolDescriptor grandparent = SymbolDescriptor.parseFromSymbol(owner.owner);
+          String companion =
+              SemanticdbSymbols.global(
+                  grandparent.owner,
+                  grandparent.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Type));
+          alternatives.add(
+              SemanticdbSymbols.global(
+                  companion, sym.descriptor.withKind(SemanticdbSymbols.Descriptor.Kind.Term)));
+        }
       case Term:
         alternatives.add(
             SemanticdbSymbols.global(

--- a/tests/minimized-scala/src/main/scala/minimized/Issue396.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/Issue396.scala
@@ -3,7 +3,7 @@ package minimized
 case class Issue396(a: Int)
 object Issue396App {
   println(Issue396)
-  Issue396.apply(42).copy(a = 41)
-  Issue396.apply(42).productElement(0)
-  Issue396.apply(42).productElementName(0)
+  Issue396.apply(a = 42).copy(a = 41)
+  Issue396.apply(a = 42).productElement(0)
+  Issue396.apply(a = 42).productElementName(0)
 }

--- a/tests/snapshots/src/main/generated/minimized/Issue396.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue396.scala
@@ -10,23 +10,28 @@ case class Issue396(a: Int)
 //         ^^^^^^^^ synthetic_definition minimized/Issue396#productElementName(). def productElementName(x$1: Int): String
 //                  definition minimized/Issue396#`<init>`(). def this(a: Int)
 //                  ^ definition minimized/Issue396#a. val a: Int
+//                  ^ synthetic_definition minimized/Issue396.apply().(a) a: Int
+//                  ^ synthetic_definition minimized/Issue396#copy().(a) default a: Int
 //                     ^^^ reference scala/Int#
 object Issue396App {
 //     ^^^^^^^^^^^ definition minimized/Issue396App. object Issue396App
   println(Issue396)
 //^^^^^^^ reference scala/Predef.println(+1).
 //        ^^^^^^^^ reference minimized/Issue396.
-  Issue396.apply(42).copy(a = 41)
+  Issue396.apply(a = 42).copy(a = 41)
 //^^^^^^^^ reference minimized/Issue396.
 //         ^^^^^ reference minimized/Issue396.apply().
-//                   ^^^^ reference minimized/Issue396#copy().
-//                        ^ reference minimized/Issue396#copy().(a)
-  Issue396.apply(42).productElement(0)
+//               ^ reference minimized/Issue396.apply().(a)
+//                       ^^^^ reference minimized/Issue396#copy().
+//                            ^ reference minimized/Issue396#copy().(a)
+  Issue396.apply(a = 42).productElement(0)
 //^^^^^^^^ reference minimized/Issue396.
 //         ^^^^^ reference minimized/Issue396.apply().
-//                   ^^^^^^^^^^^^^^ reference minimized/Issue396#productElement().
-  Issue396.apply(42).productElementName(0)
+//               ^ reference minimized/Issue396.apply().(a)
+//                       ^^^^^^^^^^^^^^ reference minimized/Issue396#productElement().
+  Issue396.apply(a = 42).productElementName(0)
 //^^^^^^^^ reference minimized/Issue396.
 //         ^^^^^ reference minimized/Issue396.apply().
-//                   ^^^^^^^^^^^^^^^^^^ reference minimized/Issue396#productElementName().
+//               ^ reference minimized/Issue396.apply().(a)
+//                       ^^^^^^^^^^^^^^^^^^ reference minimized/Issue396#productElementName().
 }

--- a/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
@@ -13,6 +13,8 @@ case class MinimizedCaseClass(value: String) {
 //         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass#copy(). def copy(value: String): MinimizedCaseClass
 //                            definition minimized/MinimizedCaseClass#`<init>`(). def this(value: String)
 //                            ^^^^^ definition minimized/MinimizedCaseClass#value. val value: String
+//                            ^^^^^ synthetic_definition minimized/MinimizedCaseClass#copy().(value) default value: String
+//                            ^^^^^ synthetic_definition minimized/MinimizedCaseClass.apply().(value) value: String
 //                                   ^^^^^^ reference scala/Predef.String#
   def this() = this("value")
 //    ^^^^ definition minimized/MinimizedCaseClass#`<init>`(+1). def this()

--- a/tests/snapshots/src/main/generated/ujson/Exceptions.scala
+++ b/tests/snapshots/src/main/generated/ujson/Exceptions.scala
@@ -15,8 +15,12 @@ case class ParseException(clue: String, index: Int)
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException#productElement(). def productElement(x$1: Int): Any
 //                        definition ujson/ParseException#`<init>`(). def this(clue: String, index: Int)
 //                        ^^^^ definition ujson/ParseException#clue. val clue: String
+//                        ^^^^ synthetic_definition ujson/ParseException.apply().(clue) clue: String
+//                        ^^^^ synthetic_definition ujson/ParseException#copy().(clue) default clue: String
 //                              ^^^^^^ reference scala/Predef.String#
 //                                      ^^^^^ definition ujson/ParseException#index. val index: Int
+//                                      ^^^^^ synthetic_definition ujson/ParseException.apply().(index) index: Int
+//                                      ^^^^^ synthetic_definition ujson/ParseException#copy().(index) default index: Int
 //                                             ^^^ reference scala/Int#
   extends Exception(clue + " at index " + index) with ParsingFailedException
 //        ^^^^^^^^^ reference scala/package.Exception#
@@ -36,6 +40,8 @@ case class IncompleteParseException(msg: String)
 //         ^^^^^^^^^^^^^^^^^^^^^^^^ synthetic_definition ujson/IncompleteParseException. object IncompleteParseException
 //                                  definition ujson/IncompleteParseException#`<init>`(). def this(msg: String)
 //                                  ^^^ definition ujson/IncompleteParseException#msg. val msg: String
+//                                  ^^^ synthetic_definition ujson/IncompleteParseException.apply().(msg) msg: String
+//                                  ^^^ synthetic_definition ujson/IncompleteParseException#copy().(msg) default msg: String
 //                                       ^^^^^^ reference scala/Predef.String#
   extends Exception(msg) with ParsingFailedException
 //        ^^^^^^^^^ reference scala/package.Exception#

--- a/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
+++ b/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
@@ -50,8 +50,12 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ synthetic_definition ujson/IndexedValue.Str#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Str#`<init>`(). def this(index: Int, value0: CharSequence)
 //               ^^^^^ definition ujson/IndexedValue.Str#index. val index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Str#copy().(index) default index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Str.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^^ definition ujson/IndexedValue.Str#value0. val value0: CharSequence
+//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Str.apply().(value0) value0: CharSequence
+//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Str#copy().(value0) default value0: CharSequence
 //                                   ^^^^ reference java/
 //                                        ^^^^ reference java/lang/
 //                                             ^^^^^^^^^^^^ reference java/lang/CharSequence#
@@ -65,8 +69,10 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ synthetic_definition ujson/IndexedValue.Obj#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Obj#`<init>`(). def this(index: Int, value0: (CharSequence, IndexedValue)*)
 //               ^^^^^ definition ujson/IndexedValue.Obj#index. val index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Obj.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^^ definition ujson/IndexedValue.Obj#value0. val value0: (CharSequence, IndexedValue)*
+//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Obj.apply().(value0) value0: (CharSequence, IndexedValue)*
 //                                    ^^^^ reference java/
 //                                         ^^^^ reference java/lang/
 //                                              ^^^^^^^^^^^^ reference java/lang/CharSequence#
@@ -81,8 +87,10 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ synthetic_definition ujson/IndexedValue.Arr.apply(). def apply(index: Int, value: IndexedValue*): Arr
 //               definition ujson/IndexedValue.Arr#`<init>`(). def this(index: Int, value: IndexedValue*)
 //               ^^^^^ definition ujson/IndexedValue.Arr#index. val index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Arr.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^ definition ujson/IndexedValue.Arr#value. val value: IndexedValue*
+//                           ^^^^^ synthetic_definition ujson/IndexedValue.Arr.apply().(value) value: IndexedValue*
 //                                  ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                         ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                                      reference java/lang/Object#`<init>`().
@@ -95,12 +103,20 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ synthetic_definition ujson/IndexedValue.Num.apply(). def apply(index: Int, s: CharSequence, decIndex: Int, expIndex: Int): Num
 //               definition ujson/IndexedValue.Num#`<init>`(). def this(index: Int, s: CharSequence, decIndex: Int, expIndex: Int)
 //               ^^^^^ definition ujson/IndexedValue.Num#index. val index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(index) default index: Int
+//               ^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^ definition ujson/IndexedValue.Num#s. val s: CharSequence
+//                           ^ synthetic_definition ujson/IndexedValue.Num.apply().(s) s: CharSequence
+//                           ^ synthetic_definition ujson/IndexedValue.Num#copy().(s) default s: CharSequence
 //                              ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                            ^^^^^^^^ definition ujson/IndexedValue.Num#decIndex. val decIndex: Int
+//                                            ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(decIndex) default decIndex: Int
+//                                            ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(decIndex) decIndex: Int
 //                                                      ^^^ reference scala/Int#
 //                                                           ^^^^^^^^ definition ujson/IndexedValue.Num#expIndex. val expIndex: Int
+//                                                           ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(expIndex) expIndex: Int
+//                                                           ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(expIndex) default expIndex: Int
 //                                                                     ^^^ reference scala/Int#
 //                                                                                  ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                                                               reference java/lang/Object#`<init>`().
@@ -113,8 +129,12 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#productElementName(). def productElementName(x$1: Int): String
 //                  definition ujson/IndexedValue.NumRaw#`<init>`(). def this(index: Int, d: Double)
 //                  ^^^^^ definition ujson/IndexedValue.NumRaw#index. val index: Int
+//                  ^^^^^ synthetic_definition ujson/IndexedValue.NumRaw.apply().(index) index: Int
+//                  ^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#copy().(index) default index: Int
 //                         ^^^ reference scala/Int#
 //                              ^ definition ujson/IndexedValue.NumRaw#d. val d: Double
+//                              ^ synthetic_definition ujson/IndexedValue.NumRaw#copy().(d) default d: Double
+//                              ^ synthetic_definition ujson/IndexedValue.NumRaw.apply().(d) d: Double
 //                                 ^^^^^^ reference scala/Double#
 //                                                 ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                              reference java/lang/Object#`<init>`().
@@ -127,6 +147,8 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^^^ synthetic_definition ujson/IndexedValue.False#copy(). def copy(index: Int): False
 //                 definition ujson/IndexedValue.False#`<init>`(). def this(index: Int)
 //                 ^^^^^ definition ujson/IndexedValue.False#index. val index: Int
+//                 ^^^^^ synthetic_definition ujson/IndexedValue.False.apply().(index) index: Int
+//                 ^^^^^ synthetic_definition ujson/IndexedValue.False#copy().(index) default index: Int
 //                        ^^^ reference scala/Int#
 //                                     ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                  reference java/lang/Object#`<init>`().
@@ -142,6 +164,8 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^^ synthetic_definition ujson/IndexedValue.True#productElementName(). def productElementName(x$1: Int): String
 //                definition ujson/IndexedValue.True#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.True#index. val index: Int
+//                ^^^^^ synthetic_definition ujson/IndexedValue.True.apply().(index) index: Int
+//                ^^^^^ synthetic_definition ujson/IndexedValue.True#copy().(index) default index: Int
 //                       ^^^ reference scala/Int#
 //                                    ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                 reference java/lang/Object#`<init>`().
@@ -157,6 +181,8 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^^ synthetic_definition ujson/IndexedValue.Null. object Null
 //                definition ujson/IndexedValue.Null#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.Null#index. val index: Int
+//                ^^^^^ synthetic_definition ujson/IndexedValue.Null.apply().(index) index: Int
+//                ^^^^^ synthetic_definition ujson/IndexedValue.Null#copy().(index) default index: Int
 //                       ^^^ reference scala/Int#
 //                                    ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                 reference java/lang/Object#`<init>`().

--- a/tests/snapshots/src/main/generated/ujson/Readable.scala
+++ b/tests/snapshots/src/main/generated/ujson/Readable.scala
@@ -41,8 +41,12 @@ object Readable extends ReadableLowPri{
 //                           ^ definition ujson/Readable.fromTransformer#[T] T
 //                              definition ujson/Readable.fromTransformer#`<init>`(). def this(t: T, w: Transformer[T])
 //                              ^ definition ujson/Readable.fromTransformer#t. val t: T
+//                              ^ synthetic_definition ujson/Readable.fromTransformer#copy().(t) default t: T
+//                              ^ synthetic_definition ujson/Readable.fromTransformer.apply().(t) t: T
 //                                 ^ reference ujson/Readable.fromTransformer#[T]
 //                                    ^ definition ujson/Readable.fromTransformer#w. val w: Transformer[T]
+//                                    ^ synthetic_definition ujson/Readable.fromTransformer#copy().(w) default w: Transformer[T]
+//                                    ^ synthetic_definition ujson/Readable.fromTransformer.apply().(w) w: Transformer[T]
 //                                       ^^^^^^^^^^^ reference ujson/Transformer#
 //                                                   ^ reference ujson/Readable.fromTransformer#[T]
 //                                                               ^^^^^^^^ reference ujson/Readable#

--- a/tests/snapshots/src/main/generated/ujson/Renderer.scala
+++ b/tests/snapshots/src/main/generated/ujson/Renderer.scala
@@ -28,8 +28,12 @@ case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
 //         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer.apply(). def apply(indent: Int, escapeUnicode: Boolean): BytesRenderer
 //                       definition ujson/BytesRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                       ^^^^^^ definition ujson/BytesRenderer#indent. val indent: Int
+//                       ^^^^^^ synthetic_definition ujson/BytesRenderer#copy().(indent) default indent: Int
+//                       ^^^^^^ synthetic_definition ujson/BytesRenderer.apply().(indent) default indent: Int
 //                               ^^^ reference scala/Int#
 //                                         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#escapeUnicode. val escapeUnicode: Boolean
+//                                         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                                         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
 //                                                        ^^^^^^^ reference scala/Boolean#
   extends BaseByteRenderer(new ByteArrayOutputStream(), indent, escapeUnicode){
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseByteRenderer#
@@ -50,9 +54,13 @@ case class StringRenderer(indent: Int = -1,
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#productElementName(). def productElementName(x$1: Int): String
 //                        definition ujson/StringRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                        ^^^^^^ definition ujson/StringRenderer#indent. val indent: Int
+//                        ^^^^^^ synthetic_definition ujson/StringRenderer#copy().(indent) default indent: Int
+//                        ^^^^^^ synthetic_definition ujson/StringRenderer.apply().(indent) default indent: Int
 //                                ^^^ reference scala/Int#
                           escapeUnicode: Boolean = false)
 //                        ^^^^^^^^^^^^^ definition ujson/StringRenderer#escapeUnicode. val escapeUnicode: Boolean
+//                        ^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                        ^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
 //                                       ^^^^^^^ reference scala/Boolean#
   extends BaseCharRenderer(new java.io.StringWriter(), indent, escapeUnicode)
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseCharRenderer#
@@ -73,14 +81,20 @@ case class Renderer(out: java.io.Writer,
 //         ^^^^^^^^ synthetic_definition ujson/Renderer#productElement(). def productElement(x$1: Int): Any
 //                  definition ujson/Renderer#`<init>`(). def this(out: Writer, indent: Int, escapeUnicode: Boolean)
 //                  ^^^ definition ujson/Renderer#out. val out: Writer
+//                  ^^^ synthetic_definition ujson/Renderer.apply().(out) out: Writer
+//                  ^^^ synthetic_definition ujson/Renderer#copy().(out) default out: Writer
 //                       ^^^^ reference java/
 //                            ^^ reference java/io/
 //                               ^^^^^^ reference java/io/Writer#
                     indent: Int = -1,
 //                  ^^^^^^ definition ujson/Renderer#indent. val indent: Int
+//                  ^^^^^^ synthetic_definition ujson/Renderer#copy().(indent) default indent: Int
+//                  ^^^^^^ synthetic_definition ujson/Renderer.apply().(indent) default indent: Int
 //                          ^^^ reference scala/Int#
                     escapeUnicode: Boolean = false)
 //                  ^^^^^^^^^^^^^ definition ujson/Renderer#escapeUnicode. val escapeUnicode: Boolean
+//                  ^^^^^^^^^^^^^ synthetic_definition ujson/Renderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                  ^^^^^^^^^^^^^ synthetic_definition ujson/Renderer#copy().(escapeUnicode) default escapeUnicode: Boolean
 //                                 ^^^^^^^ reference scala/Boolean#
   extends BaseCharRenderer(out, indent, escapeUnicode)
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseCharRenderer#

--- a/tests/snapshots/src/main/generated/ujson/Value.scala
+++ b/tests/snapshots/src/main/generated/ujson/Value.scala
@@ -750,8 +750,12 @@ object Value extends AstTransformer[Value]{
 //           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData#productElement(). def productElement(x$1: Int): Any
 //                       definition ujson/Value.InvalidData#`<init>`(). def this(data: Value, msg: String)
 //                       ^^^^ definition ujson/Value.InvalidData#data. val data: Value
+//                       ^^^^ synthetic_definition ujson/Value.InvalidData.apply().(data) data: Value
+//                       ^^^^ synthetic_definition ujson/Value.InvalidData#copy().(data) default data: Value
 //                             ^^^^^ reference ujson/Value.Value#
 //                                    ^^^ definition ujson/Value.InvalidData#msg. val msg: String
+//                                    ^^^ synthetic_definition ujson/Value.InvalidData#copy().(msg) default msg: String
+//                                    ^^^ synthetic_definition ujson/Value.InvalidData.apply().(msg) msg: String
 //                                         ^^^^^^ reference scala/Predef.String#
     extends Exception(s"$msg (data: $data)")
 //          ^^^^^^^^^ reference scala/package.Exception#
@@ -770,6 +774,8 @@ case class Str(value: String) extends Value
 //         ^^^ synthetic_definition ujson/Str.apply(). def apply(value: String): Str
 //             definition ujson/Str#`<init>`(). def this(value: String)
 //             ^^^^^ definition ujson/Str#value. val value: String
+//             ^^^^^ synthetic_definition ujson/Str.apply().(value) value: String
+//             ^^^^^ synthetic_definition ujson/Str#copy().(value) default value: String
 //                    ^^^^^^ reference scala/Predef.String#
 //                                    ^^^^^ reference ujson/Value#
 //                                          reference java/lang/Object#`<init>`().
@@ -780,6 +786,8 @@ case class Obj(value: mutable.LinkedHashMap[String, Value]) extends Value
 //         ^^^ synthetic_definition ujson/Obj#copy(). def copy(value: LinkedHashMap[String, Value]): Obj
 //             definition ujson/Obj#`<init>`(). def this(value: LinkedHashMap[String, Value])
 //             ^^^^^ definition ujson/Obj#value. val value: LinkedHashMap[String, Value]
+//             ^^^^^ synthetic_definition ujson/Obj.apply(+2).(value) value: LinkedHashMap[String, Value]
+//             ^^^^^ synthetic_definition ujson/Obj#copy().(value) default value: LinkedHashMap[String, Value]
 //                    ^^^^^^^ reference scala/collection/mutable/
 //                            ^^^^^^^^^^^^^ reference scala/collection/mutable/LinkedHashMap#
 //                                          ^^^^^^ reference scala/Predef.String#
@@ -868,6 +876,8 @@ case class Arr(value: ArrayBuffer[Value]) extends Value
 //         ^^^ synthetic_definition ujson/Arr#copy(). def copy(value: ArrayBuffer[Value]): Arr
 //             definition ujson/Arr#`<init>`(). def this(value: ArrayBuffer[Value])
 //             ^^^^^ definition ujson/Arr#value. val value: ArrayBuffer[Value]
+//             ^^^^^ synthetic_definition ujson/Arr#copy().(value) default value: ArrayBuffer[Value]
+//             ^^^^^ synthetic_definition ujson/Arr.apply(+1).(value) value: ArrayBuffer[Value]
 //                    ^^^^^^^^^^^ reference scala/collection/mutable/ArrayBuffer#
 //                                ^^^^^ reference ujson/Value#
 //                                                ^^^^^ reference ujson/Value#
@@ -944,6 +954,8 @@ case class Num(value: Double) extends Value
 //         ^^^ synthetic_definition ujson/Num. object Num
 //             definition ujson/Num#`<init>`(). def this(value: Double)
 //             ^^^^^ definition ujson/Num#value. val value: Double
+//             ^^^^^ synthetic_definition ujson/Num.apply().(value) value: Double
+//             ^^^^^ synthetic_definition ujson/Num#copy().(value) default value: Double
 //                    ^^^^^^ reference scala/Double#
 //                                    ^^^^^ reference ujson/Value#
 //                                          reference java/lang/Object#`<init>`().


### PR DESCRIPTION
Previously, "goto definition" didn't work for references to parameters of the auto-generated `copy` and `apply` methods for case classes.
```scala
case class Issue396(a: Int)
object Issue396App {
  Issue396.apply(a = 42).copy(a = 41)
//               ^ no definition
//                            ^ no definition
}
```

Now, lsif-java adds synthetic definitions for those symbols at the same location as where the `a: Int` field is defined on the case class.

Manual example demonstrating the bugfix https://sourcegraph.com/github.com/sourcegraph/sbt-sourcegraph@df4c9f22919bf9843c12afbd9a65f74a3e4b1dfd/-/blob/example/foo.scala?L1:14