### PR TITLE
Upgrade nixpkgs to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
       url = "github:numtide/flake-utils";
     };
     nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-25.11";
+      url = "github:NixOS/nixpkgs/nixos-26.05";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,12 +70,19 @@
           '';
         };
 
-        devShells = {
-          default = mkDevShell pkgs.jdk11;
-          jdk11 = mkDevShell pkgs.jdk11;
-          jdk17 = mkDevShell pkgs.jdk17;
-          jdk21 = mkDevShell pkgs.jdk21;
-        };
+        devShells =
+          let
+            # The source-built openjdk 11 segfaults at runtime (UB in markOop
+            # exposed by the toolchain in nixpkgs 26.05), so use the prebuilt
+            # Temurin binary instead. See NixOS/nixpkgs#526834.
+            jdk11 = pkgs.temurin-bin-11;
+          in
+          {
+            default = mkDevShell jdk11;
+            jdk11 = mkDevShell jdk11;
+            jdk17 = mkDevShell pkgs.jdk17;
+            jdk21 = mkDevShell pkgs.jdk21;
+          };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -70,19 +70,13 @@
           '';
         };
 
-        devShells =
-          let
-            # The source-built openjdk 11 segfaults at runtime (UB in markOop
-            # exposed by the toolchain in nixpkgs 26.05), so use the prebuilt
-            # Temurin binary instead. See NixOS/nixpkgs#526834.
-            jdk11 = pkgs.temurin-bin-11;
-          in
-          {
-            default = mkDevShell jdk11;
-            jdk11 = mkDevShell jdk11;
-            jdk17 = mkDevShell pkgs.jdk17;
-            jdk21 = mkDevShell pkgs.jdk21;
-          };
+        devShells = {
+          default = mkDevShell pkgs.temurin-bin-11;
+          # https://github.com/NixOS/nixpkgs/issues/526834
+          jdk11 = mkDevShell pkgs.temurin-bin-11;
+          jdk17 = mkDevShell pkgs.jdk17;
+          jdk21 = mkDevShell pkgs.jdk21;
+        };
       }
     );
 }


### PR DESCRIPTION
Upgrades the `nixpkgs` flake input from `nixos-25.11` to `nixos-26.05`.