### PR TITLE
Explicitly setup Gradle 8 for Java 8 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
 
       - uses: sbt/setup-sbt@v1
 
+      - name: Setup Gradle 8.10
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.10' 
+
       - name: Main project tests
         run: sbt test 
 


### PR DESCRIPTION
Github has updated base Gradle version on its runners to Gradle 9, which makes Java 17 the minimally supported version.

Unfortunately, we use globally installed `gradle` command to launch integration tests, instead of a checked-in JAR launcher.
Long term this is probably what we should do but I want to attempt a simpler solution first to get the release out.

### Test plan

- Ensure CI is restored