### PR TITLE
[Investigation] Handle Annotation Processing for Test Compilation When Other Processors Present

### DIFF
--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -79,15 +79,14 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
 
         val compilerPluginAdded =
           try {
-            project.getDependencies().add("compileOnly", javacPluginDep)
+            val dependencies = project.getDependencies()
+            dependencies.add("compileOnly", javacPluginDep)
+            dependencies.add("testCompileOnly", javacPluginDep)
 
             if (hasAnnotationPath) {
-              project
-                .getDependencies()
-                .add("annotationProcessor", javacPluginDep)
+              dependencies.add("annotationProcessor", javacPluginDep)
+              dependencies.add("testAnnotationProcessor", javacPluginDep)
             }
-
-            project.getDependencies().add("testCompileOnly", javacPluginDep)
 
             true
           } catch {


### PR DESCRIPTION
Related to #769 

I am similarly experiencing issues when attempting to index particular internal repositories. When running `scip-java index` I am seeing the following error:

```
Execution failed for task ':log-receiver:compileTestJava'.

> Compilation failed; see the compiler output below.                                                                           error: plug-in not found: semanticdb
```

Taking a closer look at the build scan I noticed that all of the `compileJava` tasks were succeeding. I used that information to isolate the `compileTestJava`. I patched in a small change that appended `--debug` to the Gradle invocation launched by SCIP. I was able to use this to print out the arguments being passed to `javac`. The most glaring difference was that my test compilation was using `-processorpath` for an alternative annotation processor (ErrorProne).

Which, according to the `javac` documentation, `-processorpath` ["Specifies where to find annotation processors. If this option is not used, then the class path is searched for processors."](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html#:~:text=Specifies%20where%20to%20find%20annotation%20processors.%20If%20this%20option%20is%20not%20used%2C%20then%20the%20class%20path%20is%20searched%20for%20processors) Which led me to question whether it just so happened that we were only adding a competing annotation for the test configurations.

Hence my change. Piggybacking on the annotation mutation when it is discovered that the annotation path is present, we now also append the `semanticdb-plugin` to the `testAnnotationProcessor` similar to how it appends to the `compileOnly` and `testCompileOnly` configurations.

### Note

I am still not 100% certain that this is the absolute root cause, but in making this small change I was able to successfully produce a SCIP index for a repo that previously used to fail.


### Test plan
As of right now this is a simple before and after within a failing repository. That repository is private, but I am willing to put a minimal repro together if it will help build confidence. 
