### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
@@ -215,7 +215,8 @@ class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
           |    }
           |  }
           |  task $lsifJavaDependencies {
-          |    def depsOut = java.nio.file.Paths.get('$dependenciesPath')
+          |    def depsOut = java.nio.file.Paths.get(
+          |      java.net.URI.create('${dependenciesPath.toUri}'))
           |    doLast {
           |      java.nio.file.Files.createDirectories(depsOut.getParent())
           |      tasks.withType(JavaCompile) {

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
@@ -70,7 +70,8 @@ object GradleJavaToolchains {
       s"""|
           |try {
           |  java.nio.file.Files.write(
-          |    java.nio.file.Paths.get('$gradleVersionPath'),
+          |    java.nio.file.Paths.get(
+          |      java.net.URI.create('${gradleVersionPath.toUri}')),
           |    [gradle.gradleVersion],
           |    java.nio.file.StandardOpenOption.TRUNCATE_EXISTING,
           |    java.nio.file.StandardOpenOption.CREATE)
@@ -88,7 +89,8 @@ object GradleJavaToolchains {
           |
           |allprojects {
           |  task $taskName {
-          |    def toolchainsOut = java.nio.file.Paths.get('$toolchainsPath')
+          |    def toolchainsOut = java.nio.file.Paths.get(
+          |      java.net.URI.create('${toolchainsPath.toUri}'))
           |    doLast {
           |      try {
           |        tasks.withType(JavaCompile) {


### PR DESCRIPTION
Previously, we didn't test lsif-java on Windows resulting in bugs like
https://github.com/sourcegraph/lsif-java/issues/422. This commit adds a
build matrix to our CI job and fixes path escaping logic so that it
should work correctly on Windows.

### Test plan

See new CI job for Windows.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
