### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
+        # os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.13.1"

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleBuildTool.scala
@@ -215,7 +215,8 @@ class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
           |    }
           |  }
           |  task $lsifJavaDependencies {
-          |    def depsOut = java.nio.file.Paths.get('$dependenciesPath')
+          |    def depsOut = java.nio.file.Paths.get(
+          |      java.net.URI.create('${dependenciesPath.toUri}'))
           |    doLast {
           |      java.nio.file.Files.createDirectories(depsOut.getParent())
           |      tasks.withType(JavaCompile) {

--- a/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
+++ b/lsif-java/src/main/scala/com/sourcegraph/lsif_java/buildtools/GradleJavaToolchains.scala
@@ -70,7 +70,8 @@ object GradleJavaToolchains {
       s"""|
           |try {
           |  java.nio.file.Files.write(
-          |    java.nio.file.Paths.get('$gradleVersionPath'),
+          |    java.nio.file.Paths.get(
+          |      java.net.URI.create('${gradleVersionPath.toUri}')),
           |    [gradle.gradleVersion],
           |    java.nio.file.StandardOpenOption.TRUNCATE_EXISTING,
           |    java.nio.file.StandardOpenOption.CREATE)
@@ -88,7 +89,8 @@ object GradleJavaToolchains {
           |
           |allprojects {
           |  task $taskName {
-          |    def toolchainsOut = java.nio.file.Paths.get('$toolchainsPath')
+          |    def toolchainsOut = java.nio.file.Paths.get(
+          |      java.net.URI.create('${toolchainsPath.toUri}'))
           |    doLast {
           |      try {
           |        tasks.withType(JavaCompile) {

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
@@ -29,9 +29,15 @@ public class LsifWriter implements AutoCloseable {
   private final AtomicInteger id = new AtomicInteger();
 
   public LsifWriter(LsifSemanticdbOptions options) throws IOException {
-    this.tmp = Files.createTempFile("lsif-semanticdb", "dump.lsif");
-    this.tmp.toFile().setReadable(true);
-    this.tmp.toFile().setWritable(true);
+    if (OperatingSystem.isWindows()) {
+      this.tmp = Files.createTempFile("lsif-semanticdb", "dump.lsif");
+    } else {
+      this.tmp =
+          Files.createTempFile(
+              "lsif-semanticdb",
+              "dump.lsif",
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--")));
+    }
     this.output =
         new LsifOutputStream(options, new BufferedOutputStream(Files.newOutputStream(tmp)));
     this.options = options;

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/LsifWriter.java
@@ -29,11 +29,9 @@ public class LsifWriter implements AutoCloseable {
   private final AtomicInteger id = new AtomicInteger();
 
   public LsifWriter(LsifSemanticdbOptions options) throws IOException {
-    this.tmp =
-        Files.createTempFile(
-            "lsif-semanticdb",
-            "dump.lsif",
-            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--")));
+    this.tmp = Files.createTempFile("lsif-semanticdb", "dump.lsif");
+    this.tmp.toFile().setReadable(true);
+    this.tmp.toFile().setWritable(true);
     this.output =
         new LsifOutputStream(options, new BufferedOutputStream(Files.newOutputStream(tmp)));
     this.options = options;

--- a/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/OperatingSystem.java
+++ b/lsif-semanticdb/src/main/java/com/sourcegraph/lsif_semanticdb/OperatingSystem.java
@@ -1,0 +1,7 @@
+package com.sourcegraph.lsif_semanticdb;
+
+public class OperatingSystem {
+  public static boolean isWindows() {
+    return System.getProperty("os.name").startsWith("Windows");
+  }
+}

--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -92,7 +92,8 @@ object JavaToolchainPlugin extends AutoPlugin {
           .toList
           .flatMap(index => "--jvm-index" :: index :: Nil)
         val arguments =
-          List(coursier.toString, "java-home", "--jvm", v) ++ index
+          List("java", "-jar", coursier.toString, "java-home", "--jvm", v) ++
+            index
         new File(Process(arguments).!!.trim)
       }
     )

--- a/tests/buildTools/src/test/scala/tests/LsifBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/LsifBuildToolSuite.scala
@@ -3,6 +3,7 @@ package tests
 import com.sourcegraph.lsif_java.{BuildInfo => V}
 
 class LsifBuildToolSuite extends BaseBuildToolSuite {
+  override def tags = List(SkipWindows)
   checkBuild(
     "basic",
     """|/lsif-java.json

--- a/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -3,6 +3,7 @@ package tests
 import scala.meta.internal.io.InputStreamIO
 
 class MavenBuildToolSuite extends BaseBuildToolSuite {
+  override def tags = List(SkipWindows)
 
   def pomXml =
     new String(

--- a/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
@@ -1,11 +1,12 @@
 package tests
 
 class MissingBuildToolSuite extends BaseBuildToolSuite {
+
   checkErrorOutput(
     "basic",
     List("index"),
     expectedOutput =
-      s"""|error: No build tool detected in workspace '/workingDirectory'. At the moment, the only supported build tools are: Gradle, Maven, sbt.
+      s"""|error: No build tool detected in workspace '${java.io.File.separator}workingDirectory'. At the moment, the only supported build tools are: Gradle, Maven, sbt.
           |""".stripMargin,
     workingDirectoryLayout = ""
   )

--- a/tests/buildTools/src/test/scala/tests/SkipWindows.scala
+++ b/tests/buildTools/src/test/scala/tests/SkipWindows.scala
@@ -1,0 +1,3 @@
+package tests
+
+object SkipWindows extends munit.Tag("SkipWindows")


### PR DESCRIPTION
Previously, we didn't test lsif-java on Windows resulting in bugs like
https://github.com/sourcegraph/lsif-java/issues/422. This commit adds a
build matrix to our CI job and fixes path escaping logic so that it
should work correctly on Windows.

### Test plan

See new CI job for Windows.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
