### PR TITLE
Drop ZINC/SBT URI scheme and prune dead helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -550,10 +550,20 @@ lazy val minimizedSettings = List[Def.Setting[_]](
   (run / fork) := true,
   (Compile / unmanagedSourceDirectories) += minimizedSourceDirectory,
   libraryDependencies ++= List("org.projectlombok" % "lombok" % "1.18.22"),
+  // Fork javac so it receives real file paths instead of sbt's `vf://` virtual-file URIs
+  // (see the comment on `semanticdbKotlincMinimized` for the long story).
+  javaHome := Some(file(System.getProperty("java.home"))),
+  Compile / javacOptions ++=
+    Seq(
+      "-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      "-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+      "-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+      "-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+      "-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+    ),
   javacOptions +=
     List(
       s"-Xplugin:semanticdb",
-      s"-build-tool:sbt",
       s"-text:on",
       s"-verbose",
       s"-sourceroot:${(ThisBuild / baseDirectory).value}",

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.semanticdb_javac;
 
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.PackageElement;
@@ -36,12 +35,8 @@ public final class GlobalSymbolsCache {
     return result;
   }
 
-  public boolean isNone(Element sym) {
-    return sym == null;
-  }
-
   private String uncachedSemanticdbSymbol(Element sym, LocalSymbolsCache locals) {
-    if (isNone(sym)) return SemanticdbSymbols.ROOT_PACKAGE;
+    if (sym == null) return SemanticdbSymbols.ROOT_PACKAGE;
 
     if (sym instanceof PackageElement) {
       if (((PackageElement) sym).isUnnamed()) return SemanticdbSymbols.ROOT_PACKAGE;

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Result.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/Result.java
@@ -1,8 +1,6 @@
 package com.sourcegraph.semanticdb_javac;
 
 import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * A Java implementation of Rust's <code>Result[T, E]</code> type, or Scala's <code>Either[A, B]
@@ -17,7 +15,7 @@ public final class Result<T, E> {
     Error;
   }
 
-  private Kind kind;
+  private final Kind kind;
   private final T ok;
   private final E error;
 
@@ -31,61 +29,15 @@ public final class Result<T, E> {
     this.ok = ok;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    Result<?, ?> result = (Result<?, ?>) o;
-    return kind == result.kind
-        && Objects.equals(error, result.error)
-        && Objects.equals(ok, result.ok);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(kind, error, ok);
-  }
-
-  @Override
-  public String toString() {
-    switch (kind) {
-      case Ok:
-        return "Error(" + error + ")";
-      case Error:
-        return "Ok(" + ok + ")";
-      default:
-        return "Result{" + "kind=" + kind + ", error=" + error + ", ok=" + ok + '}';
-    }
-  }
-
-  public <C> C fold(Function<T, C> onOk, Function<E, C> onError) {
-    switch (kind) {
-      case Ok:
-        return onOk.apply(ok);
-      case Error:
-        return onError.apply(error);
-      default:
-        throw new IllegalArgumentException(this.toString());
-    }
-  }
-
-  public <C> Result<C, E> map(Function<T, C> fn) {
-    return this.fold(left -> Result.ok(fn.apply(left)), Result::error);
-  }
-
   public boolean isOk() {
     return kind == Kind.Ok;
-  }
-
-  public boolean isError() {
-    return kind == Kind.Error;
   }
 
   public T getOrThrow() {
     if (kind == Kind.Ok) {
       return ok;
     } else {
-      throw new NoSuchElementException("no left value on " + this.toString());
+      throw new NoSuchElementException("no ok value on Result.Error(" + error + ")");
     }
   }
 
@@ -93,7 +45,7 @@ public final class Result<T, E> {
     if (kind == Kind.Error) {
       return error;
     } else {
-      throw new NoSuchElementException("no left value on " + this.toString());
+      throw new NoSuchElementException("no error value on Result.Ok(" + ok + ")");
     }
   }
 

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -58,8 +58,6 @@ public class SemanticdbJavacOptions {
         }
       } else if (arg.startsWith("-sourceroot:")) {
         result.sourceroot = Paths.get(arg.substring("-sourceroot:".length())).normalize();
-      } else if (arg.equals("-build-tool:sbt")) {
-        result.uriScheme = UriScheme.ZINC;
       } else if (arg.startsWith("-no-relative-path:")) {
         String value = arg.substring("-no-relative-path:".length());
         switch (value) {

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -208,16 +208,7 @@ public final class SemanticdbTaskListener implements TaskListener {
 
   public static Path absolutePathFromUri(SemanticdbJavacOptions options, JavaFileObject file) {
     URI uri = file.toUri();
-    if ((options.uriScheme == UriScheme.SBT || options.uriScheme == UriScheme.ZINC)
-        && uri.getScheme().equals("vf")
-        && uri.toString().startsWith("vf://tmp/")) {
-      String[] parts = uri.toString().split("/", 5);
-      if (parts.length == 5) {
-        return options.sourceroot.resolve(Paths.get(parts[4]));
-      } else {
-        throw new IllegalArgumentException("unsupported URI: " + uri);
-      }
-    } else if (options.uriScheme == UriScheme.BAZEL) {
+    if (options.uriScheme == UriScheme.BAZEL) {
       String toString = file.toString().replace(":", "/");
       // This solution is hacky, and it would be very nice to use a dedicated API
       // instead.

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/UriScheme.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/UriScheme.java
@@ -2,9 +2,5 @@ package com.sourcegraph.semanticdb_javac;
 
 public enum UriScheme {
   DEFAULT,
-  /** @deprecated Use ZINC instead */
-  @Deprecated
-  SBT,
   BAZEL,
-  ZINC
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
@@ -2,7 +2,6 @@ package com.sourcegraph.semanticdb_kotlinc
 
 import java.nio.file.Path
 import kotlin.contracts.ExperimentalContracts
-import kotlin.math.exp
 import org.jetbrains.kotlin.*
 import org.jetbrains.kotlin.com.intellij.lang.LighterASTNode
 import org.jetbrains.kotlin.com.intellij.util.diff.FlyweightCapableTreeStructure
@@ -12,17 +11,13 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.*
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
-import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirBasicExpressionChecker
-import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirClassReferenceExpressionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirQualifiedAccessExpressionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirTypeOperatorCallChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.analysis.checkers.toClassLikeSymbol
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.fir.expressions.FirClassReferenceExpression
 import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
-import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
@@ -30,8 +25,6 @@ import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.toClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
-import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName


### PR DESCRIPTION
Two small, independent cleanups that don't depend on any in-flight work.

## Drop ZINC/SBT URI scheme

Scala/SBT support was dropped in #883, but the SBT-via-Zinc plumbing in the javac plugin lingered:

- `UriScheme.SBT` (already `@Deprecated`) and `UriScheme.ZINC`
- `-build-tool:sbt` argument parsing
- `vf://tmp/` URI handling in `SemanticdbTaskListener.absolutePathFromUri`

The `minimized` sbt project was the last user of `-build-tool:sbt`. Updated it to fork javac with `--add-exports` flags (same trick `semanticdbKotlincMinimized` already uses), so the plugin sees real file paths instead of sbt's `vf://` virtual-file URIs.

## Remove dead helpers and unused imports

Pure dead-code removal:

- `Result.{fold,map,isError,equals,hashCode,toString}` — none called externally; `map` only called `fold` recursively. Improved `getOrThrow`/`getErrorOrThrow` error messages and made `kind` `final`.
- `GlobalSymbolsCache.isNone` — single-line wrapper for `sym == null`, inlined into its sole caller; dropped now-unused `ElementKind` import.
- 8 unused imports in `AnalyzerCheckers.kt` (`kotlin.math.exp`, `FirBasicExpressionChecker`, `FirClassReferenceExpressionChecker`, `FirClassReferenceExpression`, `FirStatement`, `coneType`, `resolvedType`).

## Validation

- `sbt checkAll` ✅
- `sbt unit/test` ✅
- `sbt snapshots/test` ✅ (no snapshot drift)
- `sbt minimized/clean minimized/compile` ✅
- `sbt semanticdbKotlincMinimized/clean kotlincSnapshots` ✅ (no snapshot drift)