### PR TITLE
Handle <?> special symbol name from Scala 3 Semanticdb

### DIFF
--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SymbolDescriptor.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SymbolDescriptor.java
@@ -59,7 +59,7 @@ public class SymbolDescriptor {
       if (SemanticdbSymbols.isLocal(symbol)) {
         return new SymbolDescriptor(Descriptor.local(symbol), SemanticdbSymbols.NONE);
       }
-      if (SemanticdbSymbols.NONE.equals(symbol)) {
+      if (SemanticdbSymbols.isNone(symbol)) {
         return SymbolDescriptor.NONE;
       }
       readChar();

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public final class SemanticdbSymbols {
 
   public static String NONE = "";
+  public static String NONE_STUB = "<?>";
   public static String ROOT_PACKAGE = "_root_/";
 
   /** Creates a new global SemanticDB symbol. */
@@ -28,6 +29,10 @@ public final class SemanticdbSymbols {
 
   public static boolean isLocal(String symbol) {
     return symbol.startsWith("local");
+  }
+
+  public static boolean isNone(String symbol) {
+    return NONE.equals(symbol) || NONE_STUB.equals(symbol);
   }
 
   public static boolean isGlobal(String symbol) {


### PR DESCRIPTION
See https://sourcegraph.com/github.com/lampepfl/dotty/-/blob/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala?L59

I'm not sure if we can treat it as a local instead, given that it's explicitly coming from a failed local table lookup.

This is a stopgap solution to at least not completely crash over it.

### Test plan

N/A - difficult to say if this behaviour is intentional on Scala 3 side

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
