### PR TITLE
Share document accumulator between Java/Kotlin plugins

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.semanticdb_javac;
 
 import com.sourcegraph.semanticdb.Semanticdb;
+import com.sourcegraph.semanticdb.SemanticdbDocumentBuilder;
 import com.sourcegraph.semanticdb.SemanticdbPaths;
 import com.sourcegraph.semanticdb.SemanticdbWriter;
 
@@ -12,15 +13,16 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import javax.tools.JavaFileObject;
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Callback hook that generates SemanticDB when the compiler has completed typechecking a Java
@@ -33,6 +35,16 @@ public final class SemanticdbTaskListener implements TaskListener {
   private final Types types;
   private final Trees trees;
   private final Elements elements;
+  // One shared accumulator + local-symbol cache per output path. Javac fires
+  // ANALYZE once per top-level type, so a multi-type source file produces
+  // several ANALYZE events that all target the same SemanticDB file. We
+  // accumulate across rounds so the final document keeps the richest
+  // information from any single round (notably, enclosing_range positions
+  // are only stable in the round that originally analyzed a given type) and
+  // the LocalSymbolsCache is shared so `local 0`, `local 1`, ... keep stable
+  // identities across rounds. See SemanticdbDocumentBuilder for the dedup
+  // policy.
+  private final Map<Path, PerSourceState> perSourceState = new HashMap<>();
   private int noRelativePathCounter = 0;
 
   public SemanticdbTaskListener(
@@ -58,8 +70,10 @@ public final class SemanticdbTaskListener implements TaskListener {
       inferBazelSourceroot(e.getSourceFile());
       Result<Path, String> semanticdbPath = semanticdbOutputPath(options, e);
       if (semanticdbPath.isOk()) {
+        Path output = semanticdbPath.getOrThrow();
+        perSourceState.remove(output);
         try {
-          Files.deleteIfExists(semanticdbPath.getOrThrow());
+          Files.deleteIfExists(output);
         } catch (IOException ex) {
           this.reportException(ex, e);
         }
@@ -116,12 +130,20 @@ public final class SemanticdbTaskListener implements TaskListener {
     Result<Path, String> path = semanticdbOutputPath(options, e);
     if (path != null) {
       if (path.isOk()) {
-        Semanticdb.TextDocument textDocument =
-            new SemanticdbVisitor(globals, e.getCompilationUnit(), options, types, trees, elements)
-                .buildTextDocument(e.getCompilationUnit());
         Path output = path.getOrThrow();
-        if (Files.exists(output)) appendSemanticdb(e, output, textDocument);
-        else writeSemanticdb(e, output, textDocument);
+        PerSourceState state = perSourceState.computeIfAbsent(output, k -> new PerSourceState());
+        Semanticdb.TextDocument textDocument =
+            new SemanticdbVisitor(
+                    globals,
+                    state.locals,
+                    e.getCompilationUnit(),
+                    options,
+                    types,
+                    trees,
+                    elements,
+                    state.documentBuilder)
+                .buildTextDocument(e.getCompilationUnit());
+        writeSemanticdb(e, output, textDocument);
       } else {
         reporter.error(path.getErrorOrThrow(), e);
       }
@@ -136,76 +158,10 @@ public final class SemanticdbTaskListener implements TaskListener {
     }
   }
 
-  private void appendSemanticdb(
-      TaskEvent event, Path output, Semanticdb.TextDocument textDocument) {
-    /*
-     * If there already is a semanticdb file at the given path,
-     * we do the following:
-     * - Read a documents collection
-     * - Try to find the document with the matching relative path (matching the incoming textDocument)
-     * - Then, depending on whether a matching document already exists in the collection:
-     *   - if YES, mutate it in place to only add entries from the incoming document
-     *   - if NO, simply add the incoming text document to the collection
-     * - Write the collection back to disk
-     * */
-    Semanticdb.TextDocument document = null;
-    int documentIndex = -1;
-    Semanticdb.TextDocuments documents = null;
-
-    try (InputStream is = Files.newInputStream(output.toFile().toPath())) {
-      documents = Semanticdb.TextDocuments.parseFrom(is);
-
-      for (int i = 0; i < documents.getDocumentsCount(); i++) {
-        Semanticdb.TextDocument candidate = documents.getDocuments(i);
-        if (document == null && candidate.getUri().equals(textDocument.getUri())) {
-          document = candidate;
-          documentIndex = i;
-        }
-      }
-
-    } catch (IOException e) {
-      this.reportException(e, event);
-      return;
-    }
-
-    if (document != null) {
-      // If there is a previous semanticdb document at this path, we need
-      // to deduplicate symbols and occurrences and mutate the document in place
-      Set<Semanticdb.SymbolInformation> symbols = new HashSet<>(textDocument.getSymbolsList());
-      Set<Semanticdb.SymbolOccurrence> occurrences =
-          new HashSet<>(textDocument.getOccurrencesList());
-      Set<Semanticdb.Synthetic> synthetics = new HashSet<>(textDocument.getSyntheticsList());
-
-      symbols.addAll(document.getSymbolsList());
-      occurrences.addAll(document.getOccurrencesList());
-      synthetics.addAll(document.getSyntheticsList());
-
-      documents
-          .toBuilder()
-          .addDocuments(
-              documentIndex,
-              document
-                  .toBuilder()
-                  .clearOccurrences()
-                  .addAllOccurrences(occurrences)
-                  .clearSymbols()
-                  .addAllSymbols(symbols)
-                  .clearSynthetics()
-                  .addAllSynthetics(synthetics));
-
-    } else {
-      // If no prior document was found, we can just add the incoming one to the collection
-      documents = documents.toBuilder().addDocuments(textDocument).build();
-    }
-
-    byte[] bytes = documents.toByteArray();
-
-    try {
-      Files.createDirectories(output.getParent());
-      Files.write(output, bytes);
-    } catch (IOException e) {
-      this.reportException(e, event);
-    }
+  /** Per-source-file state that survives across all ANALYZE rounds for that source. */
+  private static final class PerSourceState {
+    final SemanticdbDocumentBuilder documentBuilder = new SemanticdbDocumentBuilder();
+    final LocalSymbolsCache locals = new LocalSymbolsCache();
   }
 
   public static Path absolutePathFromUri(SemanticdbJavacOptions options, JavaFileObject file) {

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -35,15 +35,7 @@ public final class SemanticdbTaskListener implements TaskListener {
   private final Types types;
   private final Trees trees;
   private final Elements elements;
-  // One shared accumulator + local-symbol cache per output path. Javac fires
-  // ANALYZE once per top-level type, so a multi-type source file produces
-  // several ANALYZE events that all target the same SemanticDB file. We
-  // accumulate across rounds so the final document keeps the richest
-  // information from any single round (notably, enclosing_range positions
-  // are only stable in the round that originally analyzed a given type) and
-  // the LocalSymbolsCache is shared so `local 0`, `local 1`, ... keep stable
-  // identities across rounds. See SemanticdbDocumentBuilder for the dedup
-  // policy.
+  // Javac fires ANALYZE once per top-level type; accumulate across rounds per output path.
   private final Map<Path, PerSourceState> perSourceState = new HashMap<>();
   private int noRelativePathCounter = 0;
 
@@ -158,7 +150,6 @@ public final class SemanticdbTaskListener implements TaskListener {
     }
   }
 
-  /** Per-source-file state that survives across all ANALYZE rounds for that source. */
   private static final class PerSourceState {
     final SemanticdbDocumentBuilder documentBuilder = new SemanticdbDocumentBuilder();
     final LocalSymbolsCache locals = new LocalSymbolsCache();

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -70,7 +70,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   private final CompilationUnitTree compUnitTree;
   private final Elements elements;
   private final SemanticdbJavacOptions options;
-  private final SemanticdbDocumentBuilder documentBuilder = new SemanticdbDocumentBuilder();
+  private final SemanticdbDocumentBuilder documentBuilder;
   private String source;
   private String uri;
 
@@ -78,18 +78,24 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
   public SemanticdbVisitor(
       GlobalSymbolsCache globals,
+      LocalSymbolsCache locals,
       CompilationUnitTree compUnitTree,
       SemanticdbJavacOptions options,
       Types types,
       Trees trees,
-      Elements elements) {
+      Elements elements,
+      SemanticdbDocumentBuilder documentBuilder) {
     this.globals = globals; // Reused cache between compilation units.
-    this.locals = new LocalSymbolsCache(); // Fresh cache per compilation unit.
+    // Reused across all ANALYZE rounds for the same source so that local
+    // symbols (`local 0`, `local 1`, ...) keep stable identities even when
+    // javac fires several ANALYZE events for a multi-type source file.
+    this.locals = locals;
     this.options = options;
     this.types = types;
     this.elements = elements;
     this.trees = trees;
     this.compUnitTree = compUnitTree;
+    this.documentBuilder = documentBuilder;
     this.source = semanticdbText();
     this.uri = semanticdbUri(compUnitTree, options);
     this.nodes = new LinkedHashMap<>();
@@ -101,10 +107,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     resolveNodes();
 
     return documentBuilder.build(
-        Semanticdb.Language.JAVA,
-        uri,
-        options.includeText ? this.source : "",
-        semanticdbMd5());
+        Semanticdb.Language.JAVA, uri, options.includeText ? this.source : "", semanticdbMd5());
   }
 
   private Optional<Semanticdb.Range> emitSymbolOccurrence(

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -2,6 +2,7 @@ package com.sourcegraph.semanticdb_javac;
 
 import com.sourcegraph.semanticdb.Semanticdb;
 
+import com.sourcegraph.semanticdb.SemanticdbDocumentBuilder;
 import com.sourcegraph.semanticdb.SemanticdbPaths;
 import com.sourcegraph.semanticdb.SemanticdbSymbols;
 
@@ -69,8 +70,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
   private final CompilationUnitTree compUnitTree;
   private final Elements elements;
   private final SemanticdbJavacOptions options;
-  private final ArrayList<Semanticdb.SymbolOccurrence> occurrences;
-  private final ArrayList<Semanticdb.SymbolInformation> symbolInfos;
+  private final SemanticdbDocumentBuilder documentBuilder = new SemanticdbDocumentBuilder();
   private String source;
   private String uri;
 
@@ -90,8 +90,6 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     this.elements = elements;
     this.trees = trees;
     this.compUnitTree = compUnitTree;
-    this.occurrences = new ArrayList<>();
-    this.symbolInfos = new ArrayList<>();
     this.source = semanticdbText();
     this.uri = semanticdbUri(compUnitTree, options);
     this.nodes = new LinkedHashMap<>();
@@ -102,15 +100,11 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
     resolveNodes();
 
-    return Semanticdb.TextDocument.newBuilder()
-        .setSchema(Semanticdb.Schema.SEMANTICDB4)
-        .setLanguage(Semanticdb.Language.JAVA)
-        .setUri(uri)
-        .setText(options.includeText ? this.source : "")
-        .setMd5(semanticdbMd5())
-        .addAllOccurrences(occurrences)
-        .addAllSymbols(symbolInfos)
-        .build();
+    return documentBuilder.build(
+        Semanticdb.Language.JAVA,
+        uri,
+        options.includeText ? this.source : "",
+        semanticdbMd5());
   }
 
   private Optional<Semanticdb.Range> emitSymbolOccurrence(
@@ -135,7 +129,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
     if (sym == null) return;
     Optional<Semanticdb.SymbolOccurrence> occ =
         semanticdbOccurrence(sym, range, role, enclosingRange);
-    occ.ifPresent(occurrences::add);
+    occ.ifPresent(documentBuilder::addOccurrence);
   }
 
   private void emitSymbolInformation(Element sym, Tree tree) {
@@ -201,7 +195,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
     Semanticdb.SymbolInformation info = builder.build();
 
-    symbolInfos.add(info);
+    documentBuilder.addSymbol(info);
   }
 
   void resolveNodes() {

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -85,10 +85,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
       Trees trees,
       Elements elements,
       SemanticdbDocumentBuilder documentBuilder) {
-    this.globals = globals; // Reused cache between compilation units.
-    // Reused across all ANALYZE rounds for the same source so that local
-    // symbols (`local 0`, `local 1`, ...) keep stable identities even when
-    // javac fires several ANALYZE events for a multi-type source file.
+    this.globals = globals;
     this.locals = locals;
     this.options = options;
     this.types = types;

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.semanticdb_kotlinc
 import com.sourcegraph.semanticdb.Semanticdb
 
 import com.sourcegraph.semanticdb.Semanticdb.SymbolOccurrence.Role
+import com.sourcegraph.semanticdb.SemanticdbDocumentBuilder
 import com.sourcegraph.semanticdb.SemanticdbPaths
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -33,21 +34,12 @@ class SemanticdbTextDocumentBuilder(
     private val lineMap: LineMap,
     private val cache: SymbolsCache,
 ) {
-    private val occurrences = mutableListOf<Semanticdb.SymbolOccurrence>()
-    private val symbols = mutableListOf<Semanticdb.SymbolInformation>()
+    private val documentBuilder = SemanticdbDocumentBuilder()
     private val fileText = file.getContentsAsStream().reader().readText()
     private val semanticMd5 = semanticdbMD5()
 
-    fun build() = TextDocument {
-        this.text = fileText
-        this.uri = semanticdbURI()
-        this.md5 = semanticMd5
-        this.schema = Semanticdb.Schema.SEMANTICDB4
-        this.language = Semanticdb.Language.KOTLIN
-        occurrences.sortWith(compareBy({ it.range.startLine }, { it.range.startCharacter }))
-        this.addAllOccurrences(occurrences)
-        this.addAllSymbols(symbols)
-    }
+    fun build(): Semanticdb.TextDocument =
+        documentBuilder.build(Semanticdb.Language.KOTLIN, semanticdbURI(), fileText, semanticMd5)
 
     fun emitSemanticdbData(
         firBasedSymbol: FirBasedSymbol<*>?,
@@ -57,14 +49,10 @@ class SemanticdbTextDocumentBuilder(
         context: CheckerContext,
         enclosingSource: KtSourceElement? = null,
     ) {
-        symbolOccurrence(symbol, element, role, enclosingSource).let {
-            if (!occurrences.contains(it)) {
-                occurrences.add(it)
-            }
+        documentBuilder.addOccurrence(symbolOccurrence(symbol, element, role, enclosingSource))
+        if (role == Role.DEFINITION) {
+            documentBuilder.addSymbol(symbolInformation(firBasedSymbol, symbol, element, context))
         }
-        val symbolInformation = symbolInformation(firBasedSymbol, symbol, element, context)
-        if (role == Role.DEFINITION && !symbols.contains(symbolInformation))
-            symbols.add(symbolInformation)
     }
 
     @OptIn(SymbolInternals::class)

--- a/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
+++ b/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
@@ -1,0 +1,71 @@
+package com.sourcegraph.semanticdb;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Accumulator for the {@link Semanticdb.SymbolOccurrence} and {@link Semanticdb.SymbolInformation}
+ * payloads produced by a single SemanticDB-emitting compiler plugin, and assembler for the final
+ * {@link Semanticdb.TextDocument}.
+ *
+ * <p>The builder enforces the canonical SemanticDB output policy shared by every producer in this
+ * repository:
+ *
+ * <ul>
+ *   <li>exact-duplicate {@link Semanticdb.SymbolOccurrence}s and {@link
+ *       Semanticdb.SymbolInformation}s are suppressed,
+ *   <li>occurrences are sorted by {@code (startLine, startCharacter)} before being written to the
+ *       assembled {@link Semanticdb.TextDocument},
+ *   <li>the assembled document is stamped with {@link Semanticdb.Schema#SEMANTICDB4} and the
+ *       caller-supplied {@link Semanticdb.Language}.
+ * </ul>
+ *
+ * <p>Compiler-specific concerns (AST traversal, symbol resolution, range computation, text/MD5
+ * acquisition, language selection) stay in the plugins; this class is intentionally protobuf-only
+ * and contains no compiler-API dependencies.
+ */
+public final class SemanticdbDocumentBuilder {
+  private static final Comparator<Semanticdb.SymbolOccurrence> OCCURRENCE_ORDER =
+      Comparator.<Semanticdb.SymbolOccurrence>comparingInt(o -> o.getRange().getStartLine())
+          .thenComparingInt(o -> o.getRange().getStartCharacter());
+
+  private final List<Semanticdb.SymbolOccurrence> occurrences = new ArrayList<>();
+  private final List<Semanticdb.SymbolInformation> symbols = new ArrayList<>();
+  private final Set<Semanticdb.SymbolOccurrence> seenOccurrences = new HashSet<>();
+  private final Set<Semanticdb.SymbolInformation> seenSymbols = new HashSet<>();
+
+  /** Adds an occurrence to the document, suppressing exact duplicates. */
+  public void addOccurrence(Semanticdb.SymbolOccurrence occurrence) {
+    if (seenOccurrences.add(occurrence)) {
+      occurrences.add(occurrence);
+    }
+  }
+
+  /** Adds a symbol information entry to the document, suppressing exact duplicates. */
+  public void addSymbol(Semanticdb.SymbolInformation symbol) {
+    if (seenSymbols.add(symbol)) {
+      symbols.add(symbol);
+    }
+  }
+
+  /**
+   * Assembles a {@link Semanticdb.TextDocument} carrying the accumulated occurrences (sorted by
+   * range) and symbol informations.
+   */
+  public Semanticdb.TextDocument build(
+      Semanticdb.Language language, String uri, String text, String md5) {
+    occurrences.sort(OCCURRENCE_ORDER);
+    return Semanticdb.TextDocument.newBuilder()
+        .setSchema(Semanticdb.Schema.SEMANTICDB4)
+        .setLanguage(language)
+        .setUri(uri)
+        .setText(text)
+        .setMd5(md5)
+        .addAllOccurrences(occurrences)
+        .addAllSymbols(symbols)
+        .build();
+  }
+}

--- a/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
+++ b/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
@@ -2,21 +2,28 @@ package com.sourcegraph.semanticdb;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Accumulator for the {@link Semanticdb.SymbolOccurrence} and {@link Semanticdb.SymbolInformation}
- * payloads produced by a single SemanticDB-emitting compiler plugin, and assembler for the final
- * {@link Semanticdb.TextDocument}.
+ * payloads produced by a SemanticDB-emitting compiler plugin, and assembler for the final {@link
+ * Semanticdb.TextDocument}.
  *
  * <p>The builder enforces the canonical SemanticDB output policy shared by every producer in this
  * repository:
  *
  * <ul>
- *   <li>exact-duplicate {@link Semanticdb.SymbolOccurrence}s and {@link
- *       Semanticdb.SymbolInformation}s are suppressed,
+ *   <li>occurrences are deduplicated by {@code (range, symbol, role)} — additional fields like
+ *       {@code enclosing_range} are not part of identity, so a later emission that happens to lose
+ *       the enclosing range does not introduce a "duplicate" occurrence,
+ *   <li>{@link Semanticdb.SymbolInformation}s are deduplicated by {@code symbol},
+ *   <li>in both cases the first emission wins, which lets multi-pass producers (e.g. the javac
+ *       plugin, which scans the same compilation unit on every {@code ANALYZE} round and where only
+ *       the first round has complete position information for already-attributed types) accumulate
+ *       across rounds without losing data,
  *   <li>occurrences are sorted by {@code (startLine, startCharacter)} before being written to the
  *       assembled {@link Semanticdb.TextDocument},
  *   <li>the assembled document is stamped with {@link Semanticdb.Schema#SEMANTICDB4} and the
@@ -32,23 +39,20 @@ public final class SemanticdbDocumentBuilder {
       Comparator.<Semanticdb.SymbolOccurrence>comparingInt(o -> o.getRange().getStartLine())
           .thenComparingInt(o -> o.getRange().getStartCharacter());
 
-  private final List<Semanticdb.SymbolOccurrence> occurrences = new ArrayList<>();
-  private final List<Semanticdb.SymbolInformation> symbols = new ArrayList<>();
-  private final Set<Semanticdb.SymbolOccurrence> seenOccurrences = new HashSet<>();
-  private final Set<Semanticdb.SymbolInformation> seenSymbols = new HashSet<>();
+  private final Map<OccurrenceKey, Semanticdb.SymbolOccurrence> occurrences = new LinkedHashMap<>();
+  private final Map<String, Semanticdb.SymbolInformation> symbols = new LinkedHashMap<>();
 
-  /** Adds an occurrence to the document, suppressing exact duplicates. */
+  /**
+   * Adds an occurrence, keeping the first emission for any given {@code (range, symbol, role)}
+   * triple.
+   */
   public void addOccurrence(Semanticdb.SymbolOccurrence occurrence) {
-    if (seenOccurrences.add(occurrence)) {
-      occurrences.add(occurrence);
-    }
+    occurrences.putIfAbsent(new OccurrenceKey(occurrence), occurrence);
   }
 
-  /** Adds a symbol information entry to the document, suppressing exact duplicates. */
+  /** Adds a symbol information entry, keeping the first emission per {@code symbol}. */
   public void addSymbol(Semanticdb.SymbolInformation symbol) {
-    if (seenSymbols.add(symbol)) {
-      symbols.add(symbol);
-    }
+    symbols.putIfAbsent(symbol.getSymbol(), symbol);
   }
 
   /**
@@ -57,15 +61,43 @@ public final class SemanticdbDocumentBuilder {
    */
   public Semanticdb.TextDocument build(
       Semanticdb.Language language, String uri, String text, String md5) {
-    occurrences.sort(OCCURRENCE_ORDER);
+    List<Semanticdb.SymbolOccurrence> sortedOccurrences = new ArrayList<>(occurrences.values());
+    sortedOccurrences.sort(OCCURRENCE_ORDER);
     return Semanticdb.TextDocument.newBuilder()
         .setSchema(Semanticdb.Schema.SEMANTICDB4)
         .setLanguage(language)
         .setUri(uri)
         .setText(text)
         .setMd5(md5)
-        .addAllOccurrences(occurrences)
-        .addAllSymbols(symbols)
+        .addAllOccurrences(sortedOccurrences)
+        .addAllSymbols(symbols.values())
         .build();
+  }
+
+  private static final class OccurrenceKey {
+    private final Semanticdb.Range range;
+    private final String symbol;
+    private final Semanticdb.SymbolOccurrence.Role role;
+
+    OccurrenceKey(Semanticdb.SymbolOccurrence occurrence) {
+      this.range = occurrence.hasRange() ? occurrence.getRange() : null;
+      this.symbol = occurrence.getSymbol();
+      this.role = occurrence.getRole();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other instanceof OccurrenceKey)) return false;
+      OccurrenceKey that = (OccurrenceKey) other;
+      return role == that.role
+          && Objects.equals(range, that.range)
+          && Objects.equals(symbol, that.symbol);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(range, symbol, role);
+    }
   }
 }

--- a/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
+++ b/semanticdb-shared/src/main/java/com/sourcegraph/semanticdb/SemanticdbDocumentBuilder.java
@@ -8,31 +8,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Accumulator for the {@link Semanticdb.SymbolOccurrence} and {@link Semanticdb.SymbolInformation}
- * payloads produced by a SemanticDB-emitting compiler plugin, and assembler for the final {@link
- * Semanticdb.TextDocument}.
- *
- * <p>The builder enforces the canonical SemanticDB output policy shared by every producer in this
- * repository:
- *
- * <ul>
- *   <li>occurrences are deduplicated by {@code (range, symbol, role)} — additional fields like
- *       {@code enclosing_range} are not part of identity, so a later emission that happens to lose
- *       the enclosing range does not introduce a "duplicate" occurrence,
- *   <li>{@link Semanticdb.SymbolInformation}s are deduplicated by {@code symbol},
- *   <li>in both cases the first emission wins, which lets multi-pass producers (e.g. the javac
- *       plugin, which scans the same compilation unit on every {@code ANALYZE} round and where only
- *       the first round has complete position information for already-attributed types) accumulate
- *       across rounds without losing data,
- *   <li>occurrences are sorted by {@code (startLine, startCharacter)} before being written to the
- *       assembled {@link Semanticdb.TextDocument},
- *   <li>the assembled document is stamped with {@link Semanticdb.Schema#SEMANTICDB4} and the
- *       caller-supplied {@link Semanticdb.Language}.
- * </ul>
- *
- * <p>Compiler-specific concerns (AST traversal, symbol resolution, range computation, text/MD5
- * acquisition, language selection) stay in the plugins; this class is intentionally protobuf-only
- * and contains no compiler-API dependencies.
+ * Accumulator for {@link Semanticdb.SymbolOccurrence}/{@link Semanticdb.SymbolInformation} that
+ * assembles a final {@link Semanticdb.TextDocument}. First emission wins: occurrences are
+ * deduplicated by {@code (range, symbol, role)}, symbols by {@code symbol}; occurrences are sorted
+ * by start position. Contains no compiler-API dependencies.
  */
 public final class SemanticdbDocumentBuilder {
   private static final Comparator<Semanticdb.SymbolOccurrence> OCCURRENCE_ORDER =
@@ -42,23 +21,14 @@ public final class SemanticdbDocumentBuilder {
   private final Map<OccurrenceKey, Semanticdb.SymbolOccurrence> occurrences = new LinkedHashMap<>();
   private final Map<String, Semanticdb.SymbolInformation> symbols = new LinkedHashMap<>();
 
-  /**
-   * Adds an occurrence, keeping the first emission for any given {@code (range, symbol, role)}
-   * triple.
-   */
   public void addOccurrence(Semanticdb.SymbolOccurrence occurrence) {
     occurrences.putIfAbsent(new OccurrenceKey(occurrence), occurrence);
   }
 
-  /** Adds a symbol information entry, keeping the first emission per {@code symbol}. */
   public void addSymbol(Semanticdb.SymbolInformation symbol) {
     symbols.putIfAbsent(symbol.getSymbol(), symbol);
   }
 
-  /**
-   * Assembles a {@link Semanticdb.TextDocument} carrying the accumulated occurrences (sorted by
-   * range) and symbol informations.
-   */
   public Semanticdb.TextDocument build(
       Semanticdb.Language language, String uri, String text, String md5) {
     List<Semanticdb.SymbolOccurrence> sortedOccurrences = new ArrayList<>(occurrences.values());

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/LombokBuilder.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/LombokBuilder.java
@@ -15,48 +15,14 @@
 //^^^^^^^^^^^^^^^ reference local 0
 //^^^^^^^^^^^^^^^ reference local 1
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . java/lang/
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#HelloBuilder#
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#HelloBuilder#
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#HelloBuilder#message.
-//^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#HelloBuilder#message.
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#HelloBuilder#message.
 //^^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/Hello#message.
 //^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/Override#
 //^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
 //^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
-//^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#value().
 //^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#value().
 // ^^^^^ reference semanticdb maven . . lombok/
 //        ^^^^^^^ reference semanticdb maven . . lombok/Builder#


### PR DESCRIPTION
Unifies SemanticDB output across javac and kotlinc via a shared `SemanticdbDocumentBuilder` and per-source accumulator.

- Javac visitor now uses the same builder/dedup policy as kotlinc.
- Per-source state (builder + `LocalSymbolsCache`) survives across javac's multi-ANALYZE rounds for multi-type source files.
- Replaces buggy on-disk `appendSemanticdb` merge (which silently discarded later rounds and shifted local IDs).
- One `LombokBuilder` snapshot churns: 10× duplicate refs are now deduped to 1×.