### PR TITLE
ci: add JDK 25 validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
         # os: [windows-latest, ubuntu-latest]
         os: [ubuntu-latest]
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 25]
     steps:
       - uses: actions/checkout@v4
 
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 25]
     steps:
       - uses: actions/checkout@v4
 

--- a/build.sbt
+++ b/build.sbt
@@ -429,6 +429,17 @@ lazy val minimized21 = project
   .dependsOn(agent, javacPlugin)
   .disablePlugins(JavaFormatterPlugin)
 
+lazy val minimized25 = project
+  .in(file("tests/minimized/.j25"))
+  .settings(
+    javaOnlySettings,
+    minimizedSettings,
+    javaToolchainVersion := "25",
+    javacOptions ++= javacModuleOptions
+  )
+  .dependsOn(agent, javacPlugin)
+  .disablePlugins(JavaFormatterPlugin)
+
 lazy val minimizedScala = project
   .in(file("tests/minimized-scala"))
   .settings(

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -9,7 +9,7 @@ class Gradle_5_BuildToolSuite extends GradleBuildToolSuite(Gradle5)
 
 abstract class GradleBuildToolSuite(gradle: Tool.Gradle)
     extends GradleBuildToolSuiteBase(gradle) {
-  val allJava = List(8, 11, 17, 21)
+  val allJava = List(8, 11, 17, 21, 25)
 
   checkGradleBuild(
     "annotation-path",

--- a/tests/unit/src/test/scala/tests/JavaVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaVersionSuite.scala
@@ -14,5 +14,6 @@ class JavaVersionSuite extends FunSuite {
 
   checkVersion("1.8.0_272", "8")
   checkVersion("11.0.9", "11")
+  checkVersion("25.0.1", "25")
 
 }


### PR DESCRIPTION
 Add JDK 25 to CI test matrices (sbt and Maven jobs), a minimized25 test project, and version parsing coverage to confirm the compiler plugin works correctly on JDK 25.

  Closes #857

# Test plan

## Environment

| Component | Version |
|---|---|
| JDK | OpenJDK 25.0.2 (Zulu25.32+17-CA) |
| sbt | 1.10.0 |
| scip-java | 0.12.3-1-8bf6b420-SNAPSHOT |
| OS | macOS Darwin 24.6.0 |

---

### What was changed

| File | Change |
|---|---|
| `build.sbt` | Added `minimized25` sbt project targeting JDK 25 |
| `.github/workflows/ci.yml` | Added `25` to Java version matrix in both `test` and `maven` CI jobs |
| `tests/unit/src/test/scala/tests/JavaVersionSuite.scala` | Added version string parsing test case for `"25.0.1"` |
| `tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala` | Added `25` to `allJava` list |

---

### Test 1: Compiler plugin compiles under JDK 25

The `minimized25` sbt project uses `javaToolchainVersion := "25"` and shares the same Java sources as all other `minimized*` projects (`tests/minimized/src/main/java`). It injects `semanticdb-javac` as a javac plugin via the agent and verifies it can compile real Java sources and emit SemanticDB output under JDK 25.

**Command:**
```bash
sbt minimized25/compile
```

**Result:**
```
[success] Total time: 14 s, completed Apr 3, 2026, 5:18:51 PM
```

Warnings observed were pre-existing and unrelated to JDK 25:
- `sun.misc.Unsafe::arrayBaseOffset` deprecation from protobuf (affects all JDK versions)
- `source value 8 is obsolete` from javac `-source 8` flag (affects all JDK versions)

---

### Test 2: Version string parsing

`JavaVersion` parses the JVM version string from `System.getProperty("java.version")` to determine the major version. JDK 25 uses the format `"25.0.x"` (no `1.` prefix), which is the same modern format introduced in JDK 9.

**Command:**
```bash
sbt "unit/testOnly tests.JavaVersionSuite"
```

**Result:**
```
tests.JavaVersionSuite:
  + 1.8.0_272   0.034s   // legacy 1.x format
  + 11.0.9      0.001s   // modern format
  + 25.0.1      0.000s   // new test case for JDK 25
Passed: Total 3, Failed 0, Errors 0, Passed 3
```

---

### Test 3: End-to-end indexing pipeline on JDK 25

This is the most comprehensive test. It exercises the full pipeline:

1. Maven compiles real Java sources with `semanticdb-javac` injected as a javac plugin
2. SemanticDB files are written to `target/semanticdb-targetroot/`
3. `scip-java index-semanticdb` reads the SemanticDB files and produces `index.scip`

**Step 1 — Build and publish the CLI locally:**
```bash
sbt build publishM2 publishLocal dumpScipJavaVersion
export SCIP_JAVA_VERSION=$(cat VERSION)
export SCIP_JAVA_CLI=$PWD/out/bin/scip-java
```

**Step 2 — Compile `examples/maven-example` with the plugin:**
```bash
cd examples/maven-example
mvn clean verify -DskipTests \
  -Dscip-java.version=$SCIP_JAVA_VERSION \
  sourcegraph:sourcegraphDependencies
```

**Result:**
```
[INFO] Dependencies were written to target/semanticdb-targetroot/com.sourcegraph_example_jar_1.0.0-SNAPSHOT.dependencies.txt
[INFO] BUILD SUCCESS
[INFO] Total time: 3.627 s
```

**Step 3 — Convert SemanticDB to SCIP:**
```bash
$SCIP_JAVA_CLI index-semanticdb target/semanticdb-targetroot
```

**Step 4 — Verify output:**
```bash
du -h index.scip
```

**Result:**
```
info: .../examples/maven-example/index.scip
4.0K	index.scip
```

`index.scip` was produced with non-zero size, confirming the full pipeline works on JDK 25.

---

### CI coverage

The CI matrix in `.github/workflows/ci.yml` now runs against `[8, 11, 17, 21, 25]` for both the `test` job (sbt) and the `maven` job, ensuring JDK 25 is validated on every future PR automatically.

---

## Why no code changes were needed in the core

The `semanticdb-javac` plugin uses only stable, long-lived APIs:
- `com.sun.source.util.Plugin` — the standard compiler plugin interface, stable since Java 8
- `com.sun.source.util.TaskListener` / `TaskEvent.Kind.ANALYZE` — hooks into the javac analysis phase, unchanged across versions
- `javax.lang.model.*` — the standard Java language model API, stable since Java 6

The `--add-exports` flags already present for Java 17+ (`jdk.compiler/com.sun.tools.javac.*=ALL-UNNAMED`) continue to apply and work correctly on JDK 25.

The `roundToNearestStableRelease()` method in `JavaVersion.java` already handles versions beyond 17 via a `return version` fallthrough — no explicit JDK 25 constant is required.
