### PR TITLE
Promote synthetic definitions into normal definitions if they share names

### DIFF
--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolOccurrences.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/SymbolOccurrences.java
@@ -1,0 +1,26 @@
+package com.sourcegraph.lsif_semanticdb;
+
+import com.sourcegraph.semanticdb_javac.Semanticdb;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SymbolOccurrences {
+  public List<Semanticdb.SymbolOccurrence> occurrences = new ArrayList<>();
+
+  public void addSyntheticDefinition(String sym) {
+    occurrences.add(
+        Semanticdb.SymbolOccurrence.newBuilder()
+            .setSymbol(sym)
+            .setRole(Semanticdb.SymbolOccurrence.Role.SYNTHETIC_DEFINITION)
+            .build());
+  }
+
+  public void addDefinition(String sym) {
+    occurrences.add(
+        Semanticdb.SymbolOccurrence.newBuilder()
+            .setSymbol(sym)
+            .setRole(Semanticdb.SymbolOccurrence.Role.DEFINITION)
+            .build());
+  }
+}

--- a/tests/snapshots/src/main/generated/BaseByteRenderer.scala
+++ b/tests/snapshots/src/main/generated/BaseByteRenderer.scala
@@ -23,7 +23,7 @@ import upickle.core.{ArrVisitor, ObjVisitor}
   */
 class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
 //    ^^^^^^^^^^^^^^^^ definition ujson/BaseByteRenderer# class BaseByteRenderer[T <: Output]
-//    ^^^^^^^^^^^^^^^^ synthetic_definition ujson/BaseByteRenderer. object BaseByteRenderer
+//    ^^^^^^^^^^^^^^^^ definition ujson/BaseByteRenderer. object BaseByteRenderer
 //                     ^ definition ujson/BaseByteRenderer#[T] T <: Output
 //                          ^^^^^^^ reference upickle/
 //                                  ^^^^ reference upickle/core/
@@ -31,12 +31,15 @@ class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
 //                                               ^^^^^^ reference upickle/core/ByteOps.Output#
                       (out: T,
 //                     ^^^ definition ujson/BaseByteRenderer#out. private[this] val out: T
+//                     ^^^ definition ujson/BaseByteRenderer#`<init>`().(out) out: T
 //                          ^ reference ujson/BaseByteRenderer#[T]
                        indent: Int = -1,
 //                     ^^^^^^ definition ujson/BaseByteRenderer#indent. private[this] val indent: Int
+//                     ^^^^^^ definition ujson/BaseByteRenderer#`<init>`().(indent) default indent: Int
 //                             ^^^ reference scala/Int#
                        escapeUnicode: Boolean = false) extends JsVisitor[T, T]{
 //                     ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#escapeUnicode. private[this] val escapeUnicode: Boolean
+//                     ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#`<init>`().(escapeUnicode) default escapeUnicode: Boolean
 //                                    ^^^^^^^ reference scala/Boolean#
 //                                                             ^^^^^^^^^ reference ujson/JsVisitor#
 //                                                                       ^ reference ujson/BaseByteRenderer#[T]
@@ -66,13 +69,13 @@ class BaseByteRenderer[T <: upickle.core.ByteOps.Output]
 
   private[this] var depth: Int = 0
 //                  ^^^^^ definition ujson/BaseByteRenderer#depth(). private[this] var depth: Int
-//                  ^^^^^ synthetic_definition ujson/BaseByteRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
+//                  ^^^^^ definition ujson/BaseByteRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
 //                         ^^^ reference scala/Int#
 
 
   private[this] var commaBuffered = false
 //                  ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#commaBuffered(). private[this] var commaBuffered: Boolean
-//                  ^^^^^^^^^^^^^ synthetic_definition ujson/BaseByteRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
+//                  ^^^^^^^^^^^^^ definition ujson/BaseByteRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
 
   def flushBuffer() = {
 //    ^^^^^^^^^^^ definition ujson/BaseByteRenderer#flushBuffer(). def flushBuffer(): Unit

--- a/tests/snapshots/src/main/generated/BaseCharRenderer.scala
+++ b/tests/snapshots/src/main/generated/BaseCharRenderer.scala
@@ -23,7 +23,7 @@ import upickle.core.{ArrVisitor, ObjVisitor}
   */
 class BaseCharRenderer[T <: upickle.core.CharOps.Output]
 //    ^^^^^^^^^^^^^^^^ definition ujson/BaseCharRenderer# class BaseCharRenderer[T <: Output]
-//    ^^^^^^^^^^^^^^^^ synthetic_definition ujson/BaseCharRenderer. object BaseCharRenderer
+//    ^^^^^^^^^^^^^^^^ definition ujson/BaseCharRenderer. object BaseCharRenderer
 //                     ^ definition ujson/BaseCharRenderer#[T] T <: Output
 //                          ^^^^^^^ reference upickle/
 //                                  ^^^^ reference upickle/core/
@@ -31,12 +31,15 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output]
 //                                               ^^^^^^ reference upickle/core/CharOps.Output#
                       (out: T,
 //                     ^^^ definition ujson/BaseCharRenderer#out. private[this] val out: T
+//                     ^^^ definition ujson/BaseCharRenderer#`<init>`().(out) out: T
 //                          ^ reference ujson/BaseCharRenderer#[T]
                        indent: Int = -1,
 //                     ^^^^^^ definition ujson/BaseCharRenderer#indent. private[this] val indent: Int
+//                     ^^^^^^ definition ujson/BaseCharRenderer#`<init>`().(indent) default indent: Int
 //                             ^^^ reference scala/Int#
                        escapeUnicode: Boolean = false) extends JsVisitor[T, T]{
 //                     ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#escapeUnicode. private[this] val escapeUnicode: Boolean
+//                     ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#`<init>`().(escapeUnicode) default escapeUnicode: Boolean
 //                                    ^^^^^^^ reference scala/Boolean#
 //                                                             ^^^^^^^^^ reference ujson/JsVisitor#
 //                                                                       ^ reference ujson/BaseCharRenderer#[T]
@@ -66,13 +69,13 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output]
 
   private[this] var depth: Int = 0
 //                  ^^^^^ definition ujson/BaseCharRenderer#depth(). private[this] var depth: Int
-//                  ^^^^^ synthetic_definition ujson/BaseCharRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
+//                  ^^^^^ definition ujson/BaseCharRenderer#`depth_=`(). private[this] var depth_=(x$1: Int): Unit
 //                         ^^^ reference scala/Int#
 
 
   private[this] var commaBuffered = false
 //                  ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#commaBuffered(). private[this] var commaBuffered: Boolean
-//                  ^^^^^^^^^^^^^ synthetic_definition ujson/BaseCharRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
+//                  ^^^^^^^^^^^^^ definition ujson/BaseCharRenderer#`commaBuffered_=`(). private[this] var commaBuffered_=(x$1: Boolean): Unit
 
   def flushBuffer() = {
 //    ^^^^^^^^^^^ definition ujson/BaseCharRenderer#flushBuffer(). def flushBuffer(): Unit

--- a/tests/snapshots/src/main/generated/minimized/Issue396.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue396.scala
@@ -5,13 +5,14 @@ case class Issue396(a: Int)
 //         ^^^^^^^^ definition minimized/Issue396# case class Issue396(a: Int)
 //         ^^^^^^^^ synthetic_definition minimized/Issue396#copy(). def copy(a: Int): Issue396
 //         ^^^^^^^^ synthetic_definition minimized/Issue396#productElement(). def productElement(x$1: Int): Any
-//         ^^^^^^^^ synthetic_definition minimized/Issue396. object Issue396
+//         ^^^^^^^^ definition minimized/Issue396. object Issue396
 //         ^^^^^^^^ synthetic_definition minimized/Issue396.apply(). def apply(a: Int): Issue396
 //         ^^^^^^^^ synthetic_definition minimized/Issue396#productElementName(). def productElementName(x$1: Int): String
 //                  definition minimized/Issue396#`<init>`(). def this(a: Int)
 //                  ^ definition minimized/Issue396#a. val a: Int
-//                  ^ synthetic_definition minimized/Issue396.apply().(a) a: Int
-//                  ^ synthetic_definition minimized/Issue396#copy().(a) default a: Int
+//                  ^ definition minimized/Issue396.apply().(a) a: Int
+//                  ^ definition minimized/Issue396#`<init>`().(a) a: Int
+//                  ^ definition minimized/Issue396#copy().(a) default a: Int
 //                     ^^^ reference scala/Int#
 object Issue396App {
 //     ^^^^^^^^^^^ definition minimized/Issue396App. object Issue396App

--- a/tests/snapshots/src/main/generated/minimized/Issue397.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue397.scala
@@ -6,7 +6,7 @@ class Issue397 {
 //              definition minimized/Issue397#`<init>`(). def this()
   var blah = Set("abc")
 //    ^^^^ definition minimized/Issue397#blah(). var blah: Set[String]
-//    ^^^^ synthetic_definition minimized/Issue397#`blah_=`(). var blah_=(x$1: Set[String]): Unit
+//    ^^^^ definition minimized/Issue397#`blah_=`(). var blah_=(x$1: Set[String]): Unit
 //           ^^^ reference scala/Predef.Set.
 //               reference scala/collection/IterableFactory#apply().
   blah = Set.empty[String]

--- a/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
+++ b/tests/snapshots/src/main/generated/minimized/MinimizedScalaSignatures.scala
@@ -8,13 +8,14 @@ case class MinimizedCaseClass(value: String) {
 //         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass# case class MinimizedCaseClass(value: String)
 //         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass.apply(). def apply(value: String): MinimizedCaseClass
 //         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass#productElement(). def productElement(x$1: Int): Any
-//         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass. object MinimizedCaseClass
+//         ^^^^^^^^^^^^^^^^^^ definition minimized/MinimizedCaseClass. object MinimizedCaseClass
 //         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass#productElementName(). def productElementName(x$1: Int): String
 //         ^^^^^^^^^^^^^^^^^^ synthetic_definition minimized/MinimizedCaseClass#copy(). def copy(value: String): MinimizedCaseClass
 //                            definition minimized/MinimizedCaseClass#`<init>`(). def this(value: String)
 //                            ^^^^^ definition minimized/MinimizedCaseClass#value. val value: String
-//                            ^^^^^ synthetic_definition minimized/MinimizedCaseClass#copy().(value) default value: String
-//                            ^^^^^ synthetic_definition minimized/MinimizedCaseClass.apply().(value) value: String
+//                            ^^^^^ definition minimized/MinimizedCaseClass#copy().(value) default value: String
+//                            ^^^^^ definition minimized/MinimizedCaseClass#`<init>`().(value) value: String
+//                            ^^^^^ definition minimized/MinimizedCaseClass.apply().(value) value: String
 //                                   ^^^^^^ reference scala/Predef.String#
   def this() = this("value")
 //    ^^^^ definition minimized/MinimizedCaseClass#`<init>`(+1). def this()

--- a/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
+++ b/tests/snapshots/src/main/generated/ujson/AstTransformer.scala
@@ -104,10 +104,12 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //                    ^ definition ujson/AstTransformer#AstObjVisitor#[T] T
 //                       definition ujson/AstTransformer#AstObjVisitor#`<init>`(). def this(build: (T) => I)(factory: Factory[(String, I), T])
 //                       ^^^^^ definition ujson/AstTransformer#AstObjVisitor#build. private[this] val build: (T) => I
+//                       ^^^^^ definition ujson/AstTransformer#AstObjVisitor#`<init>`().(build) build: (T) => I
 //                              ^ reference ujson/AstTransformer#AstObjVisitor#[T]
 //                                   ^ reference ujson/AstTransformer#[I]
                         (implicit factory: Factory[(String, I), T])extends ObjVisitor[I, I] {
 //                                ^^^^^^^ definition ujson/AstTransformer#AstObjVisitor#factory. private[this] implicit val factory: Factory[(String, I), T]
+//                                ^^^^^^^ definition ujson/AstTransformer#AstObjVisitor#`<init>`().(factory) implicit factory: Factory[(String, I), T]
 //                                         ^^^^^^^ reference upickle/core/compat/package.Factory#
 //                                                  ^^^^^^ reference scala/Predef.String#
 //                                                          ^ reference ujson/AstTransformer#[I]
@@ -119,7 +121,7 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 
     private[this] var key: String = null
 //                    ^^^ definition ujson/AstTransformer#AstObjVisitor#key(). private[this] var key: String
-//                    ^^^ synthetic_definition ujson/AstTransformer#AstObjVisitor#`key_=`(). private[this] var key_=(x$1: String): Unit
+//                    ^^^ definition ujson/AstTransformer#AstObjVisitor#`key_=`(). private[this] var key_=(x$1: String): Unit
 //                         ^^^^^^ reference scala/Predef.String#
     private[this] val vs = factory.newBuilder
 //                    ^^ definition ujson/AstTransformer#AstObjVisitor#vs. private[this] val vs: Builder[(String, I), T]
@@ -170,11 +172,13 @@ trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
 //                    ^ definition ujson/AstTransformer#AstArrVisitor#[T] T
 //                          definition ujson/AstTransformer#AstArrVisitor#`<init>`(). def this(build: (T[I]) => I)(factory: Factory[I, T[I]])
 //                          ^^^^^ definition ujson/AstTransformer#AstArrVisitor#build. private[this] val build: (T[I]) => I
+//                          ^^^^^ definition ujson/AstTransformer#AstArrVisitor#`<init>`().(build) build: (T[I]) => I
 //                                 ^ reference ujson/AstTransformer#AstArrVisitor#[T]
 //                                   ^ reference ujson/AstTransformer#[I]
 //                                         ^ reference ujson/AstTransformer#[I]
                            (implicit factory: Factory[I, T[I]]) extends ArrVisitor[I, I]{
 //                                   ^^^^^^^ definition ujson/AstTransformer#AstArrVisitor#factory. private[this] implicit val factory: Factory[I, T[I]]
+//                                   ^^^^^^^ definition ujson/AstTransformer#AstArrVisitor#`<init>`().(factory) implicit factory: Factory[I, T[I]]
 //                                            ^^^^^^^ reference upickle/core/compat/package.Factory#
 //                                                    ^ reference ujson/AstTransformer#[I]
 //                                                       ^ reference ujson/AstTransformer#AstArrVisitor#[T]

--- a/tests/snapshots/src/main/generated/ujson/ByteArrayParser.scala
+++ b/tests/snapshots/src/main/generated/ujson/ByteArrayParser.scala
@@ -37,6 +37,7 @@ final class ByteArrayParser[J](src: Array[Byte]) extends ByteParser[J]{
 //                          ^ definition ujson/ByteArrayParser#[J] J
 //                             definition ujson/ByteArrayParser#`<init>`(). def this(src: Array[Byte])
 //                             ^^^ definition ujson/ByteArrayParser#src. private[this] val src: Array[Byte]
+//                             ^^^ definition ujson/ByteArrayParser#`<init>`().(src) src: Array[Byte]
 //                                  ^^^^^ reference scala/Array#
 //                                        ^^^^ reference scala/Byte#
 //                                                       ^^^^^^^^^^ reference ujson/ByteParser#

--- a/tests/snapshots/src/main/generated/ujson/ByteBufferParser.scala
+++ b/tests/snapshots/src/main/generated/ujson/ByteBufferParser.scala
@@ -37,6 +37,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends ByteParser[J]{
 //                           ^ definition ujson/ByteBufferParser#[J] J
 //                              definition ujson/ByteBufferParser#`<init>`(). def this(src: ByteBuffer)
 //                              ^^^ definition ujson/ByteBufferParser#src. private[this] val src: ByteBuffer
+//                              ^^^ definition ujson/ByteBufferParser#`<init>`().(src) src: ByteBuffer
 //                                   ^^^^^^^^^^ reference java/nio/ByteBuffer#
 //                                                       ^^^^^^^^^^ reference ujson/ByteParser#
 //                                                                  ^ reference ujson/ByteBufferParser#[J]

--- a/tests/snapshots/src/main/generated/ujson/CharSequenceParser.scala
+++ b/tests/snapshots/src/main/generated/ujson/CharSequenceParser.scala
@@ -18,6 +18,7 @@ private[ujson] final class CharSequenceParser[J](cs: CharSequence) extends CharP
 //                                            ^ definition ujson/CharSequenceParser#[J] J
 //                                               definition ujson/CharSequenceParser#`<init>`(). def this(cs: CharSequence)
 //                                               ^^ definition ujson/CharSequenceParser#cs. private[this] val cs: CharSequence
+//                                               ^^ definition ujson/CharSequenceParser#`<init>`().(cs) cs: CharSequence
 //                                                   ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                                                         ^^^^^^^^^^ reference ujson/CharParser#
 //                                                                                    ^ reference ujson/CharSequenceParser#[J]

--- a/tests/snapshots/src/main/generated/ujson/Exceptions.scala
+++ b/tests/snapshots/src/main/generated/ujson/Exceptions.scala
@@ -10,17 +10,19 @@ case class ParseException(clue: String, index: Int)
 //         ^^^^^^^^^^^^^^ definition ujson/ParseException# case class ParseException(clue: String, index: Int) extends Exception with ParsingFailedException
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException#productElementName(). def productElementName(x$1: Int): String
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException.apply(). def apply(clue: String, index: Int): ParseException
-//         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException. object ParseException
+//         ^^^^^^^^^^^^^^ definition ujson/ParseException. object ParseException
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException#copy(). def copy(clue: String, index: Int): ParseException
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/ParseException#productElement(). def productElement(x$1: Int): Any
 //                        definition ujson/ParseException#`<init>`(). def this(clue: String, index: Int)
 //                        ^^^^ definition ujson/ParseException#clue. val clue: String
-//                        ^^^^ synthetic_definition ujson/ParseException.apply().(clue) clue: String
-//                        ^^^^ synthetic_definition ujson/ParseException#copy().(clue) default clue: String
+//                        ^^^^ definition ujson/ParseException.apply().(clue) clue: String
+//                        ^^^^ definition ujson/ParseException#`<init>`().(clue) clue: String
+//                        ^^^^ definition ujson/ParseException#copy().(clue) default clue: String
 //                              ^^^^^^ reference scala/Predef.String#
 //                                      ^^^^^ definition ujson/ParseException#index. val index: Int
-//                                      ^^^^^ synthetic_definition ujson/ParseException.apply().(index) index: Int
-//                                      ^^^^^ synthetic_definition ujson/ParseException#copy().(index) default index: Int
+//                                      ^^^^^ definition ujson/ParseException#`<init>`().(index) index: Int
+//                                      ^^^^^ definition ujson/ParseException.apply().(index) index: Int
+//                                      ^^^^^ definition ujson/ParseException#copy().(index) default index: Int
 //                                             ^^^ reference scala/Int#
   extends Exception(clue + " at index " + index) with ParsingFailedException
 //        ^^^^^^^^^ reference scala/package.Exception#
@@ -37,11 +39,12 @@ case class IncompleteParseException(msg: String)
 //         ^^^^^^^^^^^^^^^^^^^^^^^^ synthetic_definition ujson/IncompleteParseException.apply(). def apply(msg: String): IncompleteParseException
 //         ^^^^^^^^^^^^^^^^^^^^^^^^ synthetic_definition ujson/IncompleteParseException#copy(). def copy(msg: String): IncompleteParseException
 //         ^^^^^^^^^^^^^^^^^^^^^^^^ synthetic_definition ujson/IncompleteParseException#productElementName(). def productElementName(x$1: Int): String
-//         ^^^^^^^^^^^^^^^^^^^^^^^^ synthetic_definition ujson/IncompleteParseException. object IncompleteParseException
+//         ^^^^^^^^^^^^^^^^^^^^^^^^ definition ujson/IncompleteParseException. object IncompleteParseException
 //                                  definition ujson/IncompleteParseException#`<init>`(). def this(msg: String)
 //                                  ^^^ definition ujson/IncompleteParseException#msg. val msg: String
-//                                  ^^^ synthetic_definition ujson/IncompleteParseException.apply().(msg) msg: String
-//                                  ^^^ synthetic_definition ujson/IncompleteParseException#copy().(msg) default msg: String
+//                                  ^^^ definition ujson/IncompleteParseException.apply().(msg) msg: String
+//                                  ^^^ definition ujson/IncompleteParseException#copy().(msg) default msg: String
+//                                  ^^^ definition ujson/IncompleteParseException#`<init>`().(msg) msg: String
 //                                       ^^^^^^ reference scala/Predef.String#
   extends Exception(msg) with ParsingFailedException
 //        ^^^^^^^^^ reference scala/package.Exception#

--- a/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
+++ b/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
@@ -45,17 +45,19 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ definition ujson/IndexedValue.Str# case class Str(index: Int, value0: CharSequence) extends IndexedValue
 //           ^^^ synthetic_definition ujson/IndexedValue.Str#copy(). def copy(index: Int, value0: CharSequence): Str
 //           ^^^ synthetic_definition ujson/IndexedValue.Str.apply(). def apply(index: Int, value0: CharSequence): Str
-//           ^^^ synthetic_definition ujson/IndexedValue.Str. object Str
+//           ^^^ definition ujson/IndexedValue.Str. object Str
 //           ^^^ synthetic_definition ujson/IndexedValue.Str#productElement(). def productElement(x$1: Int): Any
 //           ^^^ synthetic_definition ujson/IndexedValue.Str#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Str#`<init>`(). def this(index: Int, value0: CharSequence)
 //               ^^^^^ definition ujson/IndexedValue.Str#index. val index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Str#copy().(index) default index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Str.apply().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Str#copy().(index) default index: Int
+//               ^^^^^ definition ujson/IndexedValue.Str#`<init>`().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Str.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^^ definition ujson/IndexedValue.Str#value0. val value0: CharSequence
-//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Str.apply().(value0) value0: CharSequence
-//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Str#copy().(value0) default value0: CharSequence
+//                           ^^^^^^ definition ujson/IndexedValue.Str#`<init>`().(value0) value0: CharSequence
+//                           ^^^^^^ definition ujson/IndexedValue.Str.apply().(value0) value0: CharSequence
+//                           ^^^^^^ definition ujson/IndexedValue.Str#copy().(value0) default value0: CharSequence
 //                                   ^^^^ reference java/
 //                                        ^^^^ reference java/lang/
 //                                             ^^^^^^^^^^^^ reference java/lang/CharSequence#
@@ -65,14 +67,16 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ definition ujson/IndexedValue.Obj# case class Obj(index: Int, value0: (CharSequence, IndexedValue)*) extends IndexedValue
 //           ^^^ synthetic_definition ujson/IndexedValue.Obj.apply(). def apply(index: Int, value0: (CharSequence, IndexedValue)*): Obj
 //           ^^^ synthetic_definition ujson/IndexedValue.Obj#productElement(). def productElement(x$1: Int): Any
-//           ^^^ synthetic_definition ujson/IndexedValue.Obj. object Obj
+//           ^^^ definition ujson/IndexedValue.Obj. object Obj
 //           ^^^ synthetic_definition ujson/IndexedValue.Obj#productElementName(). def productElementName(x$1: Int): String
 //               definition ujson/IndexedValue.Obj#`<init>`(). def this(index: Int, value0: (CharSequence, IndexedValue)*)
 //               ^^^^^ definition ujson/IndexedValue.Obj#index. val index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Obj.apply().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Obj#`<init>`().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Obj.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^^ definition ujson/IndexedValue.Obj#value0. val value0: (CharSequence, IndexedValue)*
-//                           ^^^^^^ synthetic_definition ujson/IndexedValue.Obj.apply().(value0) value0: (CharSequence, IndexedValue)*
+//                           ^^^^^^ definition ujson/IndexedValue.Obj.apply().(value0) value0: (CharSequence, IndexedValue)*
+//                           ^^^^^^ definition ujson/IndexedValue.Obj#`<init>`().(value0) value0: (CharSequence, IndexedValue)*
 //                                    ^^^^ reference java/
 //                                         ^^^^ reference java/lang/
 //                                              ^^^^^^^^^^^^ reference java/lang/CharSequence#
@@ -83,72 +87,81 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^ definition ujson/IndexedValue.Arr# case class Arr(index: Int, value: IndexedValue*) extends IndexedValue
 //           ^^^ synthetic_definition ujson/IndexedValue.Arr#productElementName(). def productElementName(x$1: Int): String
 //           ^^^ synthetic_definition ujson/IndexedValue.Arr#productElement(). def productElement(x$1: Int): Any
-//           ^^^ synthetic_definition ujson/IndexedValue.Arr. object Arr
+//           ^^^ definition ujson/IndexedValue.Arr. object Arr
 //           ^^^ synthetic_definition ujson/IndexedValue.Arr.apply(). def apply(index: Int, value: IndexedValue*): Arr
 //               definition ujson/IndexedValue.Arr#`<init>`(). def this(index: Int, value: IndexedValue*)
 //               ^^^^^ definition ujson/IndexedValue.Arr#index. val index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Arr.apply().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Arr.apply().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Arr#`<init>`().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^^^^^ definition ujson/IndexedValue.Arr#value. val value: IndexedValue*
-//                           ^^^^^ synthetic_definition ujson/IndexedValue.Arr.apply().(value) value: IndexedValue*
+//                           ^^^^^ definition ujson/IndexedValue.Arr#`<init>`().(value) value: IndexedValue*
+//                           ^^^^^ definition ujson/IndexedValue.Arr.apply().(value) value: IndexedValue*
 //                                  ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                         ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                                      reference java/lang/Object#`<init>`().
   case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends IndexedValue
 //           ^^^ definition ujson/IndexedValue.Num# case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends IndexedValue
-//           ^^^ synthetic_definition ujson/IndexedValue.Num. object Num
+//           ^^^ definition ujson/IndexedValue.Num. object Num
 //           ^^^ synthetic_definition ujson/IndexedValue.Num#copy(). def copy(index: Int, s: CharSequence, decIndex: Int, expIndex: Int): Num
 //           ^^^ synthetic_definition ujson/IndexedValue.Num#productElement(). def productElement(x$1: Int): Any
 //           ^^^ synthetic_definition ujson/IndexedValue.Num#productElementName(). def productElementName(x$1: Int): String
 //           ^^^ synthetic_definition ujson/IndexedValue.Num.apply(). def apply(index: Int, s: CharSequence, decIndex: Int, expIndex: Int): Num
 //               definition ujson/IndexedValue.Num#`<init>`(). def this(index: Int, s: CharSequence, decIndex: Int, expIndex: Int)
 //               ^^^^^ definition ujson/IndexedValue.Num#index. val index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(index) default index: Int
-//               ^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Num#copy().(index) default index: Int
+//               ^^^^^ definition ujson/IndexedValue.Num#`<init>`().(index) index: Int
+//               ^^^^^ definition ujson/IndexedValue.Num.apply().(index) index: Int
 //                      ^^^ reference scala/Int#
 //                           ^ definition ujson/IndexedValue.Num#s. val s: CharSequence
-//                           ^ synthetic_definition ujson/IndexedValue.Num.apply().(s) s: CharSequence
-//                           ^ synthetic_definition ujson/IndexedValue.Num#copy().(s) default s: CharSequence
+//                           ^ definition ujson/IndexedValue.Num.apply().(s) s: CharSequence
+//                           ^ definition ujson/IndexedValue.Num#`<init>`().(s) s: CharSequence
+//                           ^ definition ujson/IndexedValue.Num#copy().(s) default s: CharSequence
 //                              ^^^^^^^^^^^^ reference java/lang/CharSequence#
 //                                            ^^^^^^^^ definition ujson/IndexedValue.Num#decIndex. val decIndex: Int
-//                                            ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(decIndex) default decIndex: Int
-//                                            ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(decIndex) decIndex: Int
+//                                            ^^^^^^^^ definition ujson/IndexedValue.Num#copy().(decIndex) default decIndex: Int
+//                                            ^^^^^^^^ definition ujson/IndexedValue.Num.apply().(decIndex) decIndex: Int
+//                                            ^^^^^^^^ definition ujson/IndexedValue.Num#`<init>`().(decIndex) decIndex: Int
 //                                                      ^^^ reference scala/Int#
 //                                                           ^^^^^^^^ definition ujson/IndexedValue.Num#expIndex. val expIndex: Int
-//                                                           ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num.apply().(expIndex) expIndex: Int
-//                                                           ^^^^^^^^ synthetic_definition ujson/IndexedValue.Num#copy().(expIndex) default expIndex: Int
+//                                                           ^^^^^^^^ definition ujson/IndexedValue.Num#`<init>`().(expIndex) expIndex: Int
+//                                                           ^^^^^^^^ definition ujson/IndexedValue.Num.apply().(expIndex) expIndex: Int
+//                                                           ^^^^^^^^ definition ujson/IndexedValue.Num#copy().(expIndex) default expIndex: Int
 //                                                                     ^^^ reference scala/Int#
 //                                                                                  ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                                                               reference java/lang/Object#`<init>`().
   case class NumRaw(index: Int, d: Double) extends IndexedValue
 //           ^^^^^^ definition ujson/IndexedValue.NumRaw# case class NumRaw(index: Int, d: Double) extends IndexedValue
 //           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#copy(). def copy(index: Int, d: Double): NumRaw
-//           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw. object NumRaw
+//           ^^^^^^ definition ujson/IndexedValue.NumRaw. object NumRaw
 //           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#productElement(). def productElement(x$1: Int): Any
 //           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw.apply(). def apply(index: Int, d: Double): NumRaw
 //           ^^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#productElementName(). def productElementName(x$1: Int): String
 //                  definition ujson/IndexedValue.NumRaw#`<init>`(). def this(index: Int, d: Double)
 //                  ^^^^^ definition ujson/IndexedValue.NumRaw#index. val index: Int
-//                  ^^^^^ synthetic_definition ujson/IndexedValue.NumRaw.apply().(index) index: Int
-//                  ^^^^^ synthetic_definition ujson/IndexedValue.NumRaw#copy().(index) default index: Int
+//                  ^^^^^ definition ujson/IndexedValue.NumRaw.apply().(index) index: Int
+//                  ^^^^^ definition ujson/IndexedValue.NumRaw#`<init>`().(index) index: Int
+//                  ^^^^^ definition ujson/IndexedValue.NumRaw#copy().(index) default index: Int
 //                         ^^^ reference scala/Int#
 //                              ^ definition ujson/IndexedValue.NumRaw#d. val d: Double
-//                              ^ synthetic_definition ujson/IndexedValue.NumRaw#copy().(d) default d: Double
-//                              ^ synthetic_definition ujson/IndexedValue.NumRaw.apply().(d) d: Double
+//                              ^ definition ujson/IndexedValue.NumRaw#copy().(d) default d: Double
+//                              ^ definition ujson/IndexedValue.NumRaw.apply().(d) d: Double
+//                              ^ definition ujson/IndexedValue.NumRaw#`<init>`().(d) d: Double
 //                                 ^^^^^^ reference scala/Double#
 //                                                 ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                              reference java/lang/Object#`<init>`().
   case class False(index: Int) extends IndexedValue{
 //           ^^^^^ definition ujson/IndexedValue.False# case class False(index: Int) extends IndexedValue
-//           ^^^^^ synthetic_definition ujson/IndexedValue.False. object False
+//           ^^^^^ definition ujson/IndexedValue.False. object False
 //           ^^^^^ synthetic_definition ujson/IndexedValue.False#productElementName(). def productElementName(x$1: Int): String
 //           ^^^^^ synthetic_definition ujson/IndexedValue.False.apply(). def apply(index: Int): False
 //           ^^^^^ synthetic_definition ujson/IndexedValue.False#productElement(). def productElement(x$1: Int): Any
 //           ^^^^^ synthetic_definition ujson/IndexedValue.False#copy(). def copy(index: Int): False
 //                 definition ujson/IndexedValue.False#`<init>`(). def this(index: Int)
 //                 ^^^^^ definition ujson/IndexedValue.False#index. val index: Int
-//                 ^^^^^ synthetic_definition ujson/IndexedValue.False.apply().(index) index: Int
-//                 ^^^^^ synthetic_definition ujson/IndexedValue.False#copy().(index) default index: Int
+//                 ^^^^^ definition ujson/IndexedValue.False.apply().(index) index: Int
+//                 ^^^^^ definition ujson/IndexedValue.False#copy().(index) default index: Int
+//                 ^^^^^ definition ujson/IndexedValue.False#`<init>`().(index) index: Int
 //                        ^^^ reference scala/Int#
 //                                     ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                  reference java/lang/Object#`<init>`().
@@ -158,14 +171,15 @@ object IndexedValue extends Transformer[IndexedValue]{
   case class True(index: Int) extends IndexedValue{
 //           ^^^^ definition ujson/IndexedValue.True# case class True(index: Int) extends IndexedValue
 //           ^^^^ synthetic_definition ujson/IndexedValue.True#productElement(). def productElement(x$1: Int): Any
-//           ^^^^ synthetic_definition ujson/IndexedValue.True. object True
+//           ^^^^ definition ujson/IndexedValue.True. object True
 //           ^^^^ synthetic_definition ujson/IndexedValue.True#copy(). def copy(index: Int): True
 //           ^^^^ synthetic_definition ujson/IndexedValue.True.apply(). def apply(index: Int): True
 //           ^^^^ synthetic_definition ujson/IndexedValue.True#productElementName(). def productElementName(x$1: Int): String
 //                definition ujson/IndexedValue.True#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.True#index. val index: Int
-//                ^^^^^ synthetic_definition ujson/IndexedValue.True.apply().(index) index: Int
-//                ^^^^^ synthetic_definition ujson/IndexedValue.True#copy().(index) default index: Int
+//                ^^^^^ definition ujson/IndexedValue.True.apply().(index) index: Int
+//                ^^^^^ definition ujson/IndexedValue.True#`<init>`().(index) index: Int
+//                ^^^^^ definition ujson/IndexedValue.True#copy().(index) default index: Int
 //                       ^^^ reference scala/Int#
 //                                    ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                 reference java/lang/Object#`<init>`().
@@ -178,11 +192,12 @@ object IndexedValue extends Transformer[IndexedValue]{
 //           ^^^^ synthetic_definition ujson/IndexedValue.Null#productElement(). def productElement(x$1: Int): Any
 //           ^^^^ synthetic_definition ujson/IndexedValue.Null#productElementName(). def productElementName(x$1: Int): String
 //           ^^^^ synthetic_definition ujson/IndexedValue.Null.apply(). def apply(index: Int): Null
-//           ^^^^ synthetic_definition ujson/IndexedValue.Null. object Null
+//           ^^^^ definition ujson/IndexedValue.Null. object Null
 //                definition ujson/IndexedValue.Null#`<init>`(). def this(index: Int)
 //                ^^^^^ definition ujson/IndexedValue.Null#index. val index: Int
-//                ^^^^^ synthetic_definition ujson/IndexedValue.Null.apply().(index) index: Int
-//                ^^^^^ synthetic_definition ujson/IndexedValue.Null#copy().(index) default index: Int
+//                ^^^^^ definition ujson/IndexedValue.Null#`<init>`().(index) index: Int
+//                ^^^^^ definition ujson/IndexedValue.Null.apply().(index) index: Int
+//                ^^^^^ definition ujson/IndexedValue.Null#copy().(index) default index: Int
 //                       ^^^ reference scala/Int#
 //                                    ^^^^^^^^^^^^ reference ujson/IndexedValue#
 //                                                 reference java/lang/Object#`<init>`().

--- a/tests/snapshots/src/main/generated/ujson/InputStreamParser.scala
+++ b/tests/snapshots/src/main/generated/ujson/InputStreamParser.scala
@@ -33,16 +33,19 @@ final class InputStreamParser[J](val inputStream: java.io.InputStream,
 //                            ^ definition ujson/InputStreamParser#[J] J
 //                               definition ujson/InputStreamParser#`<init>`(). def this(inputStream: InputStream, minBufferStartSize: Int, maxBufferStartSize: Int)
 //                                   ^^^^^^^^^^^ definition ujson/InputStreamParser#inputStream. val inputStream: InputStream
+//                                   ^^^^^^^^^^^ definition ujson/InputStreamParser#`<init>`().(inputStream) inputStream: InputStream
 //                                                ^^^^ reference java/
 //                                                     ^^ reference java/io/
 //                                                        ^^^^^^^^^^^ reference java/io/InputStream#
                                  val minBufferStartSize: Int = BufferingInputStreamParser.defaultMinBufferStartSize,
 //                                   ^^^^^^^^^^^^^^^^^^ definition ujson/InputStreamParser#minBufferStartSize. val minBufferStartSize: Int
+//                                   ^^^^^^^^^^^^^^^^^^ definition ujson/InputStreamParser#`<init>`().(minBufferStartSize) default minBufferStartSize: Int
 //                                                       ^^^ reference scala/Int#
 //                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference upickle/core/BufferingInputStreamParser.
 //                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ reference upickle/core/BufferingInputStreamParser.defaultMinBufferStartSize.
                                  val maxBufferStartSize: Int = BufferingInputStreamParser.defaultMaxBufferStartSize)
 //                                   ^^^^^^^^^^^^^^^^^^ definition ujson/InputStreamParser#maxBufferStartSize. val maxBufferStartSize: Int
+//                                   ^^^^^^^^^^^^^^^^^^ definition ujson/InputStreamParser#`<init>`().(maxBufferStartSize) default maxBufferStartSize: Int
 //                                                       ^^^ reference scala/Int#
 //                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference upickle/core/BufferingInputStreamParser.
 //                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ reference upickle/core/BufferingInputStreamParser.defaultMaxBufferStartSize.

--- a/tests/snapshots/src/main/generated/ujson/Readable.scala
+++ b/tests/snapshots/src/main/generated/ujson/Readable.scala
@@ -36,17 +36,19 @@ object Readable extends ReadableLowPri{
 //           ^^^^^^^^^^^^^^^ synthetic_definition ujson/Readable.fromTransformer#copy(). def copy(t: T, w: Transformer[T]): fromTransformer[T]
 //           ^^^^^^^^^^^^^^^ synthetic_definition ujson/Readable.fromTransformer#productElement(). def productElement(x$1: Int): Any
 //           ^^^^^^^^^^^^^^^ synthetic_definition ujson/Readable.fromTransformer.apply(). def apply(t: T, w: Transformer[T]): fromTransformer[T]
-//           ^^^^^^^^^^^^^^^ synthetic_definition ujson/Readable.fromTransformer. object fromTransformer
+//           ^^^^^^^^^^^^^^^ definition ujson/Readable.fromTransformer. object fromTransformer
 //           ^^^^^^^^^^^^^^^ synthetic_definition ujson/Readable.fromTransformer#productElementName(). def productElementName(x$1: Int): String
 //                           ^ definition ujson/Readable.fromTransformer#[T] T
 //                              definition ujson/Readable.fromTransformer#`<init>`(). def this(t: T, w: Transformer[T])
 //                              ^ definition ujson/Readable.fromTransformer#t. val t: T
-//                              ^ synthetic_definition ujson/Readable.fromTransformer#copy().(t) default t: T
-//                              ^ synthetic_definition ujson/Readable.fromTransformer.apply().(t) t: T
+//                              ^ definition ujson/Readable.fromTransformer#copy().(t) default t: T
+//                              ^ definition ujson/Readable.fromTransformer#`<init>`().(t) t: T
+//                              ^ definition ujson/Readable.fromTransformer.apply().(t) t: T
 //                                 ^ reference ujson/Readable.fromTransformer#[T]
 //                                    ^ definition ujson/Readable.fromTransformer#w. val w: Transformer[T]
-//                                    ^ synthetic_definition ujson/Readable.fromTransformer#copy().(w) default w: Transformer[T]
-//                                    ^ synthetic_definition ujson/Readable.fromTransformer.apply().(w) w: Transformer[T]
+//                                    ^ definition ujson/Readable.fromTransformer#copy().(w) default w: Transformer[T]
+//                                    ^ definition ujson/Readable.fromTransformer#`<init>`().(w) w: Transformer[T]
+//                                    ^ definition ujson/Readable.fromTransformer.apply().(w) w: Transformer[T]
 //                                       ^^^^^^^^^^^ reference ujson/Transformer#
 //                                                   ^ reference ujson/Readable.fromTransformer#[T]
 //                                                               ^^^^^^^^ reference ujson/Readable#

--- a/tests/snapshots/src/main/generated/ujson/Renderer.scala
+++ b/tests/snapshots/src/main/generated/ujson/Renderer.scala
@@ -23,17 +23,19 @@ case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
 //         ^^^^^^^^^^^^^ definition ujson/BytesRenderer# case class BytesRenderer(indent: Int, escapeUnicode: Boolean) extends BaseByteRenderer[ByteArrayOutputStream]
 //         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer#productElement(). def productElement(x$1: Int): Any
 //         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer#productElementName(). def productElementName(x$1: Int): String
-//         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer. object BytesRenderer
+//         ^^^^^^^^^^^^^ definition ujson/BytesRenderer. object BytesRenderer
 //         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer#copy(). def copy(indent: Int, escapeUnicode: Boolean): BytesRenderer
 //         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer.apply(). def apply(indent: Int, escapeUnicode: Boolean): BytesRenderer
 //                       definition ujson/BytesRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                       ^^^^^^ definition ujson/BytesRenderer#indent. val indent: Int
-//                       ^^^^^^ synthetic_definition ujson/BytesRenderer#copy().(indent) default indent: Int
-//                       ^^^^^^ synthetic_definition ujson/BytesRenderer.apply().(indent) default indent: Int
+//                       ^^^^^^ definition ujson/BytesRenderer#copy().(indent) default indent: Int
+//                       ^^^^^^ definition ujson/BytesRenderer#`<init>`().(indent) default indent: Int
+//                       ^^^^^^ definition ujson/BytesRenderer.apply().(indent) default indent: Int
 //                               ^^^ reference scala/Int#
 //                                         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#escapeUnicode. val escapeUnicode: Boolean
-//                                         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
-//                                         ^^^^^^^^^^^^^ synthetic_definition ujson/BytesRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                                         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                                         ^^^^^^^^^^^^^ definition ujson/BytesRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                                         ^^^^^^^^^^^^^ definition ujson/BytesRenderer#`<init>`().(escapeUnicode) default escapeUnicode: Boolean
 //                                                        ^^^^^^^ reference scala/Boolean#
   extends BaseByteRenderer(new ByteArrayOutputStream(), indent, escapeUnicode){
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseByteRenderer#
@@ -47,20 +49,22 @@ case class BytesRenderer(indent: Int = -1, escapeUnicode: Boolean = false)
 
 case class StringRenderer(indent: Int = -1,
 //         ^^^^^^^^^^^^^^ definition ujson/StringRenderer# case class StringRenderer(indent: Int, escapeUnicode: Boolean) extends BaseCharRenderer[StringWriter]
-//         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer. object StringRenderer
+//         ^^^^^^^^^^^^^^ definition ujson/StringRenderer. object StringRenderer
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#copy(). def copy(indent: Int, escapeUnicode: Boolean): StringRenderer
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer.apply(). def apply(indent: Int, escapeUnicode: Boolean): StringRenderer
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#productElement(). def productElement(x$1: Int): Any
 //         ^^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#productElementName(). def productElementName(x$1: Int): String
 //                        definition ujson/StringRenderer#`<init>`(). def this(indent: Int, escapeUnicode: Boolean)
 //                        ^^^^^^ definition ujson/StringRenderer#indent. val indent: Int
-//                        ^^^^^^ synthetic_definition ujson/StringRenderer#copy().(indent) default indent: Int
-//                        ^^^^^^ synthetic_definition ujson/StringRenderer.apply().(indent) default indent: Int
+//                        ^^^^^^ definition ujson/StringRenderer#copy().(indent) default indent: Int
+//                        ^^^^^^ definition ujson/StringRenderer#`<init>`().(indent) default indent: Int
+//                        ^^^^^^ definition ujson/StringRenderer.apply().(indent) default indent: Int
 //                                ^^^ reference scala/Int#
                           escapeUnicode: Boolean = false)
 //                        ^^^^^^^^^^^^^ definition ujson/StringRenderer#escapeUnicode. val escapeUnicode: Boolean
-//                        ^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
-//                        ^^^^^^^^^^^^^ synthetic_definition ujson/StringRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                        ^^^^^^^^^^^^^ definition ujson/StringRenderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                        ^^^^^^^^^^^^^ definition ujson/StringRenderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                        ^^^^^^^^^^^^^ definition ujson/StringRenderer#`<init>`().(escapeUnicode) default escapeUnicode: Boolean
 //                                       ^^^^^^^ reference scala/Boolean#
   extends BaseCharRenderer(new java.io.StringWriter(), indent, escapeUnicode)
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseCharRenderer#
@@ -74,27 +78,30 @@ case class StringRenderer(indent: Int = -1,
 
 case class Renderer(out: java.io.Writer,
 //         ^^^^^^^^ definition ujson/Renderer# case class Renderer(out: Writer, indent: Int, escapeUnicode: Boolean) extends BaseCharRenderer[Writer]
-//         ^^^^^^^^ synthetic_definition ujson/Renderer. object Renderer
+//         ^^^^^^^^ definition ujson/Renderer. object Renderer
 //         ^^^^^^^^ synthetic_definition ujson/Renderer.apply(). def apply(out: Writer, indent: Int, escapeUnicode: Boolean): Renderer
 //         ^^^^^^^^ synthetic_definition ujson/Renderer#productElementName(). def productElementName(x$1: Int): String
 //         ^^^^^^^^ synthetic_definition ujson/Renderer#copy(). def copy(out: Writer, indent: Int, escapeUnicode: Boolean): Renderer
 //         ^^^^^^^^ synthetic_definition ujson/Renderer#productElement(). def productElement(x$1: Int): Any
 //                  definition ujson/Renderer#`<init>`(). def this(out: Writer, indent: Int, escapeUnicode: Boolean)
 //                  ^^^ definition ujson/Renderer#out. val out: Writer
-//                  ^^^ synthetic_definition ujson/Renderer.apply().(out) out: Writer
-//                  ^^^ synthetic_definition ujson/Renderer#copy().(out) default out: Writer
+//                  ^^^ definition ujson/Renderer.apply().(out) out: Writer
+//                  ^^^ definition ujson/Renderer#copy().(out) default out: Writer
+//                  ^^^ definition ujson/Renderer#`<init>`().(out) out: Writer
 //                       ^^^^ reference java/
 //                            ^^ reference java/io/
 //                               ^^^^^^ reference java/io/Writer#
                     indent: Int = -1,
 //                  ^^^^^^ definition ujson/Renderer#indent. val indent: Int
-//                  ^^^^^^ synthetic_definition ujson/Renderer#copy().(indent) default indent: Int
-//                  ^^^^^^ synthetic_definition ujson/Renderer.apply().(indent) default indent: Int
+//                  ^^^^^^ definition ujson/Renderer#copy().(indent) default indent: Int
+//                  ^^^^^^ definition ujson/Renderer#`<init>`().(indent) default indent: Int
+//                  ^^^^^^ definition ujson/Renderer.apply().(indent) default indent: Int
 //                          ^^^ reference scala/Int#
                     escapeUnicode: Boolean = false)
 //                  ^^^^^^^^^^^^^ definition ujson/Renderer#escapeUnicode. val escapeUnicode: Boolean
-//                  ^^^^^^^^^^^^^ synthetic_definition ujson/Renderer.apply().(escapeUnicode) default escapeUnicode: Boolean
-//                  ^^^^^^^^^^^^^ synthetic_definition ujson/Renderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                  ^^^^^^^^^^^^^ definition ujson/Renderer.apply().(escapeUnicode) default escapeUnicode: Boolean
+//                  ^^^^^^^^^^^^^ definition ujson/Renderer#copy().(escapeUnicode) default escapeUnicode: Boolean
+//                  ^^^^^^^^^^^^^ definition ujson/Renderer#`<init>`().(escapeUnicode) default escapeUnicode: Boolean
 //                                 ^^^^^^^ reference scala/Boolean#
   extends BaseCharRenderer(out, indent, escapeUnicode)
 //        ^^^^^^^^^^^^^^^^ reference ujson/BaseCharRenderer#

--- a/tests/snapshots/src/main/generated/ujson/StringParser.scala
+++ b/tests/snapshots/src/main/generated/ujson/StringParser.scala
@@ -26,6 +26,7 @@ private[ujson] final class StringParser[J](s: String) extends CharParser[J]{
 //                                      ^ definition ujson/StringParser#[J] J
 //                                         definition ujson/StringParser#`<init>`(). def this(s: String)
 //                                         ^ definition ujson/StringParser#s. private[this] val s: String
+//                                         ^ definition ujson/StringParser#`<init>`().(s) s: String
 //                                            ^^^^^^ reference scala/Predef.String#
 //                                                            ^^^^^^^^^^ reference ujson/CharParser#
 //                                                                       ^ reference ujson/StringParser#[J]

--- a/tests/snapshots/src/main/generated/ujson/Value.scala
+++ b/tests/snapshots/src/main/generated/ujson/Value.scala
@@ -323,6 +323,7 @@ object Value extends AstTransformer[Value]{
 //                 ^^^^^^^^^^^ definition ujson/Value.Selector.IntSelector# implicit class IntSelector
 //                             definition ujson/Value.Selector.IntSelector#`<init>`(). def this(i: Int)
 //                             ^ definition ujson/Value.Selector.IntSelector#i. private[this] val i: Int
+//                             ^ definition ujson/Value.Selector.IntSelector#`<init>`().(i) i: Int
 //                                ^^^ reference scala/Int#
 //                                             ^^^^^^^^ reference ujson/Value.Selector#
 //                                                      reference java/lang/Object#`<init>`().
@@ -349,6 +350,7 @@ object Value extends AstTransformer[Value]{
 //                 ^^^^^^^^^^^^^^ definition ujson/Value.Selector.StringSelector# implicit class StringSelector
 //                                definition ujson/Value.Selector.StringSelector#`<init>`(). def this(i: String)
 //                                ^ definition ujson/Value.Selector.StringSelector#i. private[this] val i: String
+//                                ^ definition ujson/Value.Selector.StringSelector#`<init>`().(i) i: String
 //                                   ^^^^^^ reference scala/Predef.String#
 //                                                   ^^^^^^^^ reference ujson/Value.Selector#
 //                                                            reference java/lang/Object#`<init>`().
@@ -744,18 +746,20 @@ object Value extends AstTransformer[Value]{
   case class InvalidData(data: Value, msg: String)
 //           ^^^^^^^^^^^ definition ujson/Value.InvalidData# case class InvalidData(data: Value, msg: String) extends Exception
 //           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData#copy(). def copy(data: Value, msg: String): InvalidData
-//           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData. object InvalidData
+//           ^^^^^^^^^^^ definition ujson/Value.InvalidData. object InvalidData
 //           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData.apply(). def apply(data: Value, msg: String): InvalidData
 //           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData#productElementName(). def productElementName(x$1: Int): String
 //           ^^^^^^^^^^^ synthetic_definition ujson/Value.InvalidData#productElement(). def productElement(x$1: Int): Any
 //                       definition ujson/Value.InvalidData#`<init>`(). def this(data: Value, msg: String)
 //                       ^^^^ definition ujson/Value.InvalidData#data. val data: Value
-//                       ^^^^ synthetic_definition ujson/Value.InvalidData.apply().(data) data: Value
-//                       ^^^^ synthetic_definition ujson/Value.InvalidData#copy().(data) default data: Value
+//                       ^^^^ definition ujson/Value.InvalidData.apply().(data) data: Value
+//                       ^^^^ definition ujson/Value.InvalidData#`<init>`().(data) data: Value
+//                       ^^^^ definition ujson/Value.InvalidData#copy().(data) default data: Value
 //                             ^^^^^ reference ujson/Value.Value#
 //                                    ^^^ definition ujson/Value.InvalidData#msg. val msg: String
-//                                    ^^^ synthetic_definition ujson/Value.InvalidData#copy().(msg) default msg: String
-//                                    ^^^ synthetic_definition ujson/Value.InvalidData.apply().(msg) msg: String
+//                                    ^^^ definition ujson/Value.InvalidData#`<init>`().(msg) msg: String
+//                                    ^^^ definition ujson/Value.InvalidData#copy().(msg) default msg: String
+//                                    ^^^ definition ujson/Value.InvalidData.apply().(msg) msg: String
 //                                         ^^^^^^ reference scala/Predef.String#
     extends Exception(s"$msg (data: $data)")
 //          ^^^^^^^^^ reference scala/package.Exception#
@@ -769,13 +773,14 @@ case class Str(value: String) extends Value
 //         ^^^ definition ujson/Str# case class Str(value: String) extends Value
 //         ^^^ synthetic_definition ujson/Str#productElement(). def productElement(x$1: Int): Any
 //         ^^^ synthetic_definition ujson/Str#copy(). def copy(value: String): Str
-//         ^^^ synthetic_definition ujson/Str. object Str
+//         ^^^ definition ujson/Str. object Str
 //         ^^^ synthetic_definition ujson/Str#productElementName(). def productElementName(x$1: Int): String
 //         ^^^ synthetic_definition ujson/Str.apply(). def apply(value: String): Str
 //             definition ujson/Str#`<init>`(). def this(value: String)
 //             ^^^^^ definition ujson/Str#value. val value: String
-//             ^^^^^ synthetic_definition ujson/Str.apply().(value) value: String
-//             ^^^^^ synthetic_definition ujson/Str#copy().(value) default value: String
+//             ^^^^^ definition ujson/Str.apply().(value) value: String
+//             ^^^^^ definition ujson/Str#`<init>`().(value) value: String
+//             ^^^^^ definition ujson/Str#copy().(value) default value: String
 //                    ^^^^^^ reference scala/Predef.String#
 //                                    ^^^^^ reference ujson/Value#
 //                                          reference java/lang/Object#`<init>`().
@@ -786,8 +791,9 @@ case class Obj(value: mutable.LinkedHashMap[String, Value]) extends Value
 //         ^^^ synthetic_definition ujson/Obj#copy(). def copy(value: LinkedHashMap[String, Value]): Obj
 //             definition ujson/Obj#`<init>`(). def this(value: LinkedHashMap[String, Value])
 //             ^^^^^ definition ujson/Obj#value. val value: LinkedHashMap[String, Value]
-//             ^^^^^ synthetic_definition ujson/Obj.apply(+2).(value) value: LinkedHashMap[String, Value]
-//             ^^^^^ synthetic_definition ujson/Obj#copy().(value) default value: LinkedHashMap[String, Value]
+//             ^^^^^ definition ujson/Obj.apply(+2).(value) value: LinkedHashMap[String, Value]
+//             ^^^^^ definition ujson/Obj#`<init>`().(value) value: LinkedHashMap[String, Value]
+//             ^^^^^ definition ujson/Obj#copy().(value) default value: LinkedHashMap[String, Value]
 //                    ^^^^^^^ reference scala/collection/mutable/
 //                            ^^^^^^^^^^^^^ reference scala/collection/mutable/LinkedHashMap#
 //                                          ^^^^^^ reference scala/Predef.String#
@@ -876,8 +882,9 @@ case class Arr(value: ArrayBuffer[Value]) extends Value
 //         ^^^ synthetic_definition ujson/Arr#copy(). def copy(value: ArrayBuffer[Value]): Arr
 //             definition ujson/Arr#`<init>`(). def this(value: ArrayBuffer[Value])
 //             ^^^^^ definition ujson/Arr#value. val value: ArrayBuffer[Value]
-//             ^^^^^ synthetic_definition ujson/Arr#copy().(value) default value: ArrayBuffer[Value]
-//             ^^^^^ synthetic_definition ujson/Arr.apply(+1).(value) value: ArrayBuffer[Value]
+//             ^^^^^ definition ujson/Arr#`<init>`().(value) value: ArrayBuffer[Value]
+//             ^^^^^ definition ujson/Arr#copy().(value) default value: ArrayBuffer[Value]
+//             ^^^^^ definition ujson/Arr.apply(+1).(value) value: ArrayBuffer[Value]
 //                    ^^^^^^^^^^^ reference scala/collection/mutable/ArrayBuffer#
 //                                ^^^^^ reference ujson/Value#
 //                                                ^^^^^ reference ujson/Value#
@@ -951,11 +958,12 @@ case class Num(value: Double) extends Value
 //         ^^^ synthetic_definition ujson/Num#copy(). def copy(value: Double): Num
 //         ^^^ synthetic_definition ujson/Num.apply(). def apply(value: Double): Num
 //         ^^^ synthetic_definition ujson/Num#productElementName(). def productElementName(x$1: Int): String
-//         ^^^ synthetic_definition ujson/Num. object Num
+//         ^^^ definition ujson/Num. object Num
 //             definition ujson/Num#`<init>`(). def this(value: Double)
 //             ^^^^^ definition ujson/Num#value. val value: Double
-//             ^^^^^ synthetic_definition ujson/Num.apply().(value) value: Double
-//             ^^^^^ synthetic_definition ujson/Num#copy().(value) default value: Double
+//             ^^^^^ definition ujson/Num.apply().(value) value: Double
+//             ^^^^^ definition ujson/Num#copy().(value) default value: Double
+//             ^^^^^ definition ujson/Num#`<init>`().(value) value: Double
 //                    ^^^^^^ reference scala/Double#
 //                                    ^^^^^ reference ujson/Value#
 //                                          reference java/lang/Object#`<init>`().


### PR DESCRIPTION
Fixes #403 

Previously, we generated synthetic definitions for all synthetic
definitions. However, this meant that "find references" never showed
results for synthetic symbols share the same name as the non-synthetic
definition. This commit changes that so synthetic definitions that share
the same name as the non-synthetic symbol are included with "find
references" results.

While testing this change I noticed that we don't handle synthetic
constructor parameters so I added support for those along the way.

### Test plan

Snapshot tests included in the diff. I also tested the change manually in this URL here https://sourcegraph.com/github.com/sourcegraph/sbt-sourcegraph@e2f71270ea518766c65097b1f17e97b55059d792/-/blob/example/foo.scala?L3:13#tab=references

![CleanShot 2022-02-25 at 15 20 44@2x](https://user-images.githubusercontent.com/1408093/155731067-c7d572e1-d3ca-4477-a063-d09f6dcf6349.png)
![CleanShot 2022-02-25 at 15 20 47@2x](https://user-images.githubusercontent.com/1408093/155731061-087df2ba-c580-4190-995e-9ea1dc3123f8.png)

![CleanShot 2022-02-25 at 15 20 51@2x](https://user-images.githubusercontent.com/1408093/155731053-74904d20-db13-4e49-b25a-2ebe55f1f41f.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
