### PR TITLE
Skip signing Maven snapshots

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -21,8 +21,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SECRET }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}
       - name: Publish release ${{ github.ref }}
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |


### PR DESCRIPTION
Fix snapshot publishing after the Gradle migration by only passing PGP signing secrets for tagged releases.