### PR TITLE
Drop sourcegraph.github.io references from source files

### DIFF
--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
@@ -73,8 +73,7 @@ public class ScipAggregator {
               + " index this codebase. If you are using Gradle or Maven, please report an issue to"
               + " https://github.com/sourcegraph/scip-java and include steps to reproduce. If you"
               + " are using a different build tool, make sure that you have followed all of the"
-              + " steps from"
-              + " https://sourcegraph.github.io/scip-java/docs/manual-configuration.html");
+              + " manual configuration steps.");
       return;
     }
     options.reporter.startProcessing(shards.size());

--- a/scip-gradle-plugin/src/main/java/com/sourcegraph/gradle/scip/WriteDependencies.java
+++ b/scip-gradle-plugin/src/main/java/com/sourcegraph/gradle/scip/WriteDependencies.java
@@ -22,9 +22,7 @@ public class WriteDependencies extends DefaultTask {
       "This will not prevent a SCIP index from being created, but the symbols\n"
           + "extracted from this project won't be available for cross-repository navigation,\n"
           + "as this project doesn't define any Maven coordinates by which it can be referred back"
-          + " to.\n"
-          + "See here for more details:"
-          + " https://sourcegraph.github.io/scip-java/docs/manual-configuration.html#step-5-optional-enable-cross-repository-navigation";
+          + " to.";
 
   @TaskAction
   public void printResolvedDependencies() throws IOException {

--- a/scip-maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/scip-maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -46,9 +46,7 @@ public class DependencyWriterMojo extends AbstractMojo {
                   + "extracted from this project won't be available for cross-repository"
                   + " navigation,\n"
                   + "as this project doesn't define any Maven coordinates by which it can be"
-                  + " referred back to.\n"
-                  + "See here for more details:"
-                  + " https://sourcegraph.github.io/scip-java/docs/manual-configuration.html#step-5-optional-enable-cross-repository-navigation\n");
+                  + " referred back to.\n");
     } else {
       for (Object root : sourceRoots) {
         if (root instanceof String) {


### PR DESCRIPTION
Removes `sourcegraph.github.io` references from non-markdown source files.