### PR TITLE
Fix absolute path handling in `SemanticdbTaskListener.absolutePathFromUri`

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -211,9 +211,9 @@ public final class SemanticdbTaskListener implements TaskListener {
     if ((options.uriScheme == UriScheme.SBT || options.uriScheme == UriScheme.ZINC)
         && uri.getScheme().equals("vf")
         && uri.toString().startsWith("vf://tmp/")) {
-      String[] parts = uri.toString().split("/", 5);
-      if (parts.length == 5) {
-        return options.sourceroot.resolve(Paths.get(parts[4]));
+      String[] parts = uri.toString().split("/", 4);
+      if (parts.length == 4) {
+        return options.sourceroot.resolve(Paths.get(parts[3]));
       } else {
         throw new IllegalArgumentException("unsupported URI: " + uri);
       }


### PR DESCRIPTION
The previous code was off by one: 

- If given a relative path `vf://tmp/foo/bar/baz`, it would crash with `unsupported URI`
- If given an absolute path `vf://tmp//foo/bar/baz`, it would incorrectly produce a relative path `foo/bar/baz` using the absolute path's segments, which would typically duplicate the `-sourceroot` value and result in an invalid path

Looking at the code, it seems like it is simply splitting by 1 too many slashes: if we want everything after the `vf://tmp/`, we need to `.split('/', 4)` rather than `.split('/', 5)`. This seems fixes both misbehaviors listed above:

- If given a relative path `vf://tmp/foo/bar/baz`, it extracts the relative `foo/bar/baz`, which is then appended as a sub-path by `options.sourceroot.resolve`
- If given an absolute path `vf://tmp//foo/bar/baz`, it extracts the absolute `/foo/bar/baz`, which then remains unchanged and is returned by `options.sourceroot.resolve`

### Test plan

Tested manually, a local `sbt publishLocal` with these changes fixes downstream issues in tools that consume the semanticdb e.g. https://github.com/scalameta/metals/issues/7913