### PR TITLE
Fix brittle code related to launching a Bazel process

### DIFF
--- a/examples/bazel-example/.gitignore
+++ b/examples/bazel-example/.gitignore
@@ -1,0 +1,1 @@
+bazel-bazel-example


### PR DESCRIPTION
I saw flaky test failures caused by a false assumption in the code that
the `bazel query` process has completed execution after reading stdout.
We now wait for the process to complete instead of crashing the program.

### Test plan

Verify that the CI is green.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
