### PR TITLE
Add Java 25 support

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -122,6 +122,64 @@ jobs:
       - name: scip-kotlinc tests
         run: gradle :scip-kotlinc:test --no-daemon
 
+  jdk25-plugin:
+    runs-on: ubuntu-latest
+    name: scip-javac plugin (JDK 25)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          summarize: false
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      # The plugin jar targets `--release 11`, so it is built with the default
+      # toolchain (Gradle 8.14 cannot run on JDK 25) and then exercised against a
+      # JDK 25 `javac` below.
+      - name: Build scip-javac plugin jar
+        run: gradle :scip-javac:shadowJar --no-daemon
+
+      - name: Index a fixture with JDK 25 javac
+        env:
+          NIX_DEVELOP: ${{ github.workspace }}#jdk25
+        run: |
+          java -version
+          javac -version
+          shopt -s nullglob
+          jars=(scip-javac/target/gradle/libs/scip-javac-*-all.jar)
+          if [ "${#jars[@]}" -eq 0 ]; then
+            echo "scip-javac shadow jar not found" >&2
+            exit 1
+          fi
+          jar="${jars[0]}"
+          work="$(mktemp -d)"
+          mkdir -p "$work/src" "$work/out" "$work/classes"
+          printf '%s\n' \
+            'public class Hello {' \
+            '  public static void main(String[] args) {' \
+            '    System.out.println("hello from JDK 25");' \
+            '  }' \
+            '}' > "$work/src/Hello.java"
+          javac \
+            -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+            -J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+            -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+            -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+            -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+            -cp "$jar" \
+            -processorpath "$jar" \
+            -d "$work/classes" \
+            "-Xplugin:scip -sourceroot:$work/src -targetroot:$work/out" \
+            "$work/src/Hello.java"
+          shards=("$work"/out/META-INF/scip/*.scip)
+          if [ "${#shards[@]}" -eq 0 ]; then
+            echo "no SCIP shard produced under $work/out" >&2
+            find "$work/out" -type f >&2 || true
+            exit 1
+          fi
+          echo "SCIP shard generated: ${shards[0]}"
+
   snapshots:
     runs-on: ubuntu-latest
     name: Snapshots

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -16,7 +16,7 @@ rm gradle.zip
 mv /opt/gradle/*/* /opt/gradle
 
 # pre-install JDK for all major versions
-for JVM_VERSION in 21 17 11
+for JVM_VERSION in 25 21 17 11
 do 
   coursier java --jvm $JVM_VERSION --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json -- -version
 done

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,8 @@ finished indexing the project.
 
 > The `sourcegraph/scip-java` Docker image is made available for convenience at
 > the cost of performance. The `sourcegraph/scip-java` image is a big download
-> because it includes pre-installed versions of Java 11, Java 17, and Java 21.
+> because it includes pre-installed versions of Java 11, Java 17, Java 21, and
+> Java 25.
 > The `sourcegraph/scip-java` image has slow performance because it needs to
 > download all external dependencies of your codebase on every invocation.
 >
@@ -54,6 +55,9 @@ docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest 
 
 # Java 21
 docker run -v $(pwd):/sources --env JVM_VERSION=21 sourcegraph/scip-java:latest scip-java index
+
+# Java 25
+docker run -v $(pwd):/sources --env JVM_VERSION=25 sourcegraph/scip-java:latest scip-java index
 
 ```
 
@@ -207,6 +211,7 @@ of Java versions.
 | Java 11      | ✅                           |                |
 | Java 17      | ✅, requires `--add-exports` |                |
 | Java 21      | ✅, requires `--add-exports` |                |
+| Java 25      | ✅, requires `--add-exports` |                |
 
 For Java 17 and newer versions, the following JVM options are required:
 

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
           jdk11 = mkDevShell pkgs.temurin-bin-11;
           jdk17 = mkDevShell pkgs.jdk17;
           jdk21 = mkDevShell pkgs.jdk21;
+          jdk25 = mkDevShell pkgs.jdk25;
         };
       }
     );


### PR DESCRIPTION
Adds Java 25 to the supported JDKs.

- `jdk25` nix dev shell
- Pre-install JDK 25 in the Docker image (`JVM_VERSION=25`)
- New `jdk25-plugin` CI job: builds the plugin jar (`--release 11`) and runs it under a JDK 25 `javac`, asserting a SCIP shard is produced
- Docs

The plugin uses the public Compiler Tree API, so the `--release 11` jar runs unchanged on JDK 25. The Gradle/Maven test matrices stay on 11/17/21 because Gradle 8.14 cannot run on JDK 25 (that needs the separate Gradle 9 / Shadow migration).