### PR TITLE
Drop support for Java 8, make Java 11 the minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
         # os: [windows-latest, ubuntu-latest]
         os: [ubuntu-latest]
-        java: [8, 11, 17, 21]
+        java: [11, 17, 21]
     steps:
       - uses: actions/checkout@v4
 
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 21]
+        java: [11, 17, 21]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
 
       - uses: coursier/setup-action@v3
         with:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Publish ${{ github.ref }}

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -15,7 +15,7 @@ rm gradle.zip
 mv /opt/gradle/*/* /opt/gradle
 
 # pre-install JDK for all major versions
-for JVM_VERSION in 21 17 11 8
+for JVM_VERSION in 21 17 11
 do 
   coursier java --jvm $JVM_VERSION --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json -- -version
 done

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,6 @@ lazy val agent = project
   .settings(
     fatjarPackageSettings,
     javaOnlySettings,
-    javaToolchainVersion := "8",
     moduleName := "semanticdb-agent",
     libraryDependencies ++=
       List(
@@ -110,8 +109,7 @@ lazy val gradlePlugin = project
     scalaVersion := V.scala213,
     buildInfoPackage := "com.sourcegraph.scip_java",
     publish / skip := true,
-    javaToolchainVersion := "8",
-    scalacOptions ++= Seq("-target:8", "-release", "8"),
+    scalacOptions ++= Seq("-target:11", "-release", "11"),
     libraryDependencies ++=
       List(
         "dev.gradleplugins" % "gradle-api" % V.gradle % Provided,
@@ -150,7 +148,6 @@ lazy val javacPlugin = project
     fatjarPackageSettings,
     javaOnlySettings,
     moduleName := "semanticdb-javac",
-    javaToolchainVersion := "8",
     javacOptions += "-g",
     (assembly / assemblyShadeRules) :=
       Seq(
@@ -186,7 +183,6 @@ lazy val scipProto = project
   .in(file("scip-java-proto"))
   .settings(
     moduleName := "scip-java-proto",
-    javaToolchainVersion := "8",
     javaOnlySettings,
     libraryDependencies +=
       "com.google.protobuf" % "protobuf-java-util" % V.protobuf,
@@ -200,7 +196,6 @@ lazy val scip = project
   .settings(
     publishMavenStyle := true,
     moduleName := "scip-semanticdb",
-    javaToolchainVersion := "8",
     javaOnlySettings,
     (Compile / PB.targets) :=
       Seq(PB.gens.java(V.protobuf) -> (Compile / sourceManaged).value),
@@ -212,7 +207,6 @@ lazy val mavenPlugin = project
   .in(file("maven-plugin"))
   .settings(
     moduleName := "maven-plugin",
-    javaToolchainVersion := "8",
     javaOnlySettings,
     libraryDependencies ++=
       Seq(
@@ -385,12 +379,6 @@ lazy val minimizedSettings = List[Def.Setting[_]](
 lazy val minimized = project
   .in(file("tests/minimized/.j11"))
   .settings(minimizedSettings, javaOnlySettings)
-  .dependsOn(agent, javacPlugin)
-  .disablePlugins(JavaFormatterPlugin)
-
-lazy val minimized8 = project
-  .in(file("tests/minimized/.j8"))
-  .settings(minimizedSettings, javaToolchainVersion := "8", javaOnlySettings)
   .dependsOn(agent, javacPlugin)
   .disablePlugins(JavaFormatterPlugin)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,6 +95,4 @@ write tests because:
   [snapshot testing](https://jestjs.io/docs/en/snapshot-testing), which is a
   testing technique that's heavily used in this codebase.
 - Multiline literal strings in Scala make it easy to write unit tests for source
-  code (which is always multiline). Modern versions of Java support multiline
-  string literals, but they're not supported in Java 8, which is supported by
-  scip-java.
+  code (which is always multiline).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ finished indexing the project.
 
 > The `sourcegraph/scip-java` Docker image is made available for convenience at
 > the cost of performance. The `sourcegraph/scip-java` image is a big download
-> because it includes pre-installed versions of Java 8, Java 11, and Java 17.
+> because it includes pre-installed versions of Java 11, Java 17, and Java 21.
 > The `sourcegraph/scip-java` image has slow performance because it needs to
 > download all external dependencies of your codebase on every invocation.
 >
@@ -46,9 +46,6 @@ Java 17 is the default Java version in the `sourcegraph/scip-java` Docker image.
 Use the following commands to use a different JVM version:
 
 ```sh
-# Java 8
-docker run -v $(pwd):/sources --env JVM_VERSION=8 sourcegraph/scip-java:latest scip-java index
-
 # Java 11
 docker run -v $(pwd):/sources --env JVM_VERSION=11 sourcegraph/scip-java:latest scip-java index
 
@@ -227,9 +224,10 @@ of Java versions.
 | Java version | Support                      | Tracking issue |
 | ------------ | ---------------------------- | -------------- |
 | Java 7       | ❌                           |                |
-| Java 8       | ✅                           |                |
+| Java 8       | ❌                           |                |
 | Java 11      | ✅                           |                |
 | Java 17      | ✅, requires `--add-exports` |                |
+| Java 21      | ✅, requires `--add-exports` |                |
 
 For Java 17 and newer versions, the following JVM options are required:
 

--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -135,8 +135,8 @@ targetroot directory.
 
 ```
 ❯ find $TARGETROOT -type f
-build/semanticdb-targetroot/META-INF/semanticdb/j8/src/test/java/example/ExampleTest.java.semanticdb
-build/semanticdb-targetroot/META-INF/semanticdb/j8/src/main/java/example/Example.java.semanticdb
+build/semanticdb-targetroot/META-INF/semanticdb/j11/src/test/java/example/ExampleTest.java.semanticdb
+build/semanticdb-targetroot/META-INF/semanticdb/j11/src/main/java/example/Example.java.semanticdb
 ...
 ```
 

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <revision>1.0.0-SNAPSHOT</revision>
     </properties>
 

--- a/maven-plugin/src/main/resources/META-INF/maven/plugin.template.xml
+++ b/maven-plugin/src/main/resources/META-INF/maven/plugin.template.xml
@@ -11,7 +11,7 @@
   <goalPrefix>sourcegraph</goalPrefix>
   <isolatedRealm>false</isolatedRealm>
   <inheritedByDefault>true</inheritedByDefault>
-  <requiredJavaVersion>1.8</requiredJavaVersion>
+  <requiredJavaVersion>11</requiredJavaVersion>
   <requiredMavenVersion>3.9.5</requiredMavenVersion>
   <mojos>
     <mojo>

--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -51,14 +51,8 @@ object JavaToolchainPlugin extends AutoPlugin {
           .toList
           .flatMap(index => "--jvm-index" :: index :: Nil)
         val arguments =
-          List(
-            "java",
-            "-jar",
-            coursier.toString,
-            "java-home",
-            "--jvm",
-            v
-          ) ++ index
+          List("java", "-jar", coursier.toString, "java-home", "--jvm", v) ++
+            index
 
         new File(Process(arguments).!!.trim)
       }

--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -27,49 +27,15 @@ object JavaToolchainPlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = List(
-    javacOptions ++=
-      List(
-        "-target",
-        "1.8",
-        "-source",
-        "1.8",
-        "-bootclasspath",
-        java8Bootclasspath()
-      ),
-    (doc / javacOptions) --= List("-target", "1.8"),
-    (doc / javacOptions) --= bootclasspathSettings(javaToolchainVersion.value),
+    javacOptions ++= List("--release", "11"),
+    (doc / javacOptions) --= List("--release", "11"),
     (doc / javacOptions) --= List("-g"),
-    javacOptions ++= bootclasspathSettings(javaToolchainVersion.value),
-    javaOptions ++= bootclasspathSettings(javaToolchainVersion.value),
     fork := true,
     javaToolchainVersion := "11",
     javaToolchainJvmIndex := None,
     javaHome :=
       Some(getJavaHome(javaToolchainVersion.value, javaToolchainJvmIndex.value))
   )
-
-  /**
-   * For Java 8, we need to manually add the Java compiler to the boot
-   * classpath.
-   *
-   * Newer Java versions include the compiler by default.
-   */
-  private def bootclasspathSettings(version: String): List[String] = {
-    val home = getJavaHome(version)
-    val toolsJar: File = home / "lib" / "tools.jar"
-    // The tools.jar file includes the bytecode for the Java compiler in the com.sun.source package.
-    // The Java compiler is available by default in Java 9+, so we only need to add tools.jar to the
-    // bootclasspath for Java 8.
-    if (version == "8" && toolsJar.isFile) {
-      List(s"-Xbootclasspath/p:$toolsJar")
-    } else {
-      List()
-    }
-  }
-
-  private def java8Bootclasspath(): String = {
-    (getJavaHome("8") / "jre" / "lib" / "rt.jar").toString
-  }
 
   private val javaHomeCache: util.Map[String, File] = Collections
     .synchronizedMap(new util.HashMap[String, File]())
@@ -91,21 +57,13 @@ object JavaToolchainPlugin extends AutoPlugin {
             coursier.toString,
             "java-home",
             "--jvm",
-            jvmName(v)
+            v
           ) ++ index
 
         new File(Process(arguments).!!.trim)
       }
     )
   }
-
-  private def jvmName(version: String) =
-    version match {
-      case "8" if isAppleM1 =>
-        "zulu:8" // the only Java 8 distribution available for Apple M1 is Zulu
-      case _ =>
-        version
-    }
 
   private def isAppleM1 =
     scala.util.Properties.isMac && sys.props("os.arch") == "aarch64"

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleJavaCompiler.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleJavaCompiler.scala
@@ -122,21 +122,13 @@ case class GradleJavaCompiler(languageVersion: String, javacPath: Path) {
 
     // For compile{Test}Kotlin when using jvm toolchains, we need to have access
     // to JDK internals found in <java-installation-path>/lib in JDK 9+,
-    // as well as <java-installation-path>/jre/lib in JDK <=8, else we get
-    // "no class roots are found in the JDK path" from the compile{Test}Kotlin tasks.
+    // else we get "no class roots are found in the JDK path" from the
+    // compile{Test}Kotlin tasks.
     // https://docs.oracle.com/en/java/javase/12/migrate/index.html#JSMIG-GUID-A78CC891-701D-4549-AA4E-B8DD90228B4B
     val javaHome = javacPath.getParent.getParent
     val libPath = dir.resolve("lib")
     val javacLibPath = javaHome.resolve("lib")
     copyFiles(javacLibPath, libPath)
-
-    if (languageVersion == "8") {
-      val jreLibPath = dir.resolve("jre").resolve("lib")
-      Files.createDirectories(jreLibPath.getParent)
-      val javacJreLibPath = javaHome.resolve("jre").resolve("lib")
-
-      copyFiles(javacJreLibPath, jreLibPath)
-    }
   }
 }
 object GradleJavaCompiler {
@@ -150,9 +142,9 @@ object GradleJavaCompiler {
   /**
    * Parses a single space-separated line into a GradleJavaCompiler instance.
    *
-   * Example input: "8 /javacLibPath/javac"
+   * Example input: "11 /javacLibPath/javac"
    *
-   * Example output: `Some(GradleJavaCompiler("8", * /javacLibPath/javac))`
+   * Example output: `Some(GradleJavaCompiler("11", * /javacLibPath/javac))`
    */
   def fromLine(line: String): Option[GradleJavaCompiler] =
     line.split(' ') match {

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
@@ -667,8 +667,8 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
 
   }
 
-  private def jvmArchitecture(jvm: String): String =
-    JvmIndex.defaultArchitecture()
+  private def jvmArchitecture(jvm: String): String = JvmIndex
+    .defaultArchitecture()
 
   def defaultCoursierJVMArchitecture: String =
     sys.props("os.arch") match {

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
@@ -77,7 +77,7 @@ import os.SubprocessException
  * {{{
  *   {
  *     "dependencies": ["junit:junit:4.13.1"],
- *     "jvm": "8"
+ *     "jvm": "11"
  *   }
  * }}}
  */
@@ -565,11 +565,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
     })
     val javac = javacPath(config, tmp)
     index.app.reporter.info(s"$$ $javac @$argsfile")
-    val javacModuleOptions: Seq[String] =
-      if (config.jvm != "8")
-        BuildInfo.javacModuleOptions
-      else
-        Nil
+    val javacModuleOptions: Seq[String] = BuildInfo.javacModuleOptions
 
     val jvmOptions = config.jvmOptions.map("-J" + _)
 
@@ -672,15 +668,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
   }
 
   private def jvmArchitecture(jvm: String): String =
-    if (
-      // Hack only for local development on ARM64 Mac OS X
-      // won't affect any other system
-      scala.util.Properties.isMac && sys.props("os.arch") == "aarch64" &&
-      (jvm.startsWith("8") || jvm.startsWith("1.8"))
-    )
-      "amd64"
-    else
-      JvmIndex.defaultArchitecture()
+    JvmIndex.defaultArchitecture()
 
   def defaultCoursierJVMArchitecture: String =
     sys.props("os.arch") match {

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
@@ -99,7 +99,7 @@ final case class IndexDependencyCommand(
   }
 
   private def inferJvmVersion(jar: Path): Option[Int] = {
-    Option(JavaVersion.classfileJvmVersion(jar).orElse(8)).map(
+    Option(JavaVersion.classfileJvmVersion(jar).orElse(11)).map(
       JavaVersion.roundToNearestStableRelease(_)
     )
   }

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/JavaVersion.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/JavaVersion.java
@@ -13,17 +13,15 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 public class JavaVersion {
-  public final boolean isJava8;
   public final JdkPackage pkg;
   private static final PathMatcher CLASS_PATTERN =
       FileSystems.getDefault().getPathMatcher("glob:**.class");
   private static final PathMatcher JAR_PATTERN =
       FileSystems.getDefault().getPathMatcher("glob:**.jar");
 
-  public static final int JAVA8_VERSION = 8;
   public static final int JAVA11_VERSION = 11;
   public static final int JAVA17_VERSION = 17;
-  public static final int DEFAULT_JAVA_VERSION = JAVA8_VERSION;
+  public static final int DEFAULT_JAVA_VERSION = JAVA11_VERSION;
 
   @SuppressWarnings("FieldCanBeLocal")
   private static final int JAVA0_MAJOR_VERSION = 44;
@@ -33,12 +31,10 @@ public class JavaVersion {
   }
 
   public JavaVersion(String version) {
-    isJava8 = version.startsWith("1.8");
-    pkg = new JdkPackage(isJava8 ? "8" : javaVersion(version));
+    pkg = new JdkPackage(javaVersion(version));
   }
 
   private String javaVersion(String version) {
-    if (version.startsWith("1.8")) return "8";
     String[] parts = version.split("\\.");
     if (parts.length > 0) return parts[0];
     else return version;
@@ -46,7 +42,6 @@ public class JavaVersion {
 
   @SuppressWarnings("ManualMinMaxCalculation")
   public static int roundToNearestStableRelease(int version) {
-    if (version <= JAVA8_VERSION) return JAVA8_VERSION;
     if (version <= JAVA11_VERSION) return JAVA11_VERSION;
     if (version <= JAVA17_VERSION) return JAVA17_VERSION;
     return version;
@@ -59,7 +54,7 @@ public class JavaVersion {
    * Java Language spec. See
    * https://docs.oracle.com/javase/specs/jvms/se16/html/jvms-4.html#jvms-4.1
    *
-   * @return the JVM version such as <code>8</code> for Java 8 and <code>11</code> for Java 11.
+   * @return the JVM version such as <code>11</code> for Java 11 and <code>17</code> for Java 17.
    */
   public static Optional<Integer> classfileJvmVersion(Path file) {
     try {

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/PackageTable.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/PackageTable.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.scip_semanticdb;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.*;
@@ -33,7 +32,6 @@ public class PackageTable {
     // redefine classes from the JDK and we want those maven packages to take precedence over
     // the JDK. The motivation to prioritize maven packages over the JDK is that we only want
     // to exports monikers against the JDK when indexing the JDK repo.
-    indexJdk();
     for (MavenPackage pkg : options.packages) {
       indexPackage(pkg);
     }
@@ -52,7 +50,7 @@ public class PackageTable {
 
     Package result = byClassfile.get(classfile);
     if (result != null) return Optional.of(result);
-    if (!javaVersion.isJava8 && isJrtClassfile(classfile)) return Optional.of(javaVersion.pkg);
+    if (isJrtClassfile(classfile)) return Optional.of(javaVersion.pkg);
     return Optional.empty();
   }
 
@@ -94,12 +92,6 @@ public class PackageTable {
     }
   }
 
-  private void indexJdk() throws IOException {
-    if (javaVersion.isJava8) {
-      indexBootstrapClasspath();
-    }
-  }
-
   /**
    * The JRT classpath contains classfiles for the JDK for Java versions 9+.
    *
@@ -114,26 +106,5 @@ public class PackageTable {
       cachedJdkSymbols.add(classfile);
     }
     return isJrt;
-  }
-
-  /**
-   * The boot classpath contains jar files for the JDK in Java 8.
-   *
-   * <p>The bootclasspath is normal jar files on disk that can live under $JAVA_HOME.
-   */
-  private void indexBootstrapClasspath() throws IOException {
-    for (Object keyObject : System.getProperties().keySet()) {
-      Package jdk = new JdkPackage("8");
-      if (!(keyObject instanceof String)) continue;
-      String key = (String) keyObject;
-      if (!key.endsWith(".boot.class.path")) continue;
-      String value = System.getProperty(key);
-      for (String entry : value.split(File.pathSeparator)) {
-        Path path = Paths.get(entry);
-        if (JAR_PATTERN.matches(path) && Files.isRegularFile(path)) {
-          indexJarFile(path, jdk);
-        }
-      }
-    }
   }
 }

--- a/tests/buildTools/src/test/resources/example-maven-pom.xml
+++ b/tests/buildTools/src/test/resources/example-maven-pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
@@ -18,8 +18,6 @@ import munit.Tag
 import munit.TestOptions
 import os.Shellable
 
-object Java8Only extends munit.Tag("Java8Only")
-
 abstract class BaseBuildToolSuite extends MopedSuite(ScipJava.app) {
   self =>
   override def environmentVariables: Map[String, String] = sys.env
@@ -29,14 +27,6 @@ abstract class BaseBuildToolSuite extends MopedSuite(ScipJava.app) {
   override def munitTestTransforms: List[TestTransform] =
     super.munitTestTransforms ++
       List(
-        new TestTransform(
-          "Java8Only",
-          t =>
-            if (Properties.isJavaAtLeast(9) && t.tags(Java8Only))
-              t.tag(munit.Ignore)
-            else
-              t
-        ),
         new TestTransform(
           "SkipWindows",
           t =>
@@ -184,9 +174,6 @@ object BaseBuildToolSuite {
     val segments = prop.split("\\.").toList
 
     segments match {
-      // Java 1.6 - 1.8
-      case "1" :: lessThan8 :: _ :: Nil =>
-        lessThan8.toInt
       // Java 17.0.1, 11.0.20.1, ..
       case modern :: _ :: _ :: rest =>
         modern.toInt

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -9,7 +9,7 @@ class Gradle_5_BuildToolSuite extends GradleBuildToolSuite(Gradle5)
 
 abstract class GradleBuildToolSuite(gradle: Tool.Gradle)
     extends GradleBuildToolSuiteBase(gradle) {
-  val allJava = List(8, 11, 17, 21)
+  val allJava = List(11, 17, 21)
 
   checkGradleBuild(
     "annotation-path",
@@ -164,10 +164,7 @@ abstract class GradleBuildToolSuite(gradle: Tool.Gradle)
 
   allJava.foreach { java =>
     checkGradleBuild(
-      if (java == 8)
-        s"toolchains-$java".tag(Java8Only)
-      else
-        s"toolchains-$java",
+      s"toolchains-$java",
       s"""|/build.gradle
           |apply plugin: 'java'
           |java {
@@ -249,84 +246,6 @@ abstract class GradleBuildToolSuite(gradle: Tool.Gradle)
     expectedSemanticdbFiles = 1,
     extraArguments = List("--", "compileJava"),
     gradleVersions = List(Gradle8, Gradle7, Gradle6)
-  )
-
-  checkGradleBuild(
-    "playframework".tag(Java8Only),
-    """|/build.gradle
-       |plugins {
-       |  id 'org.gradle.playframework' version '0.11'
-       |  id 'idea'
-       |}
-       |
-       |play {
-       |  platform {
-       |    playVersion = '2.6.7'
-       |    scalaVersion = '2.12'
-       |    javaVersion = JavaVersion.VERSION_1_8
-       |  }
-       |  injectedRoutesGenerator = true
-       |}
-       |dependencies {
-       |  implementation "com.typesafe.play:play-guice_2.12:2.6.7"
-       |}
-       |
-       |repositories {
-       |  mavenCentral()
-       |  maven {
-       |    name "lightbend-maven-releases"
-       |    url "https://repo.lightbend.com/lightbend/maven-release"
-       |  }
-       |  ivy {
-       |    name "lightbend-ivy-release"
-       |    url "https://repo.lightbend.com/lightbend/ivy-releases"
-       |    layout "ivy"
-       |  }
-       |}
-       |/app/controllers/HomeController.java
-       |package controllers;
-       |import play.mvc.*;
-       |import views.html.*;
-       |public class HomeController extends Controller {
-       |    public Result index() {
-       |        return ok(index.render("Your new application is ready."));
-       |    }
-       |}
-       |/app/views/index.scala.html
-       |@(message: String)
-       |<h1>@message</h1>
-       |/conf/routes
-       |GET / controllers.HomeController.index
-       |""".stripMargin,
-    expectedSemanticdbFiles =
-      2, // Two files because `conf/routes` generates a Java file.
-    gradleVersions = List(Gradle6)
-  )
-
-  checkGradleBuild(
-    "checkerframework".tag(Java8Only),
-    """|/build.gradle
-       |plugins {
-       |    id 'java'
-       |    id 'org.checkerframework' version '0.5.24'
-       |}
-       |repositories {
-       |    mavenCentral()
-       |}
-       |java {
-       |  toolchain {
-       |    languageVersion = JavaLanguageVersion.of(8)
-       |  }
-       |}
-       |/src/main/java/foo/Example.java
-       |package foo;
-       |public class Example {}
-       |/src/test/java/foo/ExampleSuite.java
-       |package foo;
-       |public class ExampleSuite {}
-       |""".stripMargin,
-    expectedSemanticdbFiles = 2,
-    gradleVersions = List(Gradle6)
   )
 
   checkGradleBuild(
@@ -430,7 +349,7 @@ abstract class GradleBuildToolSuite(gradle: Tool.Gradle)
     gradleVersions = List(Gradle8, Gradle7, Gradle6)
   )
 
-  List("8", "11").foreach { java =>
+  List("11", "17").foreach { java =>
     checkGradleBuild(
       s"kotlin-jvm-toolchains-jdk$java",
       s"""|/build.gradle

--- a/tests/buildTools/src/test/scala/tests/Tool.scala
+++ b/tests/buildTools/src/test/scala/tests/Tool.scala
@@ -6,8 +6,8 @@ case class JVMSupport(minJava: Int, maxJava: Option[Int] = None) {
       (maxJava.isEmpty || maxJava.exists(javaVersion <= _))
 }
 object JVMSupport {
-  val noRestrictions = JVMSupport(8, None)
-  def atMostJava(j: Int) = JVMSupport(8, Some(j))
+  val noRestrictions = JVMSupport(11, None)
+  def atMostJava(j: Int) = JVMSupport(11, Some(j))
   def atLeastJava(j: Int) = JVMSupport(j, None)
   def javaBetween(min: Int, max: Int) = JVMSupport(min, Some(max))
 
@@ -28,7 +28,7 @@ object Tool {
   def minimumSupportedJdk(tools: Seq[Tool]): Int = tools
     .map(_.support.minJava)
     .minOption
-    .getOrElse(8)
+    .getOrElse(11)
 
   def maximumSupportedJdk(tools: Seq[Tool]): Option[Int] =
     tools.flatMap(_.support.maxJava).minOption

--- a/tests/unit/src/test/scala/tests/JavaVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaVersionSuite.scala
@@ -12,7 +12,7 @@ class JavaVersionSuite extends FunSuite {
     }
   }
 
-  checkVersion("1.8.0_272", "8")
   checkVersion("11.0.9", "11")
+  checkVersion("17.0.5", "17")
 
 }


### PR DESCRIPTION
We are about to merge `scip-kotlin` into `scip-java`. Newer Kotlin versions require JDK to be at least at version 11.

We understand that Java 8 is still supported. If this change affects you please send us an email or drop a message in [the SCIP Discord](https://discord.gg/w5TEzebTPk).

### Test plan
N/A