### PR TITLE
Drop semanticdb prefix from indexer-internal symbol APIs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -416,9 +416,10 @@ lazy val semanticdbKotlinc = project
 // `semanticdbKotlincMinimized` mirrors the (still-present) Gradle build at
 // semanticdb-kotlinc/minimized/build.gradle.kts. It compiles a small set of
 // Kotlin and Java fixtures with the assembled `semanticdbKotlinc` plugin
-// attached to kotlinc/javac, producing *.semanticdb files under
-// target/semanticdb-targetroot/ which are then converted to SCIP and rendered
-// as the human-readable golden snapshots by the `snapshots` task.
+// attached to kotlinc/javac, producing *.scip shard files under
+// target/semanticdb-targetroot/ which are then aggregated into a single SCIP
+// index and rendered as the human-readable golden snapshots by the
+// `snapshots` task.
 lazy val semanticdbKotlincMinimized = project
   .in(file("semanticdb-kotlinc/minimized"))
   .enablePlugins(KotlinPlugin)
@@ -482,7 +483,7 @@ lazy val semanticdbKotlincMinimized = project
     // ----- snapshots regeneration task -----
     // Invokes `com.sourcegraph.scip_java.ScipJava.main` twice in the cli JVM
     // (forked — ScipJava.main calls System.exit on failure). First pass
-    // converts the *.semanticdb files under target/semanticdb-targetroot/
+    // aggregates the *.scip shard files under target/semanticdb-targetroot/
     // into an index.scip; second pass renders that index as the human-readable
     // golden snapshots.
     //

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipSymbol.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipSymbol.scala
@@ -42,10 +42,8 @@ object ScipSymbol {
     }
   }
 
-  private def parseDescriptors(
-      semanticdbSymbol: String
-  ): List[SymbolDescriptor] = {
-    val descriptor = SymbolDescriptor.parseFromSymbol(semanticdbSymbol)
+  private def parseDescriptors(symbol: String): List[SymbolDescriptor] = {
+    val descriptor = SymbolDescriptor.parseFromSymbol(symbol)
     if (descriptor.owner == SemanticdbSymbols.ROOT_PACKAGE)
       Nil
     else

--- a/scip-semanticdb/BUILD
+++ b/scip-semanticdb/BUILD
@@ -19,7 +19,7 @@ java_library(
     srcs = glob(["src/main/java/**/*.java"]),
     deps = [
         ":all_java_proto",
-        "//semanticdb-shared",
+        "//semanticdb-java",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_protobuf_protobuf_java_util",

--- a/semanticdb-javac/BUILD
+++ b/semanticdb-javac/BUILD
@@ -31,7 +31,7 @@ java_library(
     srcs = glob(["src/main/java/**/*.java"]),
     resources = ["src/main/resources/META-INF/services/com.sun.source.util.Plugin"],
     deps = [
-        "//semanticdb-shared",
+        "//semanticdb-java",
         "@maven//:org_scip_code_scip_java_bindings",
     ],
 )

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/GlobalSymbolsCache.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 
 import static com.sourcegraph.semanticdb_javac.Debugging.pprint;
 
-/** Cache of SemanticDB symbols that can be referenced between files. */
+/** Cache of symbol strings shared across files. */
 public final class GlobalSymbolsCache {
 
   private final IdentityHashMap<Element, String> globals = new IdentityHashMap<>();
@@ -26,19 +26,19 @@ public final class GlobalSymbolsCache {
     this.options = options;
   }
 
-  public String semanticdbSymbol(Element sym, LocalSymbolsCache<Element, String> locals) {
+  public String symbol(Element sym, LocalSymbolsCache<Element, String> locals) {
     String result = globals.get(sym);
     if (result != null) return result;
     String localResult = locals.get(sym);
     if (localResult != null) return localResult;
-    result = uncachedSemanticdbSymbol(sym, locals);
+    result = uncachedSymbol(sym, locals);
     if (SemanticdbSymbols.isGlobal(result)) {
       globals.put(sym, result);
     }
     return result;
   }
 
-  private String uncachedSemanticdbSymbol(Element sym, LocalSymbolsCache<Element, String> locals) {
+  private String uncachedSymbol(Element sym, LocalSymbolsCache<Element, String> locals) {
     if (sym == null) return SemanticdbSymbols.ROOT_PACKAGE;
 
     if (sym instanceof PackageElement) {
@@ -66,10 +66,10 @@ public final class GlobalSymbolsCache {
 
     if (isAnonymousClass(sym) || isLocalVariable(sym)) return locals.put(sym);
 
-    String owner = semanticdbSymbol(sym.getEnclosingElement(), locals);
+    String owner = symbol(sym.getEnclosingElement(), locals);
     if (SemanticdbSymbols.isLocal(owner)) return locals.put(sym);
 
-    SemanticdbSymbols.Descriptor desc = semanticdbDescriptor(sym);
+    SemanticdbSymbols.Descriptor desc = descriptor(sym);
     if (options.verboseEnabled && desc.kind == SemanticdbSymbols.Descriptor.Kind.None) {
       if (sym instanceof QualifiedNameable)
         pprint(((QualifiedNameable) sym).getQualifiedName().toString());
@@ -96,7 +96,7 @@ public final class GlobalSymbolsCache {
     return sym instanceof TypeElement && sym.getSimpleName().length() == 0;
   }
 
-  private SemanticdbSymbols.Descriptor semanticdbDescriptor(Element sym) {
+  private SemanticdbSymbols.Descriptor descriptor(Element sym) {
     if (sym instanceof TypeElement) {
       return new SemanticdbSymbols.Descriptor(
           SemanticdbSymbols.Descriptor.Kind.Type, sym.getSimpleName().toString());

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/ScipSymbols.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/ScipSymbols.java
@@ -3,11 +3,10 @@ package com.sourcegraph.semanticdb_javac;
 import com.sourcegraph.semanticdb.SemanticdbSymbols;
 
 /**
- * Converts SemanticDB-style symbol strings into the placeholder SCIP form expected by the
- * aggregator. The compiler plug-in doesn't know the final Maven coordinates, so globals are
- * prefixed with {@link #PLACEHOLDER_PREFIX} and the aggregator rewrites them into {@code "scip-java
- * maven <g> <a> <v> <descriptor>"}. Locals use the canonical {@code "local N"} form and pass
- * through unchanged.
+ * Wraps descriptor strings into SCIP symbol strings. The compiler plug-in doesn't know the final
+ * Maven coordinates, so globals are prefixed with {@link #PLACEHOLDER_PREFIX} and the aggregator
+ * rewrites them into {@code "scip-java maven <g> <a> <v> <descriptor>"}. Locals use the canonical
+ * {@code "local N"} form and pass through unchanged.
  */
 public final class ScipSymbols {
 
@@ -15,7 +14,7 @@ public final class ScipSymbols {
 
   private ScipSymbols() {}
 
-  public static String fromSemanticdbSymbol(String symbol) {
+  public static String format(String symbol) {
     if (symbol == null || symbol.isEmpty()) return "";
     if (SemanticdbSymbols.isLocal(symbol)) {
       return "local " + symbol.substring("local".length());

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/ScipVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/ScipVisitor.java
@@ -58,8 +58,8 @@ import javax.tools.Diagnostic;
 
 /**
  * Walks a typechecked compilation unit and builds a {@link Document}. Symbols come from {@link
- * GlobalSymbolsCache} via {@link ScipSymbols#fromSemanticdbSymbol(String)} and signatures from
- * {@link ScipSignatureFormatter}.
+ * GlobalSymbolsCache} via {@link ScipSymbols#format(String)} and signatures from {@link
+ * ScipSignatureFormatter}.
  */
 public final class ScipVisitor extends TreePathScanner<Void, Void> {
 
@@ -132,36 +132,36 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
   private void emitOccurrence(
       Element sym, Optional<ScipRange> range, int roles, Optional<ScipRange> enclosingRange) {
     if (sym == null || !range.isPresent()) return;
-    String semanticdbSymbol = semanticdbSymbol(sym);
-    if (semanticdbSymbol.equals(SemanticdbSymbols.NONE)) return;
+    String symbol = symbol(sym);
+    if (symbol.equals(SemanticdbSymbols.NONE)) return;
 
     Occurrence.Builder occ =
         Occurrence.newBuilder()
             .addAllRange(range.get().asScipRange())
-            .setSymbol(ScipSymbols.fromSemanticdbSymbol(semanticdbSymbol))
+            .setSymbol(ScipSymbols.format(symbol))
             .setSymbolRoles(roles);
     enclosingRange.ifPresent(r -> occ.addAllEnclosingRange(r.asScipRange()));
     occurrences.add(occ.build());
   }
 
   private void emitSymbolInformation(Element sym, Tree tree) {
-    String semanticdbSymbol = semanticdbSymbol(sym);
-    if (semanticdbSymbol.equals(SemanticdbSymbols.NONE)) return;
+    String symbol = symbol(sym);
+    if (symbol.equals(SemanticdbSymbols.NONE)) return;
 
     SymbolInformation.Builder builder =
         SymbolInformation.newBuilder()
-            .setSymbol(ScipSymbols.fromSemanticdbSymbol(semanticdbSymbol))
+            .setSymbol(ScipSymbols.format(symbol))
             .setDisplayName(sym.getSimpleName().toString())
             .setKind(scipKind(sym));
 
-    if (SemanticdbSymbols.isLocal(semanticdbSymbol)) {
-      String enclosingSymbol = semanticdbSymbol(sym.getEnclosingElement());
+    if (SemanticdbSymbols.isLocal(symbol)) {
+      String enclosingSymbol = symbol(sym.getEnclosingElement());
       if (enclosingSymbol != null && !enclosingSymbol.equals(SemanticdbSymbols.NONE)) {
-        builder.setEnclosingSymbol(ScipSymbols.fromSemanticdbSymbol(enclosingSymbol));
+        builder.setEnclosingSymbol(ScipSymbols.format(enclosingSymbol));
       }
     }
 
-    String documentation = semanticdbDocumentation(tree);
+    String documentation = documentation(tree);
     if (documentation != null && !documentation.isEmpty()) {
       builder.addDocumentation(documentation);
     }
@@ -183,12 +183,11 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
         break;
       case METHOD:
         for (String overridden :
-            semanticdbOverrides(
-                (ExecutableElement) sym, sym.getEnclosingElement(), new HashSet<>())) {
+            overrides((ExecutableElement) sym, sym.getEnclosingElement(), new HashSet<>())) {
           if (isIgnoredOverriddenSymbol(overridden)) continue;
           builder.addRelationships(
               Relationship.newBuilder()
-                  .setSymbol(ScipSymbols.fromSemanticdbSymbol(overridden))
+                  .setSymbol(ScipSymbols.format(overridden))
                   .setIsImplementation(true)
                   .setIsReference(supportsReferenceRel));
         }
@@ -215,11 +214,11 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
 
   private void addParentRelationships(
       SymbolInformation.Builder builder, TypeElement sym, boolean supportsReferenceRel) {
-    for (String parent : semanticdbParentSymbols(sym)) {
+    for (String parent : parentSymbols(sym)) {
       if (isIgnoredOverriddenSymbol(parent)) continue;
       builder.addRelationships(
           Relationship.newBuilder()
-              .setSymbol(ScipSymbols.fromSemanticdbSymbol(parent))
+              .setSymbol(ScipSymbols.format(parent))
               .setIsImplementation(true)
               .setIsReference(supportsReferenceRel));
     }
@@ -466,8 +465,8 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
     }
   }
 
-  private String semanticdbSymbol(Element sym) {
-    return globals.semanticdbSymbol(sym, locals);
+  private String symbol(Element sym) {
+    return globals.symbol(sym, locals);
   }
 
   private Optional<ScipRange> scipRangeOf(Tree tree, CompilerRange kind, Element sym, String name) {
@@ -572,11 +571,11 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
     }
   }
 
-  private List<String> semanticdbParentSymbols(TypeElement typeElement) {
+  private List<String> parentSymbols(TypeElement typeElement) {
     ArrayList<String> parentSymbols = new ArrayList<>();
-    Set<TypeElement> parentElements = semanticdbParentTypeElements(typeElement, new HashSet<>());
+    Set<TypeElement> parentElements = parentTypeElements(typeElement, new HashSet<>());
     for (TypeElement parentElement : parentElements) {
-      String ssym = semanticdbSymbol(parentElement);
+      String ssym = symbol(parentElement);
       if (!Objects.equals(ssym, SemanticdbSymbols.NONE)) {
         parentSymbols.add(ssym);
       }
@@ -584,27 +583,26 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
     return parentSymbols;
   }
 
-  private Set<TypeElement> semanticdbParentTypeElements(
-      TypeElement typeElement, Set<TypeElement> result) {
+  private Set<TypeElement> parentTypeElements(TypeElement typeElement, Set<TypeElement> result) {
     TypeMirror superType = typeElement.getSuperclass();
-    semanticdbParentSymbol(superType, result);
+    parentSymbol(superType, result);
     for (TypeMirror interfaceType : typeElement.getInterfaces()) {
-      semanticdbParentSymbol(interfaceType, result);
+      parentSymbol(interfaceType, result);
     }
     return result;
   }
 
-  private void semanticdbParentSymbol(TypeMirror elementType, Set<TypeElement> result) {
+  private void parentSymbol(TypeMirror elementType, Set<TypeElement> result) {
     if (!(elementType instanceof NoType)) {
       Element superElement = types.asElement(elementType);
       if (superElement instanceof TypeElement) {
         result.add((TypeElement) superElement);
-        semanticdbParentTypeElements((TypeElement) superElement, result);
+        parentTypeElements((TypeElement) superElement, result);
       }
     }
   }
 
-  private Set<String> semanticdbOverrides(
+  private Set<String> overrides(
       ExecutableElement sym, Element enclosingElement, Set<String> overriddenSymbols) {
     if (enclosingElement instanceof TypeElement) {
       List<? extends TypeMirror> superTypes = types.directSupertypes(enclosingElement.asType());
@@ -620,15 +618,15 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
                 ExecutableElement enclosedExecutableElement = (ExecutableElement) enclosedElement;
                 if (elements.overrides(
                     sym, enclosedExecutableElement, (TypeElement) sym.getEnclosingElement())) {
-                  String symbol = semanticdbSymbol(enclosedExecutableElement);
+                  String symbol = symbol(enclosedExecutableElement);
                   overriddenSymbols.add(symbol);
                   methodFound = true;
-                  semanticdbOverrides(enclosedExecutableElement, superElement, overriddenSymbols);
+                  overrides(enclosedExecutableElement, superElement, overriddenSymbols);
                 }
               }
             }
             if (!methodFound) {
-              semanticdbOverrides(sym, superElement, overriddenSymbols);
+              overrides(sym, superElement, overriddenSymbols);
             }
           }
         }
@@ -655,7 +653,7 @@ public final class ScipVisitor extends TreePathScanner<Void, Void> {
     return out.toString();
   }
 
-  private String semanticdbDocumentation(Tree tree) {
+  private String documentation(Tree tree) {
     try {
       TreePath treePath = nodes.get(tree);
       String doc = trees.getDocComment(treePath);

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/ScipSymbols.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/ScipSymbols.kt
@@ -1,16 +1,15 @@
 package com.sourcegraph.semanticdb_kotlinc
 
 /**
- * Converts SemanticDB-style symbol strings into the placeholder SCIP form expected by the
- * aggregator: globals are prefixed with [PLACEHOLDER_PREFIX] (rewritten to
- * `scip-java maven <g> <a> <v> <descriptor>` once coordinates are known), locals use the canonical
- * `local N` form and pass through unchanged. Mirrors the Java `ScipSymbols` helper.
+ * Wraps descriptor strings into SCIP symbol strings: globals are prefixed with [PLACEHOLDER_PREFIX]
+ * (rewritten to `scip-java maven <g> <a> <v> <descriptor>` once coordinates are known), locals use
+ * the canonical `local N` form and pass through unchanged. Mirrors the Java `ScipSymbols` helper.
  */
 object ScipSymbols {
 
     const val PLACEHOLDER_PREFIX: String = ". . . . "
 
-    fun fromSemanticdbSymbol(symbol: Symbol): String {
+    fun format(symbol: Symbol): String {
         if (symbol == Symbol.NONE) return ""
         val raw = symbol.toString()
         if (symbol.isLocal()) {

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/ScipTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/ScipTextDocumentBuilder.kt
@@ -74,7 +74,7 @@ class ScipTextDocumentBuilder(
             Occurrence
                 .newBuilder()
                 .addAllRange(scipRange(element))
-                .setSymbol(ScipSymbols.fromSemanticdbSymbol(symbol))
+                .setSymbol(ScipSymbols.format(symbol))
                 .setSymbolRoles(roles)
         if (enclosingSource != null) {
             builder.addAllEnclosingRange(scipEnclosingRange(enclosingSource))
@@ -89,7 +89,7 @@ class ScipTextDocumentBuilder(
         element: KtSourceElement,
         context: CheckerContext,
     ) {
-        val scipSymbolStr = ScipSymbols.fromSemanticdbSymbol(symbol)
+        val scipSymbolStr = ScipSymbols.format(symbol)
         val builder =
             SymbolInformation
                 .newBuilder()
@@ -110,7 +110,7 @@ class ScipTextDocumentBuilder(
 
         val supportsRefRel = supportsReferenceRelationship(firBasedSymbol)
         for (parent in parentOrOverriddenSymbols(firBasedSymbol, context)) {
-            val parentSymbolStr = ScipSymbols.fromSemanticdbSymbol(parent)
+            val parentSymbolStr = ScipSymbols.format(parent)
             if (parentSymbolStr.isEmpty()) continue
             builder.addRelationships(
                 Relationship.newBuilder()

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SymbolsCache.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SymbolsCache.kt
@@ -66,7 +66,7 @@ class GlobalSymbolsCache {
         locals[symbol]?.let {
             return it
         }
-        return uncachedSemanticdbSymbol(symbol, locals).also {
+        return uncachedSymbol(symbol, locals).also {
             if (it.isGlobal()) globals[symbol] = it
         }
     }
@@ -74,7 +74,7 @@ class GlobalSymbolsCache {
         packages[symbol]?.let {
             return it
         }
-        return uncachedSemanticdbSymbol(symbol).also { if (it.isGlobal()) packages[symbol] = it }
+        return uncachedSymbol(symbol).also { if (it.isGlobal()) packages[symbol] = it }
     }
 
     private fun skip(symbol: FirBasedSymbol<*>?): Boolean {
@@ -83,7 +83,7 @@ class GlobalSymbolsCache {
     }
 
     @OptIn(SymbolInternals::class)
-    private fun uncachedSemanticdbSymbol(
+    private fun uncachedSymbol(
         symbol: FirBasedSymbol<*>?,
         locals: LocalSymbolsCache
     ): Symbol {
@@ -95,12 +95,12 @@ class GlobalSymbolsCache {
 
         if (owner.isLocal() || owner == Symbol.NONE) return locals + symbol
 
-        val semanticdbDescriptor = semanticdbDescriptor(symbol)
+        val descriptor = descriptor(symbol)
 
-        return Symbol.createGlobal(owner, semanticdbDescriptor)
+        return Symbol.createGlobal(owner, descriptor)
     }
 
-    private fun uncachedSemanticdbSymbol(symbol: FqName): Symbol {
+    private fun uncachedSymbol(symbol: FqName): Symbol {
         if (symbol.isRoot) return Symbol.ROOT_PACKAGE
 
         val owner = this.getSymbol(symbol.parent())
@@ -139,7 +139,7 @@ class GlobalSymbolsCache {
     }
 
     @OptIn(SymbolInternals::class)
-    private fun semanticdbDescriptor(symbol: FirBasedSymbol<*>): SemanticdbSymbolDescriptor {
+    private fun descriptor(symbol: FirBasedSymbol<*>): SemanticdbSymbolDescriptor {
         return when {
             symbol is FirAnonymousObjectSymbol ->
                 symbol.source?.let { source ->

--- a/tests/unit/src/test/scala/tests/ScipSymbolsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScipSymbolsSuite.scala
@@ -17,18 +17,18 @@ class ScipSymbolsSuite extends FunSuite {
 
   test("global symbol gets placeholder prefix") {
     assertEquals(
-      ScipSymbols.fromSemanticdbSymbol("com/example/Foo#bar()."),
+      ScipSymbols.format("com/example/Foo#bar()."),
       ". . . . com/example/Foo#bar()."
     )
   }
 
   test("local symbol gets canonical SCIP form") {
-    assertEquals(ScipSymbols.fromSemanticdbSymbol("local42"), "local 42")
+    assertEquals(ScipSymbols.format("local42"), "local 42")
   }
 
   test("empty / null symbol stays empty") {
-    assertEquals(ScipSymbols.fromSemanticdbSymbol(""), "")
-    assertEquals(ScipSymbols.fromSemanticdbSymbol(null), "")
+    assertEquals(ScipSymbols.format(""), "")
+    assertEquals(ScipSymbols.format(null), "")
   }
 
   // PackageTable that always returns no package; isolates SymbolRewriter from classpath.


### PR DESCRIPTION
Stacked on #897.

Renames misleading `semanticdb`-prefixed identifiers in the Java/Kotlin indexer code now that we only emit SCIP:

- `ScipSymbols.fromSemanticdbSymbol(String)` → `ScipSymbols.format(String)` (Java + Kotlin)
- `GlobalSymbolsCache.semanticdbSymbol/uncachedSemanticdbSymbol/semanticdbDescriptor` → `symbol/uncachedSymbol/descriptor`
- `SymbolsCache.kt` equivalents
- `ScipVisitor` helpers (`semanticdbParentSymbols`, `semanticdbOverrides`, etc.) lose the prefix
- Local variables `semanticdbSymbol` → `symbol`; docstrings updated accordingly

The shared `SemanticdbSymbols` utility class is **kept** — it encapsulates the symbol grammar SCIP adopted verbatim from SemanticDB, and it is part of the published `com.sourcegraph:semanticdb-java` artifact.

Validated with `sbt --client checkAll` and `sbt --client unit/test`.