### PR TITLE
Add a welcome screen with common tasks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -564,7 +564,7 @@ usefulTasks :=
       "Runs slow snapshot tests. Indexes a corpus of external Java libraries."
     ).alias("slowSnapshotTests"),
     UsefulTask("snapshots/test", "Runs all snapshot tests")
-      .alias("slowSnapshotTests"),
+      .alias("snapshotTests"),
     UsefulTask(
       "buildTools/testOnly tests.Gradle*",
       "Runs tests for Gradle builds"

--- a/build.sbt
+++ b/build.sbt
@@ -524,3 +524,55 @@ lazy val fatjarPackageSettings = List[Def.Setting[_]](
     ).transform(node).head
   }
 )
+
+import sbtwelcome._
+
+logo :=
+  raw"""
+       |           _             _                  
+       |          (_)           (_)                 
+       |  ___  ___ _ _ __ ______ _  __ ___   ____ _ 
+       | / __|/ __| | '_ \______| |/ _` \ \ / / _` |
+       | \__ \ (__| | |_) |     | | (_| |\ V / (_| |
+       | |___/\___|_| .__/      | |\__,_| \_/ \__,_|
+       |            | |        _/ |                 
+       |            |_|       |__/                  
+       |
+       |${version.value}
+       |
+       |${scala.Console.YELLOW}Scala ${scalaVersion
+    .value}${scala.Console.RESET}
+       |
+       |""".stripMargin
+
+usefulTasks :=
+  Seq(
+    UsefulTask(
+      "fixAll",
+      "Run Scalafmt, Scalafix and Javafmt on all sources. Run this before opening a PR."
+    ).noAlias,
+    UsefulTask(
+      "snapshots/run",
+      "Update snapshot tests. Use this command after you have fixed a bug."
+    ).alias("regenerateSnapshots"),
+    UsefulTask(
+      "snapshots/testOnly tests.MinimizedSnapshotSuite",
+      "Run a small subset of snapshot tests for fast iteration"
+    ).alias("fastSnapshotTests"),
+    UsefulTask(
+      "snapshots/testOnly tests.LibrarySnapshotSuite",
+      "Runs slow snapshot tests. Indexes a corpus of external Java libraries."
+    ).alias("slowSnapshotTests"),
+    UsefulTask("snapshots/test", "Runs all snapshot tests")
+      .alias("slowSnapshotTests"),
+    UsefulTask(
+      "buildTools/testOnly tests.Gradle*",
+      "Runs tests for Gradle builds"
+    ).alias("gradleTests"),
+    UsefulTask(
+      "buildTools/testOnly tests.Maven*",
+      "Runs tests for Gradle builds"
+    ).alias("mavenTests")
+  )
+
+logoColor := scala.Console.MAGENTA

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.3.1")
 // sbt-jdi-tools appears to fix an error related to this message:
 // [error] (plugin / Compile / compileIncremental) java.lang.NoClassDefFoundError: com/sun/tools/javac/code/Symbol
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")


### PR DESCRIPTION
Let me know what you think.

Welcome banner when SBT is loaded with some commands from https://sourcegraph.github.io/scip-java/docs/contributing.html#helpful-commands being given helpful aliases.

These aliases survive wiping of SBT workspace because they're not part of history, but rather part of the build.

If desired, they can also be used in CI, as individual steps for better reporting, i.e. `sbt --client gradleTests`, `sbt --client snapshotTests`, etc.

<img width="854" alt="image" src="https://user-images.githubusercontent.com/1052965/233077158-a75628c4-4867-4f45-8831-aee865ccc2d1.png">


### Test plan

No testing required as the change is not functional.
Eyeballing CI output is enough.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
