### PR TITLE
Drop support for Java 11 and modernize

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+common --java_language_version=17
+common --tool_java_language_version=17
+common --java_runtime_version=remotejdk_21
+common --tool_java_runtime_version=remotejdk_21

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v4
 
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/repos.yaml
+++ b/.github/workflows/repos.yaml
@@ -56,16 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: gradle-java11-pusher
-            repository: pusher/pusher-http-java
-            ref: 94f25a2848e5939cf27dafad8ed25aeaa2d83274
-            directory: .
-            build_tool: gradle
-            build_command: ""
-            java: 11
-            bazel_version: ""
-            covers: Gradle, Java project target 11, Java 11 runtime
-
           - name: maven-java17-spring-boot
             repository: spring-guides/gs-spring-boot
             ref: 2ffad4f418c3052b534184228a45d062f566096f
@@ -75,16 +65,6 @@ jobs:
             java: 17
             bazel_version: ""
             covers: Maven, Java project target 17, Java 17 runtime
-
-          - name: maven-java11-wagon-multimodule
-            repository: apache/maven-wagon
-            ref: 20b847446bb60f49af0428d592eadee774b5bff2
-            directory: .
-            build_tool: maven
-            build_command: "-DskipTests compile"
-            java: 11
-            bazel_version: ""
-            covers: Maven, multi-module Java, Java 11 runtime
 
           - name: maven-kotlin-json-kotlin-maven
             repository: pwall567/json-kotlin-maven
@@ -107,16 +87,6 @@ jobs:
             java: 21
             bazel_version: ""
             covers: Gradle, Java project target 21, Java 21 runtime
-
-          - name: gradle-java11-mapstruct-lombok
-            repository: mapstruct/mapstruct-examples
-            ref: 3f9fd5ffe9e2272b6219a4216e842f8c009d1005
-            directory: mapstruct-lombok
-            build_tool: gradle
-            build_command: "compileJava"
-            java: 11
-            bazel_version: ""
-            covers: Gradle, Java annotation processors, Lombok, MapStruct, generated sources, Java 11 runtime
 
           - name: gradle-kotlin-okio
             repository: square/okio

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ scip-snapshots/META-INF/
 # writes META-INF/scip/sources/Test.kt.scip relative to the test
 # cwd.
 scip-kotlinc/META-INF/
+
+/.kotlin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The recommended way to get a working development environment is via
 [Nix](https://nixos.org/download) and the provided [flake](https://github.com/sourcegraph/scip-java/blob/main/flake.nix):
 
 ```sh
-nix develop              # default shell (JDK 11)
+nix develop              # default shell (JDK 17)
 nix develop .#jdk17      # JDK 17
 nix develop .#jdk21      # JDK 21
 ```
@@ -19,7 +19,7 @@ This drops you into a shell with `gradle`, `maven`, `bazelisk`, `nodejs`,
 
 If you'd rather install tools manually, you'll need at least:
 
-- `java`: any version should work
+- `java`: JDK 17 or newer
 - `git`: any version should work
 - `gradle`: `brew install gradle`, or see
   [general installation guide](https://gradle.org/install/).

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -16,7 +16,7 @@ rm gradle.zip
 mv /opt/gradle/*/* /opt/gradle
 
 # pre-install JDK for all major versions
-for JVM_VERSION in 21 17 11
+for JVM_VERSION in 21 17
 do 
   coursier java --jvm $JVM_VERSION --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json -- -version
 done

--- a/bin/scip-java-docker-script.sh
+++ b/bin/scip-java-docker-script.sh
@@ -3,7 +3,7 @@
 # version. It assumes that `coursier` is available on the `$PATH` and that the
 # `scip-java` binary is already installed at `/app/scip-java/bin/scip-java`.
 set -eu
-JVM_VERSION="${JVM_VERSION:-21,17,11,8}"
+JVM_VERSION="${JVM_VERSION:-21,17}"
 FILE="$PWD/lsif-java.json"
 if test -f "$FILE"; then
 	FROM_CONFIG=$(jq -r '.jvm' "$FILE")
@@ -21,11 +21,9 @@ do
 	if [ "$LAST_CODE" != "0" ]; then
 		echo "Using JVM version '$JVM_VERSION'"
 
-		if [ "$JVM_VERSION" = "17" ] || [ "$JVM_VERSION" = "21" ]; then
-			export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-		else
-			export JAVA_OPTS=""
-		fi
+		# scip-java requires JDK 17+, all of which need these --add-exports to
+		# reach internal javac APIs, so apply them unconditionally.
+		export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
 		eval "$(coursier java --jvm "$JVM_VERSION" --env --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json)"
 
 		java -version

--- a/bin/scip-java-docker-script.sh
+++ b/bin/scip-java-docker-script.sh
@@ -12,6 +12,13 @@ if test -f "$FILE"; then
 	fi
 fi
 
+# scip-java requires JDK 17+, all of which need these --add-exports to reach
+# internal javac APIs, so apply them unconditionally. The build derives them
+# from gradle/javac-internals.properties (the single source of truth) and ships
+# them ready-to-use in the distribution.
+JAVA_OPTS=$(cat /app/scip-java/javac-jvm-options)
+export JAVA_OPTS
+
 JVM_VERSIONS=$(echo "$JVM_VERSION" | tr "," "\n")
 
 LAST_CODE="-1"
@@ -21,9 +28,6 @@ do
 	if [ "$LAST_CODE" != "0" ]; then
 		echo "Using JVM version '$JVM_VERSION'"
 
-		# scip-java requires JDK 17+, all of which need these --add-exports to
-		# reach internal javac APIs, so apply them unconditionally.
-		export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
 		eval "$(coursier java --jvm "$JVM_VERSION" --env --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json)"
 
 		java -version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -342,10 +342,26 @@ project(":scip-java") {
         }
     }
 
+    // Emit the javac --add-exports flags as a ready-to-use, space-separated
+    // string so the Docker wrapper script can read them with a plain `cat`,
+    // keeping gradle/javac-internals.properties the single source of truth.
+    val generateJavacJvmOptions = tasks.register("generateJavacJvmOptions") {
+        val output = layout.buildDirectory.file("generated/distribution/javac-jvm-options")
+        val options = javacJvmOptions.joinToString(" ")
+        inputs.property("options", options)
+        outputs.file(output)
+        doLast {
+            val file = output.get().asFile
+            file.parentFile.mkdirs()
+            file.writeText("$options\n")
+        }
+    }
+
     extensions.configure<DistributionContainer> {
         named("main") {
             contents {
                 from(generateDistributionVersion)
+                from(generateJavacJvmOptions)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -471,7 +471,7 @@ project(":scip-snapshots") {
                 rootProject.layout.projectDirectory.dir("scip-snapshots/expected/kotlin/common").asFile.absolutePath,
             "snapshot.case.kotlin-common.targetroot" to kotlinTargetroot.get().asFile.absolutePath,
             "snapshot.case.kotlin-common.aggregateNoEmitInverseRelationships" to "true",
-            "scip.jdk.version" to "11",
+            "scip.jdk.version" to "17",
         )
 
     tasks.named<Test>("test") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,13 +57,13 @@ subprojects {
 
     plugins.withType<JavaPlugin> {
         extensions.configure<JavaPluginExtension> {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
 
         tasks.withType<JavaCompile>().configureEach {
             options.encoding = "UTF-8"
-            options.release.set(11)
+            options.release.set(17)
         }
 
         tasks.withType<Javadoc>().configureEach {
@@ -81,7 +81,7 @@ subprojects {
 
     plugins.withId("org.jetbrains.kotlin.jvm") {
         tasks.withType<KotlinCompile>().configureEach {
-            compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
+            compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ finished indexing the project.
 
 > The `sourcegraph/scip-java` Docker image is made available for convenience at
 > the cost of performance. The `sourcegraph/scip-java` image is a big download
-> because it includes pre-installed versions of Java 11, Java 17, and Java 21.
+> because it includes pre-installed versions of Java 17 and Java 21.
 > The `sourcegraph/scip-java` image has slow performance because it needs to
 > download all external dependencies of your codebase on every invocation.
 >
@@ -46,9 +46,6 @@ Java 17 is the default Java version in the `sourcegraph/scip-java` Docker image.
 Use the following commands to use a different JVM version:
 
 ```sh
-# Java 11
-docker run -v $(pwd):/sources --env JVM_VERSION=11 sourcegraph/scip-java:latest scip-java index
-
 # Java 17 (default)
 docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
 
@@ -60,7 +57,7 @@ docker run -v $(pwd):/sources --env JVM_VERSION=21 sourcegraph/scip-java:latest 
 ### Java launcher
 
 Use the Java launcher to install `scip-java` on your local computer or any
-Docker image with a pre-installed Java version.
+Docker image with a pre-installed Java version (JDK 17 or newer).
 
 ```sh
 # macOS/Linux
@@ -86,7 +83,8 @@ the `index` subcommand.
 ### Java fat jar
 
 Use the fat jar option to build a standalone `scip-java` executable. Note that
-you still need a Java installation to run the `scip-java` binary.
+you still need a Java installation (JDK 17 or newer) to run the `scip-java`
+binary.
 
 ```sh
 # macOS/Linux
@@ -204,7 +202,7 @@ of Java versions.
 | ------------ | ---------------------------- | -------------- |
 | Java 7       | ❌                           |                |
 | Java 8       | ❌                           |                |
-| Java 11      | ✅                           |                |
+| Java 11      | ❌                           |                |
 | Java 17      | ✅, requires `--add-exports` |                |
 | Java 21      | ✅, requires `--add-exports` |                |
 

--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -117,8 +117,8 @@ targetroot directory.
 
 ```
 ❯ find $TARGETROOT -type f
-build/scip-targetroot/META-INF/scip/j11/src/test/java/example/ExampleTest.java.scip
-build/scip-targetroot/META-INF/scip/j11/src/main/java/example/Example.java.scip
+build/scip-targetroot/META-INF/scip/j17/src/test/java/example/ExampleTest.java.scip
+build/scip-targetroot/META-INF/scip/j17/src/main/java/example/Example.java.scip
 ...
 ```
 

--- a/examples/bazel-example/.bazelrc
+++ b/examples/bazel-example/.bazelrc
@@ -1,0 +1,4 @@
+common --java_language_version=17
+common --tool_java_language_version=17
+common --java_runtime_version=remotejdk_21
+common --tool_java_runtime_version=remotejdk_21

--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,7 @@
         };
 
         devShells = {
-          default = mkDevShell pkgs.temurin-bin-11;
-          # https://github.com/NixOS/nixpkgs/issues/526834
-          jdk11 = mkDevShell pkgs.temurin-bin-11;
+          default = mkDevShell pkgs.jdk17;
           jdk17 = mkDevShell pkgs.jdk17;
           jdk21 = mkDevShell pkgs.jdk21;
         };

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/BazelBuildTool.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/BazelBuildTool.java
@@ -67,8 +67,8 @@ public class BazelBuildTool {
             );
     ScipAggregator.run(scipOptions);
 
-    if (!scipOptions.reporter.hasErrors()) {
-      System.out.println("done: " + scipOptions.output);
+    if (!scipOptions.reporter().hasErrors()) {
+      System.out.println("done: " + scipOptions.output());
       return 0;
     } else {
       System.out.println("SCIP index generation failed");

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
@@ -41,7 +41,7 @@ public class PackageTable {
     return SymbolDescriptor.toplevel(symbol)
         .flatMap(
             toplevel -> {
-              String classfile = toplevel.owner + toplevel.descriptor.name + ".class";
+              String classfile = toplevel.owner + toplevel.descriptor.name() + ".class";
               return packageForClassfile(classfile);
             });
   }

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
@@ -41,7 +41,7 @@ public class PackageTable {
     return SymbolDescriptor.toplevel(symbol)
         .flatMap(
             toplevel -> {
-              String classfile = toplevel.owner + toplevel.descriptor.name() + ".class";
+              String classfile = toplevel.owner() + toplevel.descriptor().name() + ".class";
               return packageForClassfile(classfile);
             });
   }

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/PackageTable.java
@@ -27,12 +27,12 @@ public class PackageTable {
 
   public PackageTable(ScipAggregatorOptions options) throws IOException {
     this.jdkPackage = JdkPackage.forRuntime();
-    this.indexDirectoryEntries = options.allowExportingGlobalSymbolsFromDirectoryEntries;
+    this.indexDirectoryEntries = options.allowExportingGlobalSymbolsFromDirectoryEntries();
     // NOTE: it's important that we index the JDK before maven packages. Some maven packages
     // redefine classes from the JDK and we want those maven packages to take precedence over
     // the JDK. The motivation to prioritize maven packages over the JDK is that we only want
     // to exports monikers against the JDK when indexing the JDK repo.
-    for (MavenPackage pkg : options.packages) {
+    for (MavenPackage pkg : options.packages()) {
       indexPackage(pkg);
     }
   }

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
@@ -218,17 +218,10 @@ public class ScipAggregator {
   }
 
   private static boolean supportsReferenceRelationship(SymbolInformation info) {
-    switch (info.getKind()) {
-      case Class:
-      case Enum:
-      case Interface:
-      case Type:
-      case Object:
-      case PackageObject:
-        return false;
-      default:
-        return true;
-    }
+    return switch (info.getKind()) {
+      case Class, Enum, Interface, Type, Object, PackageObject -> false;
+      default -> true;
+    };
   }
 
   private static boolean isIgnoredOverriddenSymbol(String symbol) {

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregator.java
@@ -66,23 +66,25 @@ public class ScipAggregator {
     SymbolRewriter rewriter = new SymbolRewriter(packages);
     List<Path> shards = findShards();
     Collections.sort(shards);
-    if (options.reporter.hasErrors()) return;
-    if (shards.isEmpty() && !options.allowEmptyIndex) {
-      options.reporter.error(
-          "No SCIP shards found. This typically means that `scip-java` is unable to automatically"
-              + " index this codebase. If you are using Gradle or Maven, please report an issue to"
-              + " https://github.com/sourcegraph/scip-java and include steps to reproduce. If you"
-              + " are using a different build tool, make sure that you have followed all of the"
-              + " manual configuration steps.");
+    if (options.reporter().hasErrors()) return;
+    if (shards.isEmpty() && !options.allowEmptyIndex()) {
+      options
+          .reporter()
+          .error(
+              "No SCIP shards found. This typically means that `scip-java` is unable to"
+                  + " automatically index this codebase. If you are using Gradle or Maven, please"
+                  + " report an issue to https://github.com/sourcegraph/scip-java and include steps"
+                  + " to reproduce. If you are using a different build tool, make sure that you"
+                  + " have followed all of the manual configuration steps.");
       return;
     }
-    options.reporter.startProcessing(shards.size());
+    options.reporter().startProcessing(shards.size());
     writer.emitTyped(metadataIndex());
 
     Map<String, List<String>> inverseReferences = computeInverseReferences(shards, rewriter);
     shardStream(shards).forEach(shard -> processShard(shard, rewriter, inverseReferences));
     writer.build();
-    options.reporter.endProcessing();
+    options.reporter().endProcessing();
   }
 
   /**
@@ -101,16 +103,17 @@ public class ScipAggregator {
 
           @Override
           public FileVisitResult visitFileFailed(Path file, IOException exc) {
-            options.reporter.error(exc);
+            options.reporter().error(exc);
             return FileVisitResult.CONTINUE;
           }
         };
-    for (Path root : options.targetroots) {
+    for (Path root : options.targetroots()) {
       if (JAR_PATTERN.matches(root)) shards.add(root);
       else if (Files.isDirectory(root)) Files.walkFileTree(root, visitor);
       else
-        options.reporter.warning(
-            "ignoring target root that does not exist or is not a directory: " + root);
+        options
+            .reporter()
+            .warning("ignoring target root that does not exist or is not a directory: " + root);
     }
     return shards;
   }
@@ -120,13 +123,13 @@ public class ScipAggregator {
         .setMetadata(
             Metadata.newBuilder()
                 .setVersion(ProtocolVersion.UnspecifiedProtocolVersion)
-                .setProjectRoot(options.sourceroot.toUri().toString())
+                .setProjectRoot(options.sourceroot().toUri().toString())
                 .setTextDocumentEncoding(TextEncoding.UTF8)
                 .setToolInfo(
                     ToolInfo.newBuilder()
-                        .setName(options.toolInfo.getName())
-                        .setVersion(options.toolInfo.getVersion())
-                        .addAllArguments(options.toolInfo.getArgumentsList())))
+                        .setName(options.toolInfo().getName())
+                        .setVersion(options.toolInfo().getVersion())
+                        .addAllArguments(options.toolInfo().getArgumentsList())))
         .build();
   }
 
@@ -135,7 +138,7 @@ public class ScipAggregator {
     for (Document shard : readShard(shardPath)) {
       Document rewritten = rewriteDocument(shard, rewriter, inverseReferences);
       writer.emitTyped(Index.newBuilder().addDocuments(rewritten).build());
-      options.reporter.processedOneItem();
+      options.reporter().processedOneItem();
     }
   }
 
@@ -198,7 +201,7 @@ public class ScipAggregator {
    */
   private Map<String, List<String>> computeInverseReferences(
       List<Path> shards, SymbolRewriter rewriter) {
-    if (!options.emitInverseRelationships) return Collections.emptyMap();
+    if (!options.emitInverseRelationships()) return Collections.emptyMap();
     Map<String, List<String>> result = new HashMap<>();
     for (Path shard : shards) {
       for (Document doc : readShard(shard)) {
@@ -231,7 +234,7 @@ public class ScipAggregator {
   }
 
   private Stream<Path> shardStream(List<Path> shards) {
-    return options.parallel ? shards.parallelStream() : shards.stream();
+    return options.parallel() ? shards.parallelStream() : shards.stream();
   }
 
   private Collection<Document> readShard(Path shardPath) {
@@ -239,8 +242,8 @@ public class ScipAggregator {
       if (JAR_PATTERN.matches(shardPath)) return readShardsFromJar(shardPath);
       return Index.parseFrom(parseFromBytes(Files.readAllBytes(shardPath))).getDocumentsList();
     } catch (IOException e) {
-      options.reporter.error("invalid SCIP shard: " + shardPath);
-      options.reporter.error(e);
+      options.reporter().error("invalid SCIP shard: " + shardPath);
+      options.reporter().error(e);
       return Collections.emptyList();
     }
   }

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregatorOptions.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipAggregatorOptions.java
@@ -5,40 +5,14 @@ import java.util.List;
 import org.scip_code.scip.ToolInfo;
 
 /** Configuration options to tweak the scip-aggregator command. */
-public class ScipAggregatorOptions {
-
-  public final List<Path> targetroots;
-  public final Path output;
-  public final Path sourceroot;
-  public final ScipAggregatorReporter reporter;
-  public final ToolInfo toolInfo;
-  public final boolean parallel;
-  public final List<MavenPackage> packages;
-  public final boolean emitInverseRelationships;
-  public final boolean allowEmptyIndex;
-  public final boolean allowExportingGlobalSymbolsFromDirectoryEntries;
-
-  public ScipAggregatorOptions(
-      List<Path> targetroots,
-      Path output,
-      Path sourceroot,
-      ScipAggregatorReporter reporter,
-      ToolInfo toolInfo,
-      boolean parallel,
-      List<MavenPackage> packages,
-      boolean emitInverseRelationships,
-      boolean allowEmptyIndex,
-      boolean allowExportingGlobalSymbolsFromDirectoryEntries) {
-    this.targetroots = targetroots;
-    this.output = output;
-    this.sourceroot = sourceroot;
-    this.reporter = reporter;
-    this.toolInfo = toolInfo;
-    this.parallel = parallel;
-    this.packages = packages;
-    this.emitInverseRelationships = emitInverseRelationships;
-    this.allowEmptyIndex = allowEmptyIndex;
-    this.allowExportingGlobalSymbolsFromDirectoryEntries =
-        allowExportingGlobalSymbolsFromDirectoryEntries;
-  }
-}
+public record ScipAggregatorOptions(
+    List<Path> targetroots,
+    Path output,
+    Path sourceroot,
+    ScipAggregatorReporter reporter,
+    ToolInfo toolInfo,
+    boolean parallel,
+    List<MavenPackage> packages,
+    boolean emitInverseRelationships,
+    boolean allowEmptyIndex,
+    boolean allowExportingGlobalSymbolsFromDirectoryEntries) {}

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipWriter.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/ScipWriter.java
@@ -31,7 +31,7 @@ public class ScipWriter implements AutoCloseable {
 
   public void build() throws IOException {
     close();
-    Files.move(tmp, options.output, StandardCopyOption.REPLACE_EXISTING);
+    Files.move(tmp, options.output(), StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class ScipWriter implements AutoCloseable {
     try {
       output.flush();
     } catch (IOException e) {
-      options.reporter.error(e);
+      options.reporter().error(e);
     }
   }
 }

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/SymbolDescriptor.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/SymbolDescriptor.java
@@ -5,15 +5,7 @@ import com.sourcegraph.scip.ScipSymbols.Descriptor;
 import com.sourcegraph.scip.ScipSymbols.Descriptor.Kind;
 import java.util.Optional;
 
-public class SymbolDescriptor {
-
-  public final ScipSymbols.Descriptor descriptor;
-  public final String owner;
-
-  public SymbolDescriptor(ScipSymbols.Descriptor descriptor, String owner) {
-    this.descriptor = descriptor;
-    this.owner = owner;
-  }
+public record SymbolDescriptor(ScipSymbols.Descriptor descriptor, String owner) {
 
   public static SymbolDescriptor NONE = new SymbolDescriptor(Descriptor.NONE, ScipSymbols.NONE);
 
@@ -29,14 +21,14 @@ public class SymbolDescriptor {
       return Optional.empty();
     }
     SymbolDescriptor current = parseFromSymbol(symbol);
-    if (current.descriptor.kind() == Kind.Package) {
+    if (current.descriptor().kind() == Kind.Package) {
       return Optional.empty();
     }
-    SymbolDescriptor owner = parseFromSymbol(current.owner);
-    if (owner.descriptor.kind() == Kind.Package) {
+    SymbolDescriptor owner = parseFromSymbol(current.owner());
+    if (owner.descriptor().kind() == Kind.Package) {
       return Optional.of(current);
     } else {
-      return toplevel(current.owner);
+      return toplevel(current.owner());
     }
   }
 

--- a/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/SymbolDescriptor.java
+++ b/scip-aggregator/src/main/java/com/sourcegraph/scip_aggregator/SymbolDescriptor.java
@@ -29,11 +29,11 @@ public class SymbolDescriptor {
       return Optional.empty();
     }
     SymbolDescriptor current = parseFromSymbol(symbol);
-    if (current.descriptor.kind == Kind.Package) {
+    if (current.descriptor.kind() == Kind.Package) {
       return Optional.empty();
     }
     SymbolDescriptor owner = parseFromSymbol(current.owner);
-    if (owner.descriptor.kind == Kind.Package) {
+    if (owner.descriptor.kind() == Kind.Package) {
       return Optional.of(current);
     } else {
       return toplevel(current.owner);

--- a/scip-aggregator/src/test/java/com/sourcegraph/scip_aggregator/SymbolDescriptorTest.java
+++ b/scip-aggregator/src/test/java/com/sourcegraph/scip_aggregator/SymbolDescriptorTest.java
@@ -14,9 +14,9 @@ class SymbolDescriptorTest {
 
   private static void check(String symbol, Kind kind, String name, String owner) {
     SymbolDescriptor obtained = SymbolDescriptor.parseFromSymbol(symbol);
-    assertEquals(name, obtained.descriptor.name, symbol);
+    assertEquals(name, obtained.descriptor.name(), symbol);
     assertEquals(owner, obtained.owner, symbol);
-    assertEquals(kind, obtained.descriptor.kind, symbol);
+    assertEquals(kind, obtained.descriptor.kind(), symbol);
   }
 
   @Test

--- a/scip-aggregator/src/test/java/com/sourcegraph/scip_aggregator/SymbolDescriptorTest.java
+++ b/scip-aggregator/src/test/java/com/sourcegraph/scip_aggregator/SymbolDescriptorTest.java
@@ -14,9 +14,9 @@ class SymbolDescriptorTest {
 
   private static void check(String symbol, Kind kind, String name, String owner) {
     SymbolDescriptor obtained = SymbolDescriptor.parseFromSymbol(symbol);
-    assertEquals(name, obtained.descriptor.name(), symbol);
-    assertEquals(owner, obtained.owner, symbol);
-    assertEquals(kind, obtained.descriptor.kind(), symbol);
+    assertEquals(name, obtained.descriptor().name(), symbol);
+    assertEquals(owner, obtained.owner(), symbol);
+    assertEquals(kind, obtained.descriptor().kind(), symbol);
   }
 
   @Test

--- a/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
+++ b/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
@@ -67,16 +67,14 @@ class GradleBuildToolTest : BuildToolHarness() {
             )
         )
         add(checkGradleBuild("basic", "gradle/basic", expectedScipFiles = 2))
-        for (java in listOf(11, 17, 21)) {
-            add(
-                checkGradleBuild(
-                    "toolchains-$java",
-                    "gradle/toolchains",
-                    expectedScipFiles = 1,
-                    substitutions = mapOf("@JAVA@" to "$java"),
-                )
+        add(
+            checkGradleBuild(
+                "toolchains",
+                "gradle/toolchains",
+                expectedScipFiles = 1,
+                substitutions = mapOf("@JAVA@" to "17"),
             )
-        }
+        )
         add(
             checkGradleBuild(
                 "protobuf-generator",
@@ -130,16 +128,14 @@ class GradleBuildToolTest : BuildToolHarness() {
                         .trimMargin(),
             )
         )
-        for (java in listOf(11, 17)) {
-            add(
-                checkGradleBuild(
-                    "kotlin-jvm-toolchains-jdk$java",
-                    "gradle/kotlin-jvm-toolchains",
-                    expectedScipFiles = 1,
-                    substitutions = mapOf("@JAVA@" to "$java"),
-                )
+        add(
+            checkGradleBuild(
+                "kotlin-jvm-toolchains-jdk17",
+                "gradle/kotlin-jvm-toolchains",
+                expectedScipFiles = 1,
+                substitutions = mapOf("@JAVA@" to "17"),
             )
-        }
+        )
         // Regression test: projects that lazily register custom source sets (e.g.
         // intTest) with a Java toolchain used to fail because the eager `.all {}`
         // API finalized the javaCompiler property before Gradle finished

--- a/scip-java/src/test/resources/fixtures/gradle/lazy-sourceset-with-toolchain/build.gradle
+++ b/scip-java/src/test/resources/fixtures/gradle/lazy-sourceset-with-toolchain/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(11)
+    languageVersion = JavaLanguageVersion.of(17)
   }
 }
 sourceSets {

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/CompilerRange.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/CompilerRange.java
@@ -55,44 +55,34 @@ public enum CompilerRange {
   FROM_END_WITH_TEXT_SEARCH;
 
   public boolean isFromPoint() {
-    switch (this) {
-      case FROM_POINT_TO_SYMBOL_NAME:
-      case FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE:
-      case FROM_POINT_WITH_TEXT_SEARCH:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this) {
+      case FROM_POINT_TO_SYMBOL_NAME,
+          FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE,
+          FROM_POINT_WITH_TEXT_SEARCH ->
+          true;
+      default -> false;
+    };
   }
 
   public boolean isFromEndPoint() {
-    switch (this) {
-      case FROM_END_TO_SYMBOL_NAME:
-      case FROM_END_WITH_TEXT_SEARCH:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this) {
+      case FROM_END_TO_SYMBOL_NAME, FROM_END_WITH_TEXT_SEARCH -> true;
+      default -> false;
+    };
   }
 
   public boolean isFromTextSearch() {
-    switch (this) {
-      case FROM_TEXT_SEARCH:
-      case FROM_END_WITH_TEXT_SEARCH:
-      case FROM_POINT_WITH_TEXT_SEARCH:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this) {
+      case FROM_TEXT_SEARCH, FROM_END_WITH_TEXT_SEARCH, FROM_POINT_WITH_TEXT_SEARCH -> true;
+      default -> false;
+    };
   }
 
   public boolean isPlusOne() {
-    switch (this) {
-      case FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this) {
+      case FROM_POINT_TO_SYMBOL_NAME_PLUS_ONE -> true;
+      default -> false;
+    };
   }
 
   public boolean isFromEnd() {

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
@@ -8,12 +8,12 @@ import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.NoType;
 
 /** Cache of SCIP symbols that can be referenced between files. */
 public final class GlobalSymbolsCache {
@@ -59,9 +59,7 @@ public final class GlobalSymbolsCache {
       }
 
       return sb.toString();
-    } else
-    // check for Module without referring to Module as it doesn't exist < JDK 9
-    if (sym.asType() instanceof NoType) return ScipSymbols.ROOT_PACKAGE;
+    } else if (sym instanceof ModuleElement) return ScipSymbols.ROOT_PACKAGE;
 
     if (isAnonymousClass(sym) || isLocalVariable(sym)) return locals.put(sym);
 

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
@@ -79,14 +79,10 @@ public final class GlobalSymbolsCache {
   }
 
   private boolean isLocalVariable(Element sym) {
-    switch (sym.getKind()) {
-      case PARAMETER:
-      case EXCEPTION_PARAMETER:
-      case LOCAL_VARIABLE:
-        return true;
-      default:
-        return false;
-    }
+    return switch (sym.getKind()) {
+      case PARAMETER, EXCEPTION_PARAMETER, LOCAL_VARIABLE -> true;
+      default -> false;
+    };
   }
 
   private boolean isAnonymousClass(Element sym) {

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
@@ -40,11 +40,11 @@ public final class GlobalSymbolsCache {
   private String uncachedSymbol(Element sym, LocalSymbolsCache<Element, String> locals) {
     if (sym == null) return ScipSymbols.ROOT_PACKAGE;
 
-    if (sym instanceof PackageElement) {
-      if (((PackageElement) sym).isUnnamed()) return ScipSymbols.ROOT_PACKAGE;
+    if (sym instanceof PackageElement packageElement) {
+      if (packageElement.isUnnamed()) return ScipSymbols.ROOT_PACKAGE;
 
       StringBuilder sb = new StringBuilder();
-      String qualifiedName = ((PackageElement) sym).getQualifiedName().toString();
+      String qualifiedName = packageElement.getQualifiedName().toString();
       int i = 0;
       int j = 0;
       while (j < qualifiedName.length()) {
@@ -68,8 +68,8 @@ public final class GlobalSymbolsCache {
 
     ScipSymbols.Descriptor desc = scipDescriptor(sym);
     if (options.verboseEnabled && desc.kind == ScipSymbols.Descriptor.Kind.None) {
-      if (sym instanceof QualifiedNameable)
-        pprint(((QualifiedNameable) sym).getQualifiedName().toString());
+      if (sym instanceof QualifiedNameable qualifiedNameable)
+        pprint(qualifiedNameable.getQualifiedName().toString());
       else pprint(sym.getSimpleName().toString());
       pprint(
           String.format(
@@ -97,11 +97,11 @@ public final class GlobalSymbolsCache {
     if (sym instanceof TypeElement) {
       return new ScipSymbols.Descriptor(
           ScipSymbols.Descriptor.Kind.Type, sym.getSimpleName().toString());
-    } else if (sym instanceof ExecutableElement) {
+    } else if (sym instanceof ExecutableElement executableElement) {
       return new ScipSymbols.Descriptor(
           ScipSymbols.Descriptor.Kind.Method,
           sym.getSimpleName().toString(),
-          methodDisambiguator((ExecutableElement) sym));
+          methodDisambiguator(executableElement));
     } else if (sym instanceof TypeParameterElement) {
       return new ScipSymbols.Descriptor(
           ScipSymbols.Descriptor.Kind.TypeParameter, sym.getSimpleName().toString());
@@ -135,8 +135,9 @@ public final class GlobalSymbolsCache {
     Iterable<? extends Element> elements = sym.getEnclosingElement().getEnclosedElements();
     ArrayList<ExecutableElement> methods = new ArrayList<>();
     for (Element e : elements) {
-      if (e instanceof ExecutableElement && e.getSimpleName() == sym.getSimpleName()) {
-        methods.add((ExecutableElement) e);
+      if (e instanceof ExecutableElement executableElement
+          && e.getSimpleName() == sym.getSimpleName()) {
+        methods.add(executableElement);
       }
     }
     // NOTE(olafur): sort static methods last, according to the spec. Historical note: this

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/GlobalSymbolsCache.java
@@ -67,7 +67,7 @@ public final class GlobalSymbolsCache {
     if (ScipSymbols.isLocal(owner)) return locals.put(sym);
 
     ScipSymbols.Descriptor desc = scipDescriptor(sym);
-    if (options.verboseEnabled && desc.kind == ScipSymbols.Descriptor.Kind.None) {
+    if (options.verboseEnabled && desc.kind() == ScipSymbols.Descriptor.Kind.None) {
       if (sym instanceof QualifiedNameable qualifiedNameable)
         pprint(qualifiedNameable.getQualifiedName().toString());
       else pprint(sym.getSimpleName().toString());

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavaSignatureFormatter.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavaSignatureFormatter.java
@@ -66,14 +66,14 @@ final class ScipJavaSignatureFormatter {
    * Returns the signature text for {@code sym}, or {@code ""} when {@code sym} has no signature.
    */
   String format(Element sym, Tree declTree) {
-    if (sym instanceof TypeElement) {
-      return formatClass((TypeElement) sym, declTree);
-    } else if (sym instanceof ExecutableElement) {
-      return formatMethod((ExecutableElement) sym, declTree);
-    } else if (sym instanceof VariableElement) {
-      return formatVariable((VariableElement) sym, declTree);
-    } else if (sym instanceof TypeParameterElement) {
-      return formatTypeParameter((TypeParameterElement) sym);
+    if (sym instanceof TypeElement typeElement) {
+      return formatClass(typeElement, declTree);
+    } else if (sym instanceof ExecutableElement executableElement) {
+      return formatMethod(executableElement, declTree);
+    } else if (sym instanceof VariableElement variableElement) {
+      return formatVariable(variableElement, declTree);
+    } else if (sym instanceof TypeParameterElement typeParameterElement) {
+      return formatTypeParameter(typeParameterElement);
     }
     return "";
   }
@@ -382,9 +382,9 @@ final class ScipJavaSignatureFormatter {
   }
 
   private static ModifiersTree modifiers(Tree tree) {
-    if (tree instanceof ClassTree) return ((ClassTree) tree).getModifiers();
-    if (tree instanceof MethodTree) return ((MethodTree) tree).getModifiers();
-    if (tree instanceof VariableTree) return ((VariableTree) tree).getModifiers();
+    if (tree instanceof ClassTree classTree) return classTree.getModifiers();
+    if (tree instanceof MethodTree methodTree) return methodTree.getModifiers();
+    if (tree instanceof VariableTree variableTree) return variableTree.getModifiers();
     return null;
   }
 
@@ -398,8 +398,7 @@ final class ScipJavaSignatureFormatter {
       b.append('(');
       ExpressionTree first = args.get(0);
       // `@Foo(value = X)` collapses to `@Foo(X)`, per JLS 9.7.3.
-      if (first instanceof AssignmentTree) {
-        AssignmentTree assign = (AssignmentTree) first;
+      if (first instanceof AssignmentTree assign) {
         if (isValueIdentifier(assign.getVariable())) {
           b.append(formatExpression(assign.getExpression()));
         } else {
@@ -423,46 +422,41 @@ final class ScipJavaSignatureFormatter {
   }
 
   private static boolean isValueIdentifier(ExpressionTree tree) {
-    return tree instanceof IdentifierTree
-        && "value".contentEquals(((IdentifierTree) tree).getName());
+    return tree instanceof IdentifierTree identifierTree
+        && "value".contentEquals(identifierTree.getName());
   }
 
   private String formatExpression(ExpressionTree expr) {
-    if (expr instanceof LiteralTree) return formatLiteral(((LiteralTree) expr).getValue());
-    if (expr instanceof IdentifierTree) return ((IdentifierTree) expr).getName().toString();
-    if (expr instanceof MemberSelectTree) {
-      MemberSelectTree select = (MemberSelectTree) expr;
+    if (expr instanceof LiteralTree literalTree) return formatLiteral(literalTree.getValue());
+    if (expr instanceof IdentifierTree identifierTree) return identifierTree.getName().toString();
+    if (expr instanceof MemberSelectTree select) {
       return formatExpression(select.getExpression()) + "." + select.getIdentifier();
     }
-    if (expr instanceof NewArrayTree) {
-      List<? extends ExpressionTree> inits = ((NewArrayTree) expr).getInitializers();
+    if (expr instanceof NewArrayTree newArrayTree) {
+      List<? extends ExpressionTree> inits = newArrayTree.getInitializers();
       if (inits == null) inits = Collections.emptyList();
       return inits.stream().map(this::formatExpression).collect(Collectors.joining(", ", "{", "}"));
     }
-    if (expr instanceof AnnotationTree) return formatAnnotation((AnnotationTree) expr);
-    if (expr instanceof AssignmentTree) {
-      AssignmentTree assign = (AssignmentTree) expr;
+    if (expr instanceof AnnotationTree annotationTree) return formatAnnotation(annotationTree);
+    if (expr instanceof AssignmentTree assign) {
       return formatExpression(assign.getVariable())
           + " = "
           + formatExpression(assign.getExpression());
     }
-    if (expr instanceof BinaryTree) {
-      BinaryTree bin = (BinaryTree) expr;
+    if (expr instanceof BinaryTree bin) {
       return formatExpression(bin.getLeftOperand())
           + " "
           + binaryOperator(bin.getKind())
           + " "
           + formatExpression(bin.getRightOperand());
     }
-    if (expr instanceof UnaryTree) {
-      UnaryTree un = (UnaryTree) expr;
+    if (expr instanceof UnaryTree un) {
       return unaryOperator(un.getKind(), formatExpression(un.getExpression()));
     }
-    if (expr instanceof ParenthesizedTree) {
-      return formatExpression(((ParenthesizedTree) expr).getExpression());
+    if (expr instanceof ParenthesizedTree parenthesizedTree) {
+      return formatExpression(parenthesizedTree.getExpression());
     }
-    if (expr instanceof TypeCastTree) {
-      TypeCastTree cast = (TypeCastTree) expr;
+    if (expr instanceof TypeCastTree cast) {
       TypeMirror type = typeOf(cast.getType());
       String typeText = type != null ? formatType(type) : cast.getType().toString();
       return "(" + typeText + ") " + formatExpression(cast.getExpression());
@@ -570,11 +564,12 @@ final class ScipJavaSignatureFormatter {
    * the initializer is not a {@code new EnumType(...)} expression or carries no arguments.
    */
   private static String enumConstantArgs(Tree declTree) {
-    if (!(declTree instanceof VariableTree)) return "";
-    ExpressionTree initializer = ((VariableTree) declTree).getInitializer();
-    if (!(initializer instanceof NewClassTree)) return "";
-    return ((NewClassTree) initializer)
-        .getArguments().stream().map(Object::toString).collect(Collectors.joining(", "));
+    if (!(declTree instanceof VariableTree variableTree)) return "";
+    ExpressionTree initializer = variableTree.getInitializer();
+    if (!(initializer instanceof NewClassTree newClassTree)) return "";
+    return newClassTree.getArguments().stream()
+        .map(Object::toString)
+        .collect(Collectors.joining(", "));
   }
 
   private static boolean isEnumParent(TypeMirror parent) {
@@ -590,10 +585,10 @@ final class ScipJavaSignatureFormatter {
   }
 
   private static boolean isQualified(TypeMirror tpe, String qualifiedName) {
-    if (!(tpe instanceof DeclaredType)) return false;
-    Element elem = ((DeclaredType) tpe).asElement();
-    return elem instanceof TypeElement
-        && qualifiedName.contentEquals(((TypeElement) elem).getQualifiedName());
+    if (!(tpe instanceof DeclaredType declaredType)) return false;
+    Element elem = declaredType.asElement();
+    return elem instanceof TypeElement typeElement
+        && qualifiedName.contentEquals(typeElement.getQualifiedName());
   }
 
   private Element elementOf(Tree tree) {

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavaSignatureFormatter.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavaSignatureFormatter.java
@@ -91,20 +91,11 @@ final class ScipJavaSignatureFormatter {
     if (!isEnum && !isAnnotation && !isInterface) printKeyword(s, formatModifiers(sym));
 
     switch (sym.getKind()) {
-      case CLASS:
-        printKeyword(s, "class");
-        break;
-      case ENUM:
-        printKeyword(s, "enum");
-        break;
-      case ANNOTATION_TYPE:
-        printKeyword(s, "@interface");
-        break;
-      case INTERFACE:
-        printKeyword(s, "interface");
-        break;
-      default:
-        break;
+      case CLASS -> printKeyword(s, "class");
+      case ENUM -> printKeyword(s, "enum");
+      case ANNOTATION_TYPE -> printKeyword(s, "@interface");
+      case INTERFACE -> printKeyword(s, "interface");
+      default -> {}
     }
     s.append(sym.getSimpleName());
 
@@ -133,8 +124,7 @@ final class ScipJavaSignatureFormatter {
 
     // Mirror SignatureFormatter's Java extends/implements logic.
     switch (sym.getKind()) {
-      case CLASS:
-      case ENUM:
+      case CLASS, ENUM -> {
         if (isEnum || !hasNonRedundantParent) {
           printKeyword(s, " implements");
           s.append(nonSynthetic.stream().map(this::formatType).collect(Collectors.joining(", ")));
@@ -148,14 +138,12 @@ final class ScipJavaSignatureFormatter {
             s.append(supers);
           }
         }
-        break;
-      case INTERFACE:
-      case ANNOTATION_TYPE:
+      }
+      case INTERFACE, ANNOTATION_TYPE -> {
         printKeyword(s, " extends");
         s.append(nonSynthetic.stream().map(this::formatType).collect(Collectors.joining(", ")));
-        break;
-      default:
-        break;
+      }
+      default -> {}
     }
     return s.toString();
   }
@@ -319,28 +307,18 @@ final class ScipJavaSignatureFormatter {
       };
 
   private static String primitiveName(TypeKind kind) {
-    switch (kind) {
-      case BOOLEAN:
-        return "boolean";
-      case BYTE:
-        return "byte";
-      case SHORT:
-        return "short";
-      case INT:
-        return "int";
-      case LONG:
-        return "long";
-      case CHAR:
-        return "char";
-      case FLOAT:
-        return "float";
-      case DOUBLE:
-        return "double";
-      case VOID:
-        return "void";
-      default:
-        return UNRESOLVED;
-    }
+    return switch (kind) {
+      case BOOLEAN -> "boolean";
+      case BYTE -> "byte";
+      case SHORT -> "short";
+      case INT -> "int";
+      case LONG -> "long";
+      case CHAR -> "char";
+      case FLOAT -> "float";
+      case DOUBLE -> "double";
+      case VOID -> "void";
+      default -> UNRESOLVED;
+    };
   }
 
   // -------- Access / modifiers --------
@@ -473,72 +451,43 @@ final class ScipJavaSignatureFormatter {
   }
 
   private static String binaryOperator(Tree.Kind kind) {
-    switch (kind) {
-      case PLUS:
-        return "+";
-      case MINUS:
-        return "-";
-      case MULTIPLY:
-        return "*";
-      case DIVIDE:
-        return "/";
-      case REMAINDER:
-        return "%";
-      case GREATER_THAN:
-        return ">";
-      case LESS_THAN:
-        return "<";
-      case AND:
-        return "&";
-      case XOR:
-        return "^";
-      case OR:
-        return "|";
-      case CONDITIONAL_AND:
-        return "&&";
-      case CONDITIONAL_OR:
-        return "||";
-      case LEFT_SHIFT:
-        return "<<";
-      case RIGHT_SHIFT:
-        return ">>";
-      case UNSIGNED_RIGHT_SHIFT:
-        return ">>>";
-      case EQUAL_TO:
-        return "==";
-      case NOT_EQUAL_TO:
-        return "!=";
-      case GREATER_THAN_EQUAL:
-        return ">=";
-      case LESS_THAN_EQUAL:
-        return "<=";
-      default:
-        throw new IllegalArgumentException("unexpected binary operator " + kind);
-    }
+    return switch (kind) {
+      case PLUS -> "+";
+      case MINUS -> "-";
+      case MULTIPLY -> "*";
+      case DIVIDE -> "/";
+      case REMAINDER -> "%";
+      case GREATER_THAN -> ">";
+      case LESS_THAN -> "<";
+      case AND -> "&";
+      case XOR -> "^";
+      case OR -> "|";
+      case CONDITIONAL_AND -> "&&";
+      case CONDITIONAL_OR -> "||";
+      case LEFT_SHIFT -> "<<";
+      case RIGHT_SHIFT -> ">>";
+      case UNSIGNED_RIGHT_SHIFT -> ">>>";
+      case EQUAL_TO -> "==";
+      case NOT_EQUAL_TO -> "!=";
+      case GREATER_THAN_EQUAL -> ">=";
+      case LESS_THAN_EQUAL -> "<=";
+      default -> throw new IllegalArgumentException("unexpected binary operator " + kind);
+    };
   }
 
   private static String unaryOperator(Tree.Kind kind, String value) {
-    switch (kind) {
-      case UNARY_MINUS:
+    return switch (kind) {
       // The old SignatureFormatter.formatUnaryOperation rendered UNARY_PLUS as "-value".
       // Preserve that behavior to keep snapshots stable.
-      case UNARY_PLUS:
-        return "-" + value;
-      case POSTFIX_INCREMENT:
-        return value + "++";
-      case POSTFIX_DECREMENT:
-        return value + "--";
-      case PREFIX_INCREMENT:
-        return "++" + value;
-      case PREFIX_DECREMENT:
-        return "--" + value;
-      case BITWISE_COMPLEMENT:
-        return "~" + value;
-      case LOGICAL_COMPLEMENT:
-        return "!" + value;
-      default:
-        throw new IllegalArgumentException("unexpected unary operator " + kind);
-    }
+      case UNARY_MINUS, UNARY_PLUS -> "-" + value;
+      case POSTFIX_INCREMENT -> value + "++";
+      case POSTFIX_DECREMENT -> value + "--";
+      case PREFIX_INCREMENT -> "++" + value;
+      case PREFIX_DECREMENT -> "--" + value;
+      case BITWISE_COMPLEMENT -> "~" + value;
+      case LOGICAL_COMPLEMENT -> "!" + value;
+      default -> throw new IllegalArgumentException("unexpected unary operator " + kind);
+    };
   }
 
   // -------- Helpers --------

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavacOptions.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavacOptions.java
@@ -52,23 +52,15 @@ public class ScipJavacOptions extends ScipOptions {
       } else if (arg.startsWith("-no-relative-path:")) {
         String value = arg.substring("-no-relative-path:".length());
         switch (value) {
-          case "index_anyway":
-            result.noRelativePath = NoRelativePathMode.INDEX_ANYWAY;
-            break;
-          case "skip":
-            result.noRelativePath = NoRelativePathMode.SKIP;
-            break;
-          case "error":
-            result.noRelativePath = NoRelativePathMode.ERROR;
-            break;
-          case "warning":
-            result.noRelativePath = NoRelativePathMode.WARNING;
-            break;
-          default:
-            result.errors.add(
-                String.format(
-                    "unknown -no-relative-path mode '%s'. Valid values are %s.",
-                    value, NoRelativePathMode.validStringValues()));
+          case "index_anyway" -> result.noRelativePath = NoRelativePathMode.INDEX_ANYWAY;
+          case "skip" -> result.noRelativePath = NoRelativePathMode.SKIP;
+          case "error" -> result.noRelativePath = NoRelativePathMode.ERROR;
+          case "warning" -> result.noRelativePath = NoRelativePathMode.WARNING;
+          default ->
+              result.errors.add(
+                  String.format(
+                      "unknown -no-relative-path mode '%s'. Valid values are %s.",
+                      value, NoRelativePathMode.validStringValues()));
         }
       } else if (arg.equals("-build-tool:bazel")) {
         result.uriScheme = UriScheme.BAZEL;

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavacOptions.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipJavacOptions.java
@@ -43,7 +43,7 @@ public class ScipJavacOptions extends ScipOptions {
         String argValue = arg.substring("-targetroot:".length());
         if (argValue.equals(JAVAC_CLASSES_DIR_ARG)) {
           useJavacClassesDir = true;
-          result.targetroot = getJavacClassesDir(result, task).classes;
+          result.targetroot = getJavacClassesDir(result, task).classes();
         } else {
           result.targetroot = Paths.get(argValue);
         }
@@ -66,8 +66,8 @@ public class ScipJavacOptions extends ScipOptions {
         result.uriScheme = UriScheme.BAZEL;
         useJavacClassesDir = true;
         TargetPaths paths = getJavacClassesDir(result, task);
-        result.targetroot = paths.classes;
-        result.generatedTargetRoot = paths.sources;
+        result.targetroot = paths.classes();
+        result.generatedTargetRoot = paths.sources();
       } else if (arg.equals("-text:on")) {
         result.includeText = true;
       } else if (arg.equals("-text:off")) {

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
@@ -110,9 +110,9 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
 
   @Override
   public Void visitPackage(PackageTree node, Void unused) {
-    // JDK 17+ TreePathScanner would otherwise recurse into the package name's
-    // identifiers and emit a self-reference for `package X.Y;`. JDK 11 does
-    // not. Skipping the package subtree keeps output stable across JDKs.
+    // Skip the package subtree: TreePathScanner would otherwise recurse into the
+    // package name's identifiers and emit an unwanted self-reference for
+    // `package X.Y;`.
     return null;
   }
 

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
@@ -340,29 +340,21 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
     boolean isStatic = mods.contains(Modifier.STATIC);
     boolean isAbstract = mods.contains(Modifier.ABSTRACT);
     boolean isDefault = mods.contains(Modifier.DEFAULT);
-    switch (sym.getKind()) {
-      case ENUM:
-        return SymbolInformation.Kind.Enum;
-      case CLASS:
-        return SymbolInformation.Kind.Class;
-      case INTERFACE:
-      case ANNOTATION_TYPE:
-        return SymbolInformation.Kind.Interface;
-      case CONSTRUCTOR:
-        return SymbolInformation.Kind.Constructor;
-      case METHOD:
-        if (isStatic) return SymbolInformation.Kind.StaticMethod;
-        if (isAbstract && !isDefault) return SymbolInformation.Kind.AbstractMethod;
-        return SymbolInformation.Kind.Method;
-      case FIELD:
-        return isStatic ? SymbolInformation.Kind.StaticField : SymbolInformation.Kind.Field;
-      case LOCAL_VARIABLE:
-        return SymbolInformation.Kind.Variable;
-      case TYPE_PARAMETER:
-        return SymbolInformation.Kind.TypeParameter;
-      default:
-        return SymbolInformation.Kind.UnspecifiedKind;
-    }
+    return switch (sym.getKind()) {
+      case ENUM -> SymbolInformation.Kind.Enum;
+      case CLASS -> SymbolInformation.Kind.Class;
+      case INTERFACE, ANNOTATION_TYPE -> SymbolInformation.Kind.Interface;
+      case CONSTRUCTOR -> SymbolInformation.Kind.Constructor;
+      case METHOD -> {
+        if (isStatic) yield SymbolInformation.Kind.StaticMethod;
+        if (isAbstract && !isDefault) yield SymbolInformation.Kind.AbstractMethod;
+        yield SymbolInformation.Kind.Method;
+      }
+      case FIELD -> isStatic ? SymbolInformation.Kind.StaticField : SymbolInformation.Kind.Field;
+      case LOCAL_VARIABLE -> SymbolInformation.Kind.Variable;
+      case TYPE_PARAMETER -> SymbolInformation.Kind.TypeParameter;
+      default -> SymbolInformation.Kind.UnspecifiedKind;
+    };
   }
 
   // =======================================

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/ScipVisitor.java
@@ -122,11 +122,9 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
   private void resolveNodes() {
     Set<Tree> ignoreNodes = new HashSet<>();
     for (Tree node : nodes.keySet()) {
-      if (node instanceof NewClassTree) {
-        NewClassTree newClassTree = (NewClassTree) node;
+      if (node instanceof NewClassTree newClassTree) {
         if (newClassTree.getClassBody() == null) {
-          if (newClassTree.getIdentifier() instanceof ParameterizedTypeTree) {
-            ParameterizedTypeTree paramNode = (ParameterizedTypeTree) newClassTree.getIdentifier();
+          if (newClassTree.getIdentifier() instanceof ParameterizedTypeTree paramNode) {
             ignoreNodes.add(paramNode.getType());
           }
           ignoreNodes.add(newClassTree.getIdentifier());
@@ -137,22 +135,22 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
     for (Map.Entry<Tree, TreePath> entry : nodes.entrySet()) {
       Tree node = entry.getKey();
       if (ignoreNodes.contains(node)) continue;
-      if (node instanceof TypeParameterTree) {
-        resolveTypeParameterTree((TypeParameterTree) node, entry.getValue());
-      } else if (node instanceof ClassTree) {
-        resolveClassTree((ClassTree) node, entry.getValue());
-      } else if (node instanceof MethodTree) {
-        resolveMethodTree((MethodTree) node, entry.getValue());
-      } else if (node instanceof VariableTree) {
-        resolveVariableTree((VariableTree) node, entry.getValue());
-      } else if (node instanceof IdentifierTree) {
-        resolveIdentifierTree((IdentifierTree) node, entry.getValue());
-      } else if (node instanceof MemberReferenceTree) {
-        resolveMemberReferenceTree((MemberReferenceTree) node, entry.getValue());
-      } else if (node instanceof MemberSelectTree) {
-        resolveMemberSelectTree((MemberSelectTree) node, entry.getValue());
-      } else if (node instanceof NewClassTree) {
-        resolveNewClassTree((NewClassTree) node, entry.getValue());
+      if (node instanceof TypeParameterTree typeParameterTree) {
+        resolveTypeParameterTree(typeParameterTree, entry.getValue());
+      } else if (node instanceof ClassTree classTree) {
+        resolveClassTree(classTree, entry.getValue());
+      } else if (node instanceof MethodTree methodTree) {
+        resolveMethodTree(methodTree, entry.getValue());
+      } else if (node instanceof VariableTree variableTree) {
+        resolveVariableTree(variableTree, entry.getValue());
+      } else if (node instanceof IdentifierTree identifierTree) {
+        resolveIdentifierTree(identifierTree, entry.getValue());
+      } else if (node instanceof MemberReferenceTree memberReferenceTree) {
+        resolveMemberReferenceTree(memberReferenceTree, entry.getValue());
+      } else if (node instanceof MemberSelectTree memberSelectTree) {
+        resolveMemberSelectTree(memberSelectTree, entry.getValue());
+      } else if (node instanceof NewClassTree newClassTree) {
+        resolveNewClassTree(newClassTree, entry.getValue());
       }
     }
   }
@@ -302,16 +300,17 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
     SymbolInformation.Kind kind = scipKind(sym);
     if (kind != SymbolInformation.Kind.UnspecifiedKind) builder.setKind(kind);
 
-    if (sym instanceof TypeElement) {
-      for (TypeElement parent : parentTypeElements((TypeElement) sym)) {
+    if (sym instanceof TypeElement typeElement) {
+      for (TypeElement parent : parentTypeElements(typeElement)) {
         String parentSymbol = scipSymbol(parent);
         if (parentSymbol.isEmpty()) continue;
         builder.addRelationships(
             Relationship.newBuilder().setSymbol(parentSymbol).setIsImplementation(true));
       }
-    } else if (sym instanceof ExecutableElement && sym.getKind() == ElementKind.METHOD) {
+    } else if (sym instanceof ExecutableElement executableElement
+        && sym.getKind() == ElementKind.METHOD) {
       for (String overridden :
-          overriddenSymbols((ExecutableElement) sym, sym.getEnclosingElement(), new HashSet<>())) {
+          overriddenSymbols(executableElement, sym.getEnclosingElement(), new HashSet<>())) {
         if (overridden.isEmpty()) continue;
         builder.addRelationships(
             Relationship.newBuilder()
@@ -321,14 +320,12 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
       }
     }
 
-    if (sym.getKind() == ElementKind.ENUM_CONSTANT && tree instanceof VariableTree) {
-      VariableTree variableTree = (VariableTree) tree;
-      if (variableTree.getInitializer() instanceof NewClassTree) {
+    if (sym.getKind() == ElementKind.ENUM_CONSTANT && tree instanceof VariableTree variableTree) {
+      if (variableTree.getInitializer() instanceof NewClassTree newClassTree) {
         String args =
-            ((NewClassTree) variableTree.getInitializer())
-                .getArguments().stream()
-                    .map(ExpressionTree::toString)
-                    .collect(Collectors.joining(", "));
+            newClassTree.getArguments().stream()
+                .map(ExpressionTree::toString)
+                .collect(Collectors.joining(", "));
         if (!args.isEmpty()) {
           builder.setDisplayName(sym.getSimpleName().toString() + "(" + args + ")");
         }
@@ -469,14 +466,14 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
   private void addParent(TypeMirror parent, Set<TypeElement> seen, List<TypeElement> out) {
     if (parent instanceof NoType) return;
     Element parentElement = types.asElement(parent);
-    if (!(parentElement instanceof TypeElement)) return;
-    if (!seen.add((TypeElement) parentElement)) return;
+    if (!(parentElement instanceof TypeElement parentTypeElement)) return;
+    if (!seen.add(parentTypeElement)) return;
     // Skip java.lang.Object: it is the implicit superclass of every class and would
     // dominate find-implementations searches in downstream tooling.
-    if (!isJavaLangObject((TypeElement) parentElement)) {
-      out.add((TypeElement) parentElement);
+    if (!isJavaLangObject(parentTypeElement)) {
+      out.add(parentTypeElement);
     }
-    collectParents((TypeElement) parentElement, seen, out);
+    collectParents(parentTypeElement, seen, out);
   }
 
   private static boolean isJavaLangObject(TypeElement element) {
@@ -487,13 +484,12 @@ final class ScipVisitor extends TreePathScanner<Void, Void> {
       ExecutableElement sym, Element enclosingElement, Set<String> out) {
     if (!(enclosingElement instanceof TypeElement)) return out;
     for (TypeMirror superType : types.directSupertypes(enclosingElement.asType())) {
-      if (!(superType instanceof DeclaredType)) continue;
-      Element superElement = ((DeclaredType) superType).asElement();
+      if (!(superType instanceof DeclaredType declaredType)) continue;
+      Element superElement = declaredType.asElement();
       if (!(superElement instanceof TypeElement)) continue;
       boolean methodFound = false;
       for (Element enclosed : superElement.getEnclosedElements()) {
-        if (!(enclosed instanceof ExecutableElement)) continue;
-        ExecutableElement candidate = (ExecutableElement) enclosed;
+        if (!(enclosed instanceof ExecutableElement candidate)) continue;
         if (!elements.overrides(sym, candidate, (TypeElement) sym.getEnclosingElement())) continue;
         String symbol = scipSymbol(candidate);
         if (!symbol.isEmpty()) out.add(symbol);

--- a/scip-javac/src/main/java/com/sourcegraph/scip_javac/TargetPaths.java
+++ b/scip-javac/src/main/java/com/sourcegraph/scip_javac/TargetPaths.java
@@ -2,12 +2,4 @@ package com.sourcegraph.scip_javac;
 
 import java.nio.file.Path;
 
-public class TargetPaths {
-  public Path classes;
-  public Path sources;
-
-  public TargetPaths(Path classesDir, Path sourcesDir) {
-    classes = classesDir;
-    sources = sourcesDir;
-  }
-}
+public record TargetPaths(Path classes, Path sources) {}

--- a/scip-maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/scip-maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -49,8 +49,7 @@ public class DependencyWriterMojo extends AbstractMojo {
                   + " referred back to.\n");
     } else {
       for (Object root : sourceRoots) {
-        if (root instanceof String) {
-          String rootString = (String) root;
+        if (root instanceof String rootString) {
           builder.append(
               String.format("%s\t%s\t%s\t%s\n", groupID, artifactID, version, rootString));
         }
@@ -58,8 +57,7 @@ public class DependencyWriterMojo extends AbstractMojo {
     }
 
     for (Object dep : artifacts) {
-      if (dep instanceof Artifact) {
-        Artifact artifact = (Artifact) dep;
+      if (dep instanceof Artifact artifact) {
         if (artifact.getFile() != null) {
           builder.append(
               String.format(

--- a/scip-shared/src/main/java/com/sourcegraph/scip/ScipDocumentBuilder.java
+++ b/scip-shared/src/main/java/com/sourcegraph/scip/ScipDocumentBuilder.java
@@ -71,8 +71,7 @@ public final class ScipDocumentBuilder {
     @Override
     public boolean equals(Object other) {
       if (this == other) return true;
-      if (!(other instanceof OccurrenceKey)) return false;
-      OccurrenceKey that = (OccurrenceKey) other;
+      if (!(other instanceof OccurrenceKey that)) return false;
       return roles == that.roles
           && Objects.equals(range, that.range)
           && Objects.equals(symbol, that.symbol);

--- a/scip-shared/src/main/java/com/sourcegraph/scip/ScipSymbols.java
+++ b/scip-shared/src/main/java/com/sourcegraph/scip/ScipSymbols.java
@@ -123,24 +123,16 @@ public final class ScipSymbols {
     }
 
     public String encode() {
-      switch (kind) {
-        case None:
-          return "";
-        case Term:
-          return encodeName(name) + ".";
-        case Method:
-          return encodeName(name) + disambiguator + ".";
-        case Type:
-          return encodeName(name) + "#";
-        case Package:
-          return encodeName(name) + "/";
-        case Parameter:
-          return "(" + encodeName(name) + ")";
-        case TypeParameter:
-          return "[" + encodeName(name) + "]";
-        default:
-          throw new IllegalArgumentException(String.format("%s", kind));
-      }
+      return switch (kind) {
+        case None -> "";
+        case Term -> encodeName(name) + ".";
+        case Method -> encodeName(name) + disambiguator + ".";
+        case Type -> encodeName(name) + "#";
+        case Package -> encodeName(name) + "/";
+        case Parameter -> "(" + encodeName(name) + ")";
+        case TypeParameter -> "[" + encodeName(name) + "]";
+        default -> throw new IllegalArgumentException(String.format("%s", kind));
+      };
     }
 
     /** Wraps non-alphanumeric identifiers in backticks, according to the SCIP spec. */

--- a/scip-shared/src/main/java/com/sourcegraph/scip/ScipSymbols.java
+++ b/scip-shared/src/main/java/com/sourcegraph/scip/ScipSymbols.java
@@ -1,7 +1,5 @@
 package com.sourcegraph.scip;
 
-import java.util.Objects;
-
 /**
  * Utilities to construct SCIP symbols.
  *
@@ -52,7 +50,7 @@ public final class ScipSymbols {
    *   <li>method descriptor "method()."
    * </ul>
    */
-  public static final class Descriptor {
+  public record Descriptor(Kind kind, String name, String disambiguator) {
 
     public static Descriptor NONE = new Descriptor(Kind.None, "", "");
 
@@ -67,18 +65,8 @@ public final class ScipSymbols {
       TypeParameter;
     }
 
-    public final Kind kind;
-    public final String name;
-    public final String disambiguator;
-
     public Descriptor(Kind kind, String name) {
       this(kind, name, "");
-    }
-
-    public Descriptor(Kind kind, String name, String disambiguator) {
-      this.kind = kind;
-      this.name = name;
-      this.disambiguator = disambiguator;
     }
 
     public Descriptor withName(String newName) {
@@ -91,35 +79,6 @@ public final class ScipSymbols {
 
     public static Descriptor local(String name) {
       return new Descriptor(Kind.Local, name);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      Descriptor that = (Descriptor) o;
-      return kind == that.kind
-          && Objects.equals(name, that.name)
-          && Objects.equals(disambiguator, that.disambiguator);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(kind, name, disambiguator);
-    }
-
-    @Override
-    public String toString() {
-      return "Descriptor{"
-          + "kind="
-          + kind
-          + ", name='"
-          + name
-          + '\''
-          + ", disambiguator='"
-          + disambiguator
-          + '\''
-          + '}';
     }
 
     public String encode() {

--- a/scip-snapshots/README.md
+++ b/scip-snapshots/README.md
@@ -7,7 +7,7 @@ This directory contains end-to-end snapshot fixtures for `scip-javac`,
 
 ```text
 cases/
-  java/common/      Java fixtures compiled with `--release 11`.
+  java/common/      Java fixtures compiled with `--release 17`.
   kotlin/common/    Kotlin fixtures, including Java interop consumers.
   mixed/            Reserved for first-class mixed-language integration cases.
 

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AbstractClasses.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AbstractClasses.java
@@ -14,7 +14,7 @@
 //                                      > public AbstractClasses()
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AbstractClasses#defaultImplementation().
     public String defaultImplementation() {
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/AbstractClasses#defaultImplementation().
 //                                      kind Method
 //                                      display_name defaultImplementation
@@ -26,7 +26,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AbstractClasses#abstractImplementation().
     public abstract String abstractImplementation();
-//                  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                         ^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/AbstractClasses#abstractImplementation().
 //                                                kind AbstractMethod
 //                                                display_name abstractImplementation

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnnotationParameters.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnnotationParameters.java
@@ -7,7 +7,7 @@
 //               display_name Bar
 //               signature_documentation
 //               > @interface Bar
-//               relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//               relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Bar#value().
     double value();
 //         ^^^^^ definition scip-java maven . . minimized/Bar#value().
@@ -26,7 +26,7 @@
 //                display_name BarB
 //                signature_documentation
 //                > @interface BarB
-//                relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/BarB#value().
     boolean value();
 //          ^^^^^ definition scip-java maven . . minimized/BarB#value().
@@ -45,10 +45,10 @@
 //                    display_name Nullable
 //                    signature_documentation
 //                    > @interface Nullable
-//                    relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                    relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Nullable#value().
     String value() default "";
-//  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //         ^^^^^ definition scip-java maven . . minimized/Nullable#value().
 //               kind AbstractMethod
 //               display_name value
@@ -66,10 +66,10 @@
 //                  display_name BarRef
 //                  signature_documentation
 //                  > @interface BarRef
-//                  relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                  relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/BarRef#value().
     SuppressWarnings value();
-//  ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+//  ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
 //                   ^^^^^ definition scip-java maven . . minimized/BarRef#value().
 //                         kind AbstractMethod
 //                         display_name value
@@ -102,8 +102,8 @@
     @Bar(~5)
 //   ^^^ reference scip-java maven . . minimized/Bar#
     @SuppressWarnings(value = "unchecked")
-//   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
-//                    ^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#value().
+//   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
+//                    ^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#value().
     double test2();
 //         ^^^^^ definition scip-java maven . . minimized/Foo#test2().
 //               kind AbstractMethod
@@ -163,8 +163,8 @@
 //  ⌄ enclosing_range_start scip-java maven . . minimized/TestRef#testCase().
     @BarRef(@SuppressWarnings(value = "unchecked"))
 //   ^^^^^^ reference scip-java maven . . minimized/BarRef#
-//           ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
-//                            ^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#value().
+//           ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
+//                            ^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#value().
     abstract double testCase();
 //                  ^^^^^^^^ definition scip-java maven . . minimized/TestRef#testCase().
 //                           kind AbstractMethod

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Annotations.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Annotations.java
@@ -4,52 +4,52 @@
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Documented#
+//                            ^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Documented#
   import java.lang.annotation.Retention;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Retention#
+//                            ^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Retention#
   import java.lang.annotation.RetentionPolicy;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/RetentionPolicy#
+//                            ^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/RetentionPolicy#
   import java.lang.annotation.Target;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Target#
+//                            ^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Target#
   
   import static java.lang.annotation.ElementType.*;
 //              ^^^^ reference scip-java maven . . java/
 //                   ^^^^ reference scip-java maven . . java/lang/
 //                        ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                                   ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#
+//                                   ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/Annotations#
   @Documented
-// ^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Documented#
+// ^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Documented#
   @Retention(RetentionPolicy.RUNTIME)
-// ^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Retention#
-//           ^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/RetentionPolicy#
-//                           ^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/RetentionPolicy#RUNTIME.
+// ^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Retention#
+//           ^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/RetentionPolicy#
+//                           ^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/RetentionPolicy#RUNTIME.
   @Target(value = {CONSTRUCTOR,
-// ^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Target#
-//        ^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Target#value().
-//                 ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#CONSTRUCTOR.
+// ^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Target#
+//        ^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Target#value().
+//                 ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#CONSTRUCTOR.
           FIELD,
-//        ^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#FIELD.
+//        ^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#FIELD.
           LOCAL_VARIABLE,
-//        ^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#LOCAL_VARIABLE.
+//        ^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#LOCAL_VARIABLE.
           METHOD,
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#METHOD.
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#METHOD.
           PACKAGE,
-//        ^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#PACKAGE.
+//        ^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#PACKAGE.
           PARAMETER,
-//        ^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#PARAMETER.
+//        ^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#PARAMETER.
           TYPE}
-//        ^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#TYPE.
+//        ^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#TYPE.
   )
   public @interface Annotations {
 //                  ^^^^^^^^^^^ definition scip-java maven . . minimized/Annotations#
@@ -60,11 +60,11 @@
 //                              > @Retention(RetentionPolicy.RUNTIME)
 //                              > @Target({CONSTRUCTOR, FIELD, LOCAL_VARIABLE, METHOD, PACKAGE, PARAMETER, TYPE})
 //                              > public @interface Annotations
-//                              relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                              relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Annotations#value().
     String value() default "";
-//  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //         ^^^^^ definition scip-java maven . . minimized/Annotations#value().
 //               kind AbstractMethod
 //               display_name value
@@ -74,7 +74,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Annotations#format().
     String format() default "";
-//  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //         ^^^^^^ definition scip-java maven . . minimized/Annotations#format().
 //                kind AbstractMethod
 //                display_name format

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnnotationsOnParameterizedTypes.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnnotationsOnParameterizedTypes.java
@@ -4,27 +4,27 @@
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^ reference scip-java maven . . java/lang/reflect/
-//                         ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/Constructor#
+//                         ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/Constructor#
   import java.lang.reflect.InvocationHandler;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^ reference scip-java maven . . java/lang/reflect/
-//                         ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/InvocationHandler#
+//                         ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/InvocationHandler#
   import java.util.concurrent.ConcurrentHashMap;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/util/concurrent/
-//                            ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/concurrent/ConcurrentHashMap#
+//                            ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/concurrent/ConcurrentHashMap#
   import java.util.concurrent.ConcurrentMap;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/util/concurrent/
-//                            ^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/concurrent/ConcurrentMap#
+//                            ^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/concurrent/ConcurrentMap#
   import java.util.function.Function;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
 //                 ^^^^^^^^ reference scip-java maven . . java/util/function/
-//                          ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
+//                          ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/AnnotationsOnParameterizedTypes#
   public interface AnnotationsOnParameterizedTypes {
@@ -63,7 +63,7 @@
 //        display_name W
 //        signature_documentation
 //        > W
-//         ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
+//         ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
 //                  ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter().[W]
 //                     ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter().[C]
 //                        ^^^^^^^ definition scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter().
@@ -72,13 +72,13 @@
 //                                signature_documentation
 //                                > public abstract <C, W> Function<W, C> adapter(Class<C> contract, Class<W> wrappedClass)
 //                                relationship scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter(). implementation reference
-//                                ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
+//                                ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
 //                                      ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter().[C]
 //                                         ^^^^^^^^ definition local 0
 //                                                  display_name contract
 //                                                  signature_documentation
 //                                                  > Class<C> contract
-//                                                   ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
+//                                                   ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
 //                                                         ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter().[W]
 //                                                            ^^^^^^^^^^^^ definition local 1
 //                                                                         display_name wrappedClass
@@ -109,22 +109,22 @@
 //                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypes#
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#proxyConstructors.
     private ConcurrentMap<Class<?>, Constructor<?>> proxyConstructors = new ConcurrentHashMap<>();
-//          ^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/concurrent/ConcurrentMap#
-//                        ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
-//                                  ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/Constructor#
+//          ^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/concurrent/ConcurrentMap#
+//                        ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
+//                                  ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/Constructor#
 //                                                  ^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#proxyConstructors.
 //                                                                    kind Field
 //                                                                    display_name proxyConstructors
 //                                                                    signature_documentation
 //                                                                    > private ConcurrentMap<Class<?>, Constructor<?>> proxyConstructors
-//                                                                          ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/concurrent/ConcurrentHashMap#`<init>`().
+//                                                                          ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/concurrent/ConcurrentHashMap#`<init>`().
 //                                                                                               ⌃ enclosing_range_end scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#proxyConstructors.
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[C]
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[W]
 //  ⌄ enclosing_range_start scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().
     @Override
-//   ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//   ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 //                                       ⌄ enclosing_range_start local 2
 //                                                          ⌄ enclosing_range_start local 3
     public <C, W> Function<W, C> adapter(Class<C> contract, Class<W> wrappedClass) {
@@ -138,7 +138,7 @@
 //               display_name W
 //               signature_documentation
 //               > W
-//                ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
+//                ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
 //                         ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[W]
 //                            ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[C]
 //                               ^^^^^^^ definition scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().
@@ -148,13 +148,13 @@
 //                                       > @Override
 //                                       > public <C, W> Function<W, C> adapter(Class<C> contract, Class<W> wrappedClass)
 //                                       relationship scip-java maven . . minimized/AnnotationsOnParameterizedTypes#adapter(). implementation reference
-//                                       ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
+//                                       ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
 //                                             ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[C]
 //                                                ^^^^^^^^ definition local 2
 //                                                         display_name contract
 //                                                         signature_documentation
 //                                                         > Class<C> contract
-//                                                          ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
+//                                                          ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
 //                                                                ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[W]
 //                                                                   ^^^^^^^^^^^^ definition local 3
 //                                                                                display_name wrappedClass
@@ -165,8 +165,8 @@
   
 //    ⌄ enclosing_range_start local 4
       Function<InvocationHandler, C> constructor = getConstructor(contract);
-//    ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
-//             ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/InvocationHandler#
+//    ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
+//             ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/InvocationHandler#
 //                                ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#adapter().[C]
 //                                   ^^^^^^^^^^^ definition local 4
 //                                               kind Variable
@@ -178,9 +178,9 @@
 //                                                                         ⌃ enclosing_range_end local 4
   
       System.out.println(constructor);
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+9).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+9).
 //                       ^^^^^^^^^^^ reference local 4
   
       return null;
@@ -198,15 +198,15 @@
 //             display_name T
 //             signature_documentation
 //             > T
-//              ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
-//                       ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/InvocationHandler#
+//              ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
+//                       ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/InvocationHandler#
 //                                          ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#getConstructor().[T]
 //                                             ^^^^^^^^^^^^^^ definition scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#getConstructor().
 //                                                            kind Method
 //                                                            display_name getConstructor
 //                                                            signature_documentation
 //                                                            > private <T> Function<InvocationHandler, T> getConstructor(Class<T> contract)
-//                                                            ^^^^^ reference scip-java maven jdk 11 java/lang/Class#
+//                                                            ^^^^^ reference scip-java maven jdk 17 java/lang/Class#
 //                                                                  ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#getConstructor().[T]
 //                                                                     ^^^^^^^^ definition local 5
 //                                                                              display_name contract
@@ -215,10 +215,10 @@
 //                                                                            ⌃ enclosing_range_end local 5
 //    ⌄ enclosing_range_start local 6
       @SuppressWarnings("unchecked")
-//     ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+//     ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
 //                                                                                              ⌄ enclosing_range_start local 7
       Constructor<T> constructor = (Constructor<T>) proxyConstructors.computeIfAbsent(contract, c -> {
-//    ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/Constructor#
+//    ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/Constructor#
 //                ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#getConstructor().[T]
 //                   ^^^^^^^^^^^ definition local 6
 //                               kind Variable
@@ -226,10 +226,10 @@
 //                               signature_documentation
 //                               > @SuppressWarnings("unchecked")
 //                               > Constructor<T> constructor
-//                                  ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/reflect/Constructor#
+//                                  ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/reflect/Constructor#
 //                                              ^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#getConstructor().[T]
 //                                                  ^^^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/AnnotationsOnParameterizedTypesImpl#proxyConstructors.
-//                                                                    ^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/concurrent/ConcurrentMap#computeIfAbsent().
+//                                                                    ^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/concurrent/ConcurrentMap#computeIfAbsent().
 //                                                                                    ^^^^^^^^ reference local 5
 //                                                                                              ^ definition local 7
 //                                                                                                display_name c
@@ -241,9 +241,9 @@
 //      ⌃ enclosing_range_end local 6
   
       System.out.println(constructor);
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+9).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+9).
 //                       ^^^^^^^^^^^ reference local 6
   
       return null;

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnonymousClasses.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/AnonymousClasses.java
@@ -4,11 +4,11 @@
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
 //                 ^^^^^^^^ reference scip-java maven . . java/util/function/
-//                          ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
+//                          ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/AnonymousClasses#
   @SuppressWarnings("ALL")
-// ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
   public class AnonymousClasses {
 //             ^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/AnonymousClasses#
 //                              kind Class
@@ -36,32 +36,32 @@
 //                            ⌃ enclosing_range_end local 0
 //    ⌄ enclosing_range_start local 1
       Function<Integer, Integer> fn =
-//    ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
-//             ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
-//                      ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//    ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
+//             ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
+//                      ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                               ^^ definition local 1
 //                                  kind Variable
 //                                  display_name fn
 //                                  signature_documentation
 //                                  > Function<Integer, Integer> fn
           new Function<Integer, Integer>() {
-//            ^^^^^^^^ reference scip-java maven jdk 11 java/util/function/Function#
-//                     ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
-//                              ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//            ^^^^^^^^ reference scip-java maven jdk 17 java/util/function/Function#
+//                     ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
+//                              ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //          ⌄ enclosing_range_start local 3
             @Override
-//           ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//           ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 //                               ⌄ enclosing_range_start local 4
             public Integer apply(Integer integer) {
-//                 ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//                 ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                         ^^^^^ definition local 3
 //                               kind Method
 //                               display_name apply
 //                               signature_documentation
 //                               > @Override
 //                               > public Integer apply(Integer integer)
-//                               relationship scip-java maven jdk 11 java/util/function/Function#apply(). implementation reference
-//                               ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//                               relationship scip-java maven jdk 17 java/util/function/Function#apply(). implementation reference
+//                               ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                                       ^^^^^^^ definition local 4
 //                                               display_name integer
 //                                               signature_documentation
@@ -77,7 +77,7 @@
   
       return fn.apply(n);
 //           ^^ reference local 1
-//              ^^^^^ reference scip-java maven jdk 11 java/util/function/Function#apply().
+//              ^^^^^ reference scip-java maven jdk 17 java/util/function/Function#apply().
 //                    ^ reference local 0
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/AnonymousClasses#app().

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Arrays.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Arrays.java
@@ -14,7 +14,7 @@
 //                    > public Arrays()
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Arrays#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Arrays#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -30,7 +30,7 @@
 //                       ⌃ enclosing_range_end local 0
 //    ⌄ enclosing_range_start local 1
       String[] b = {"1", "2", "3"};
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //             ^ definition local 1
 //               kind Variable
 //               display_name b
@@ -47,7 +47,7 @@
 //                               ⌃ enclosing_range_end local 2
 //    ⌄ enclosing_range_start local 3
       String[][] d = {{"1"}, {"2"}, {"3"}};
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //               ^ definition local 3
 //                 kind Variable
 //                 display_name d

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ClassOf.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ClassOf.java
@@ -14,7 +14,7 @@
 //                     > public ClassOf()
 //  ⌄ enclosing_range_start scip-java maven . . minimized/ClassOf#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/ClassOf#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -23,7 +23,7 @@
       return ClassOf.class.getName();
 //           ^^^^^^^ reference scip-java maven . . minimized/ClassOf#
 //                   ^^^^^ reference scip-java maven . . minimized/ClassOf#class.
-//                         ^^^^^^^ reference scip-java maven jdk 11 java/lang/Class#getName().
+//                         ^^^^^^^ reference scip-java maven jdk 17 java/lang/Class#getName().
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/ClassOf#app().
   }

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Docstrings.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Docstrings.java
@@ -79,15 +79,15 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Docstrings#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Docstrings#app().
 //                           kind StaticMethod
 //                           display_name app
 //                           signature_documentation
 //                           > public static String app()
       return String.format("%s%s%s", field, method(), methodParameter(42));
-//           ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
-//                  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#format().
+//           ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
+//                  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#format().
 //                                   ^^^^^ reference scip-java maven . . minimized/Docstrings#field.
 //                                          ^^^^^^ reference scip-java maven . . minimized/Docstrings#method().
 //                                                    ^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Docstrings#methodParameter().

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/EnumImplementsInterface.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/EnumImplementsInterface.java
@@ -3,7 +3,7 @@
   import java.io.Serializable;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^ reference scip-java maven . . java/io/
-//               ^^^^^^^^^^^^ reference scip-java maven jdk 11 java/io/Serializable#
+//               ^^^^^^^^^^^^ reference scip-java maven jdk 17 java/io/Serializable#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/EnumImplementsInterface#
   enum EnumImplementsInterface implements Serializable {
@@ -12,16 +12,16 @@
 //                             display_name EnumImplementsInterface
 //                             signature_documentation
 //                             > enum EnumImplementsInterface implements Serializable
-//                             relationship scip-java maven jdk 11 java/io/Serializable# implementation
-//                             relationship scip-java maven jdk 11 java/lang/Comparable# implementation
-//                             relationship scip-java maven jdk 11 java/lang/Enum# implementation
-//                             relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
+//                             relationship scip-java maven jdk 17 java/io/Serializable# implementation
+//                             relationship scip-java maven jdk 17 java/lang/Comparable# implementation
+//                             relationship scip-java maven jdk 17 java/lang/Enum# implementation
+//                             relationship scip-java maven jdk 17 java/lang/constant/Constable# implementation
 //     ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/EnumImplementsInterface#`<init>`().
 //                             kind Constructor
 //                             display_name <init>
 //                             signature_documentation
 //                             > private EnumImplementsInterface()
-//                                        ^^^^^^^^^^^^ reference scip-java maven jdk 11 java/io/Serializable#
+//                                        ^^^^^^^^^^^^ reference scip-java maven jdk 17 java/io/Serializable#
 //  ⌄ enclosing_range_start scip-java maven . . minimized/EnumImplementsInterface#A.
     A,
 //  ^ definition scip-java maven . . minimized/EnumImplementsInterface#A.

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/EnumImplementsInterface.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/EnumImplementsInterface.java
@@ -15,6 +15,7 @@
 //                             relationship scip-java maven jdk 11 java/io/Serializable# implementation
 //                             relationship scip-java maven jdk 11 java/lang/Comparable# implementation
 //                             relationship scip-java maven jdk 11 java/lang/Enum# implementation
+//                             relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
 //     ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/EnumImplementsInterface#`<init>`().
 //                             kind Constructor
 //                             display_name <init>

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Enums.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Enums.java
@@ -20,6 +20,7 @@
 //           relationship scip-java maven jdk 11 java/io/Serializable# implementation
 //           relationship scip-java maven jdk 11 java/lang/Comparable# implementation
 //           relationship scip-java maven jdk 11 java/lang/Enum# implementation
+//           relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Enums#A.
     A("A", 420),
 //  ^ definition scip-java maven . . minimized/Enums#A.

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Enums.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Enums.java
@@ -3,12 +3,12 @@
   import java.util.Arrays;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^ reference scip-java maven jdk 11 java/util/Arrays#
+//                 ^^^^^^ reference scip-java maven jdk 17 java/util/Arrays#
   import java.util.stream.Collectors;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
 //                 ^^^^^^ reference scip-java maven . . java/util/stream/
-//                        ^^^^^^^^^^ reference scip-java maven jdk 11 java/util/stream/Collectors#
+//                        ^^^^^^^^^^ reference scip-java maven jdk 17 java/util/stream/Collectors#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/Enums#
   enum Enums {
@@ -17,10 +17,10 @@
 //           display_name Enums
 //           signature_documentation
 //           > enum Enums
-//           relationship scip-java maven jdk 11 java/io/Serializable# implementation
-//           relationship scip-java maven jdk 11 java/lang/Comparable# implementation
-//           relationship scip-java maven jdk 11 java/lang/Enum# implementation
-//           relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
+//           relationship scip-java maven jdk 17 java/io/Serializable# implementation
+//           relationship scip-java maven jdk 17 java/lang/Comparable# implementation
+//           relationship scip-java maven jdk 17 java/lang/Enum# implementation
+//           relationship scip-java maven jdk 17 java/lang/constant/Constable# implementation
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Enums#A.
     A("A", 420),
 //  ^ definition scip-java maven . . minimized/Enums#A.
@@ -47,7 +47,7 @@
 //          ⌃ enclosing_range_end scip-java maven . . minimized/Enums#C.
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Enums#value.
     public String value;
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^^^ definition scip-java maven . . minimized/Enums#value.
 //                      kind Field
 //                      display_name value
@@ -64,7 +64,7 @@
 //        display_name <init>
 //        signature_documentation
 //        > private Enums(String value, int a)
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //               ^^^^^ definition local 0
 //                     display_name value
 //                     signature_documentation
@@ -83,7 +83,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Enums#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Enums#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -92,29 +92,29 @@
 //    ⌄ enclosing_range_start local 2
 //                                             ⌄ enclosing_range_start local 3
       String all = Arrays.stream(values()).map(e -> e.value).map(Enums::valueOf).collect(Collectors.toList()).toString();
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //           ^^^ definition local 2
 //               kind Variable
 //               display_name all
 //               signature_documentation
 //               > String all
-//                 ^^^^^^ reference scip-java maven jdk 11 java/util/Arrays#
-//                        ^^^^^^ reference scip-java maven jdk 11 java/util/Arrays#stream().
+//                 ^^^^^^ reference scip-java maven jdk 17 java/util/Arrays#
+//                        ^^^^^^ reference scip-java maven jdk 17 java/util/Arrays#stream().
 //                               ^^^^^^ reference scip-java maven . . minimized/Enums#values().
-//                                         ^^^ reference scip-java maven jdk 11 java/util/stream/Stream#map().
+//                                         ^^^ reference scip-java maven jdk 17 java/util/stream/Stream#map().
 //                                             ^ definition local 3
 //                                               display_name e
 //                                               signature_documentation
 //                                               > Enums e
 //                                                  ^ reference local 3
 //                                                    ^^^^^ reference scip-java maven . . minimized/Enums#value.
-//                                                           ^^^ reference scip-java maven jdk 11 java/util/stream/Stream#map().
+//                                                           ^^^ reference scip-java maven jdk 17 java/util/stream/Stream#map().
 //                                                               ^^^^^ reference scip-java maven . . minimized/Enums#
 //                                                                      ^^^^^^^ reference scip-java maven . . minimized/Enums#valueOf().
-//                                                                               ^^^^^^^ reference scip-java maven jdk 11 java/util/stream/Stream#collect(+1).
-//                                                                                       ^^^^^^^^^^ reference scip-java maven jdk 11 java/util/stream/Collectors#
-//                                                                                                  ^^^^^^ reference scip-java maven jdk 11 java/util/stream/Collectors#toList().
-//                                                                                                            ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Object#toString().
+//                                                                               ^^^^^^^ reference scip-java maven jdk 17 java/util/stream/Stream#collect(+1).
+//                                                                                       ^^^^^^^^^^ reference scip-java maven jdk 17 java/util/stream/Collectors#
+//                                                                                                  ^^^^^^ reference scip-java maven jdk 17 java/util/stream/Collectors#toList().
+//                                                                                                            ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Object#toString().
 //                                             ⌃ enclosing_range_end local 3
 //                                                                                                                      ⌃ enclosing_range_end local 2
       return all + A.value + B.value + C.value;

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Fields.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Fields.java
@@ -118,7 +118,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Fields#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Fields#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -156,8 +156,8 @@
 //                                              ^^^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Fields#InnerStaticFields#`<init>`().
 //                                                                 ⌃ enclosing_range_end local 2
       return String.valueOf(fields.privateField)
-//           ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
-//                  ^^^^^^^ reference scip-java maven jdk 11 java/lang/String#valueOf(+5).
+//           ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
+//                  ^^^^^^^ reference scip-java maven jdk 17 java/lang/String#valueOf(+5).
 //                          ^^^^^^ reference local 0
 //                                 ^^^^^^^^^^^^ reference scip-java maven . . minimized/Fields#privateField.
           + fields.protectedField

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ForComprehensions.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ForComprehensions.java
@@ -3,11 +3,11 @@
   import java.util.Collections;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#
+//                 ^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#
   import java.util.List;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^ reference scip-java maven jdk 11 java/util/List#
+//                 ^^^^ reference scip-java maven jdk 17 java/util/List#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/ForComprehensions#
   public class ForComprehensions {
@@ -36,15 +36,15 @@
 //                            ⌃ enclosing_range_end local 0
 //    ⌄ enclosing_range_start local 1
       List<Integer> integers = Collections.singletonList(n);
-//    ^^^^ reference scip-java maven jdk 11 java/util/List#
-//         ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//    ^^^^ reference scip-java maven jdk 17 java/util/List#
+//         ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                  ^^^^^^^^ definition local 1
 //                           kind Variable
 //                           display_name integers
 //                           signature_documentation
 //                           > List<Integer> integers
-//                             ^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#
-//                                         ^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#singletonList().
+//                             ^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#
+//                                         ^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#singletonList().
 //                                                       ^ reference local 0
 //                                                         ⌃ enclosing_range_end local 1
 //    ⌄ enclosing_range_start local 2

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/InnerClasses.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/InnerClasses.java
@@ -19,7 +19,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#STRING.
     private static final String STRING = "asdf";
-//                       ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                       ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                              ^^^^^^ definition scip-java maven . . minimized/InnerClasses#STRING.
 //                                     kind StaticField
 //                                     display_name STRING
@@ -70,10 +70,10 @@
 //                        display_name InnerEnum
 //                        signature_documentation
 //                        > public enum InnerEnum
-//                        relationship scip-java maven jdk 11 java/io/Serializable# implementation
-//                        relationship scip-java maven jdk 11 java/lang/Comparable# implementation
-//                        relationship scip-java maven jdk 11 java/lang/Enum# implementation
-//                        relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
+//                        relationship scip-java maven jdk 17 java/io/Serializable# implementation
+//                        relationship scip-java maven jdk 17 java/lang/Comparable# implementation
+//                        relationship scip-java maven jdk 17 java/lang/Enum# implementation
+//                        relationship scip-java maven jdk 17 java/lang/constant/Constable# implementation
 //              ^^^^^^^^^ definition scip-java maven . . minimized/InnerClasses#InnerEnum#`<init>`().
 //                        kind Constructor
 //                        display_name <init>
@@ -154,7 +154,7 @@
 //                                    display_name InnerAnnotation
 //                                    signature_documentation
 //                                    > public @interface InnerAnnotation
-//                                    relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                                    relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //    ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#InnerAnnotation#value().
       int value();
 //        ^^^^^ definition scip-java maven . . minimized/InnerClasses#InnerAnnotation#value().
@@ -168,7 +168,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#InnerStaticClass#
     @SuppressWarnings(STRING + " ")
-//   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+//   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
 //                    ^^^^^^ reference scip-java maven . . minimized/InnerClasses#STRING.
     @InnerAnnotation(top / bottom)
 //   ^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerAnnotation#
@@ -208,8 +208,8 @@
 //                          > public class InnerClass implements InnerInterface<Integer, Integer>
 //                          relationship scip-java maven . . minimized/InnerClasses#InnerInterface# implementation
 //                                     ^^^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerInterface#
-//                                                    ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
-//                                                             ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//                                                    ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
+//                                                             ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //    ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#InnerClass#field.
       private final int field;
 //                      ^^^^^ definition scip-java maven . . minimized/InnerClasses#InnerClass#field.
@@ -246,9 +246,9 @@
 //                            signature_documentation
 //                            > public void innerMethod()
         System.out.println(field + exampleField);
-//      ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//             ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                 ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+3).
+//      ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//             ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                 ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+3).
 //                         ^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerClass#field.
 //                                 ^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#exampleField.
       }
@@ -256,10 +256,10 @@
   
 //    ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#InnerClass#apply().
       @Override
-//     ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//     ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 //                         ⌄ enclosing_range_start local 3
       public Integer apply(Integer integer) {
-//           ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//           ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                   ^^^^^ definition scip-java maven . . minimized/InnerClasses#InnerClass#apply().
 //                         kind Method
 //                         display_name apply
@@ -267,7 +267,7 @@
 //                         > @Override
 //                         > public Integer apply(Integer integer)
 //                         relationship scip-java maven . . minimized/InnerClasses#InnerInterface#apply(). implementation reference
-//                         ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//                         ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                                 ^^^^^^^ definition local 3
 //                                         display_name integer
 //                                         signature_documentation
@@ -341,10 +341,10 @@
 //                                                  > InnerEnum magicEnum
 //                                                ⌃ enclosing_range_end local 6
       if (System.nanoTime() > System.currentTimeMillis()) {
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//               ^^^^^^^^ reference scip-java maven jdk 11 java/lang/System#nanoTime().
-//                            ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//                                   ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/System#currentTimeMillis().
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//               ^^^^^^^^ reference scip-java maven jdk 17 java/lang/System#nanoTime().
+//                            ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//                                   ^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/System#currentTimeMillis().
         magicEnum = InnerEnum.B;
 //      ^^^^^^^^^ reference local 6
 //                  ^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#
@@ -355,16 +355,16 @@
         case B:
 //           ^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#B.
           System.out.println("b");
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//               ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                   ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//               ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                   ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
           break;
         case A:
 //           ^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#A.
           System.out.println("a");
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//               ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                   ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//               ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                   ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
           break;
         default:
           break;
@@ -373,20 +373,20 @@
 //        ^^^^^^^^^ reference local 6
 //                     ^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#
 //                               ^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#A.
-//                                  ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//                                         ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                                             ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//                                  ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//                                         ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                                             ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
       else if (magicEnum == InnerEnum.C) System.out.println("b");
 //             ^^^^^^^^^ reference local 6
 //                          ^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#
 //                                    ^ reference scip-java maven . . minimized/InnerClasses#InnerEnum#C.
-//                                       ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//                                              ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                                                  ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//                                       ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//                                              ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                                                  ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
       else System.out.println("c");
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//                ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//                    ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//                ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//                    ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/InnerClasses#testEnum().
   
@@ -400,8 +400,8 @@
 //    ⌄ enclosing_range_start local 7
       InnerInterface<String, String> fn =
 //    ^^^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerInterface#
-//                   ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
-//                           ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                   ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
+//                           ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                   ^^ definition local 7
 //                                      kind Variable
 //                                      display_name fn
@@ -409,14 +409,14 @@
 //                                      > InnerInterface<String, String> fn
           new InnerInterface<String, String>() {
 //            ^^^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerInterface#
-//                           ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
-//                                   ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                           ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
+//                                   ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //          ⌄ enclosing_range_start local 9
             @Override
-//           ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//           ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 //                              ⌄ enclosing_range_start local 10
             public String apply(String s) {
-//                 ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                 ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                        ^^^^^ definition local 9
 //                              kind Method
 //                              display_name apply
@@ -424,7 +424,7 @@
 //                              > @Override
 //                              > public String apply(String s)
 //                              relationship scip-java maven . . minimized/InnerClasses#InnerInterface#apply(). implementation reference
-//                              ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                              ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                     ^ definition local 10
 //                                       display_name s
 //                                       signature_documentation
@@ -437,9 +437,9 @@
           };
 //         ⌃ enclosing_range_end local 7
       System.out.println(fn.apply("a"));
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
 //                       ^^ reference local 7
 //                          ^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerInterface#apply().
     }
@@ -447,7 +447,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/InnerClasses#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/InnerClasses#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -491,9 +491,9 @@
 //    ^^^^^^^^^^ reference local 13
 //               ^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#InnerClass#innerMethod().
       System.out.println(runInnerInterface(innerClass, a));
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+9).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+9).
 //                       ^^^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/InnerClasses#runInnerInterface().
 //                                         ^^^^^^^^^^ reference local 13
 //                                                     ^ reference local 11

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/InnerClasses.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/InnerClasses.java
@@ -73,6 +73,7 @@
 //                        relationship scip-java maven jdk 11 java/io/Serializable# implementation
 //                        relationship scip-java maven jdk 11 java/lang/Comparable# implementation
 //                        relationship scip-java maven jdk 11 java/lang/Enum# implementation
+//                        relationship scip-java maven jdk 11 java/lang/constant/Constable# implementation
 //              ^^^^^^^^^ definition scip-java maven . . minimized/InnerClasses#InnerEnum#`<init>`().
 //                        kind Constructor
 //                        display_name <init>

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Interfaces.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Interfaces.java
@@ -18,7 +18,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Interfaces#abstractInterfaceMethod().
     String abstractInterfaceMethod();
-//  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //         ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/Interfaces#abstractInterfaceMethod().
 //                                 kind AbstractMethod
 //                                 display_name abstractInterfaceMethod
@@ -29,7 +29,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Interfaces#defaultInterfaceMethod().
     default String defaultInterfaceMethod() {
-//          ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//          ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                 ^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/Interfaces#defaultInterfaceMethod().
 //                                        kind Method
 //                                        display_name defaultInterfaceMethod

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/LombokBuilder.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/LombokBuilder.java
@@ -12,18 +12,18 @@
 //⌄ enclosing_range_start scip-java maven . . minimized/Hello#HelloBuilder#message().
 //⌄ enclosing_range_start local 1
   @lombok.Builder
-//^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+//^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
 //^^^^^^^^^^^^^^^ reference scip-java maven . . java/lang/
 //^^^^^^^^^^^^^^^ reference scip-java maven . . java/
-//^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Hello#message.
 //^^^^^^^^^^^^^^^ reference local 0
-//^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#value().
+//^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#value().
 //^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Hello#HelloBuilder#
 //^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Hello#
 //^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/Hello#HelloBuilder#message.
 //^^^^^^^^^^^^^^^ reference local 1
-//^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 // ^^^^^^ reference scip-java maven . . lombok/
 //        ^^^^^^^ reference scip-java maven . . lombok/Builder#
 //              ⌃ enclosing_range_end scip-java maven . . minimized/Hello#HelloBuilder#build().
@@ -52,7 +52,7 @@
 //      ^^^^^ reference scip-java maven . . minimized/Hello#`<init>`().
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Hello#message.
     private String message;
-//          ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//          ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                 ^^^^^^^ definition scip-java maven . . minimized/Hello#message.
 //                         kind Field
 //                         display_name message

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Methods.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Methods.java
@@ -33,13 +33,13 @@
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Methods#overload(+1).
 //                          ⌄ enclosing_range_start local 1
     private String overload(String value) {
-//          ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//          ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                 ^^^^^^^^ definition scip-java maven . . minimized/Methods#overload(+1).
 //                          kind Method
 //                          display_name overload
 //                          signature_documentation
 //                          > private String overload(String value)
-//                          ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                          ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                 ^^^^^ definition local 1
 //                                       display_name value
 //                                       signature_documentation
@@ -71,13 +71,13 @@
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Methods#staticOverload(+1).
 //                                       ⌄ enclosing_range_start local 3
     private static String staticOverload(String value) {
-//                 ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                 ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                        ^^^^^^^^^^^^^^ definition scip-java maven . . minimized/Methods#staticOverload(+1).
 //                                       kind StaticMethod
 //                                       display_name staticOverload
 //                                       signature_documentation
 //                                       > private static String staticOverload(String value)
-//                                       ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                                       ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                              ^^^^^ definition local 3
 //                                                    display_name value
 //                                                    signature_documentation
@@ -92,7 +92,7 @@
 //                           ⌄ enclosing_range_start local 4
 //                                  ⌄ enclosing_range_start local 5
     public static String app(int n, String m) throws RuntimeException, IndexOutOfBoundsException {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Methods#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -102,13 +102,13 @@
 //                                 display_name n
 //                                 signature_documentation
 //                                 > int n
-//                                  ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                                  ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                         ^ definition local 5
 //                                           display_name m
 //                                           signature_documentation
 //                                           > String m
-//                                                   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/RuntimeException#
-//                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/IndexOutOfBoundsException#
+//                                                   ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/RuntimeException#
+//                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/IndexOutOfBoundsException#
 //                               ⌃ enclosing_range_end local 4
 //                                         ⌃ enclosing_range_end local 5
 //    ⌄ enclosing_range_start local 6
@@ -133,7 +133,7 @@
 //                             ⌃ enclosing_range_end local 7
 //    ⌄ enclosing_range_start local 8
       String b = staticOverload(m);
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //           ^ definition local 8
 //             kind Variable
 //             display_name b
@@ -155,7 +155,7 @@
 //                               ⌃ enclosing_range_end local 9
 //    ⌄ enclosing_range_start local 10
       String d = methods.overload(m);
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //           ^ definition local 10
 //             kind Variable
 //             display_name d

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/MinimizedJavaMain.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/MinimizedJavaMain.java
@@ -25,7 +25,7 @@
 //                          display_name main
 //                          signature_documentation
 //                          > public static void main(String[] args)
-//                          ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                          ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                   ^^^^ definition local 0
 //                                        display_name args
 //                                        signature_documentation
@@ -37,9 +37,9 @@
 //                          ^^^^^^^^^^^^^ reference scip-java maven . . minimized/TypeVariables#
 //                                        ^^ reference scip-java maven . . minimized/TypeVariables#CT#`<init>`().
       System.out.println(
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+8).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+8).
           Methods.app(42, "42")
 //        ^^^^^^^ reference scip-java maven . . minimized/Methods#
 //                ^^^ reference scip-java maven . . minimized/Methods#app().
@@ -63,13 +63,13 @@
 //                         ^^^ reference scip-java maven . . minimized/Primitives#app().
               + new ParameterizedTypes<Integer, String>().app(42, "42")
 //                  ^^^^^^^^^^^^^^^^^^ reference scip-java maven . . minimized/ParameterizedTypes#`<init>`().
-//                                     ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
-//                                              ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                                     ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
+//                                              ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                                        ^^^ reference scip-java maven . . minimized/ParameterizedTypes#app().
               + RawTypes.x.toString()
 //              ^^^^^^^^ reference scip-java maven . . minimized/RawTypes#
 //                       ^ reference scip-java maven . . minimized/RawTypes#x.
-//                         ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Object#toString().
+//                         ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Object#toString().
               + ClassOf.app()
 //              ^^^^^^^ reference scip-java maven . . minimized/ClassOf#
 //                      ^^^ reference scip-java maven . . minimized/ClassOf#app().

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/OverloadResolution.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/OverloadResolution.java
@@ -29,13 +29,13 @@
 //                        signature_documentation
 //                        > public static int app()
       return "".lastIndexOf('a')
-//              ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/String#lastIndexOf().
+//              ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/String#lastIndexOf().
           + "".lastIndexOf('b', 0)
-//             ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/String#lastIndexOf(+1).
+//             ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/String#lastIndexOf(+1).
           + "".lastIndexOf("c")
-//             ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/String#lastIndexOf(+2).
+//             ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/String#lastIndexOf(+2).
           + "".lastIndexOf("d", 0);
-//             ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/String#lastIndexOf(+3).
+//             ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/String#lastIndexOf(+3).
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/OverloadResolution#app().
   }

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Overrides.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Overrides.java
@@ -33,9 +33,9 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Overrides#toString().
     @Override
-//   ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//   ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
     public String toString() {
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^^^^^^ definition scip-java maven . . minimized/Overrides#toString().
 //                         kind Method
 //                         display_name toString
@@ -43,7 +43,7 @@
 //                         > @Override
 //                         > public String toString()
 //                         relationship scip-java maven . . minimized/Overrides#Child#toString(). implementation reference
-//                         relationship scip-java maven jdk 11 java/lang/Object#toString(). implementation reference
+//                         relationship scip-java maven jdk 17 java/lang/Object#toString(). implementation reference
       return "";
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/Overrides#toString().
@@ -65,7 +65,7 @@
       // Same-file override of a concrete superclass method.
 //    ⌄ enclosing_range_start scip-java maven . . minimized/Overrides#Child#stuff().
       @Override
-//     ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//     ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
       public void stuff() {}
 //                ^^^^^ definition scip-java maven . . minimized/Overrides#Child#stuff().
 //                      kind Method
@@ -81,9 +81,9 @@
       // relationships.
 //    ⌄ enclosing_range_start scip-java maven . . minimized/Overrides#Child#toString().
       @Override
-//     ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//     ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
       public String toString() {
-//           ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//           ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                  ^^^^^^^^ definition scip-java maven . . minimized/Overrides#Child#toString().
 //                           kind Method
 //                           display_name toString
@@ -91,7 +91,7 @@
 //                           > @Override
 //                           > public String toString()
 //                           relationship scip-java maven . . minimized/Overrides#toString(). implementation reference
-//                           relationship scip-java maven jdk 11 java/lang/Object#toString(). implementation reference
+//                           relationship scip-java maven jdk 17 java/lang/Object#toString(). implementation reference
         return "";
       }
 //    ⌃ enclosing_range_end scip-java maven . . minimized/Overrides#Child#toString().

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ParameterizedTypes.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/ParameterizedTypes.java
@@ -3,19 +3,19 @@
   import java.util.HashMap;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^^ reference scip-java maven jdk 11 java/util/HashMap#
+//                 ^^^^^^^ reference scip-java maven jdk 17 java/util/HashMap#
   import java.util.Iterator;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^^^ reference scip-java maven jdk 11 java/util/Iterator#
+//                 ^^^^^^^^ reference scip-java maven jdk 17 java/util/Iterator#
   import java.util.List;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^ reference scip-java maven jdk 11 java/util/List#
+//                 ^^^^ reference scip-java maven jdk 17 java/util/List#
   import java.util.Map;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^ reference scip-java maven jdk 11 java/util/Map#
+//                 ^^^ reference scip-java maven jdk 17 java/util/Map#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#
 //⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#[A]
@@ -41,7 +41,7 @@
 //                                     display_name B
 //                                     signature_documentation
 //                                     > B extends String
-//                                             ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                                             ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //  ⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#iteratorable().[T]
 //  ⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#iteratorable().
 //                                                                 ⌄ enclosing_range_start local 0
@@ -51,16 +51,16 @@
 //            display_name T
 //            signature_documentation
 //            > T extends Iterable<A> & Iterator<B>
-//                    ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Iterable#
+//                    ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Iterable#
 //                             ^ reference scip-java maven . . minimized/ParameterizedTypes#[A]
-//                                  ^^^^^^^^ reference scip-java maven jdk 11 java/util/Iterator#
+//                                  ^^^^^^^^ reference scip-java maven jdk 17 java/util/Iterator#
 //                                           ^ reference scip-java maven . . minimized/ParameterizedTypes#[B]
 //                                                    ^^^^^^^^^^^^ definition scip-java maven . . minimized/ParameterizedTypes#iteratorable().
 //                                                                 kind Method
 //                                                                 display_name iteratorable
 //                                                                 signature_documentation
 //                                                                 > public <T extends Iterable<A> & Iterator<B>> void iteratorable(List<T> list)
-//                                                                 ^^^^ reference scip-java maven jdk 11 java/util/List#
+//                                                                 ^^^^ reference scip-java maven jdk 17 java/util/List#
 //                                                                      ^ reference scip-java maven . . minimized/ParameterizedTypes#iteratorable().[T]
 //                                                                         ^^^^ definition local 0
 //                                                                              display_name list
@@ -74,7 +74,7 @@
 //                    ⌄ enclosing_range_start local 1
 //                         ⌄ enclosing_range_start local 2
     public String app(A a, B b) {
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^ definition scip-java maven . . minimized/ParameterizedTypes#app().
 //                    kind Method
 //                    display_name app
@@ -94,15 +94,15 @@
 //                           ⌃ enclosing_range_end local 2
       return a.toString() + b;
 //           ^ reference local 1
-//             ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Object#toString().
+//             ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Object#toString().
 //                          ^ reference local 2
     }
 //  ⌃ enclosing_range_end scip-java maven . . minimized/ParameterizedTypes#app().
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#doStuff().
     public Map<? extends String, ?> doStuff() { return null; }
-//         ^^^ reference scip-java maven jdk 11 java/util/Map#
-//                       ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^ reference scip-java maven jdk 17 java/util/Map#
+//                       ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                  ^^^^^^^ definition scip-java maven . . minimized/ParameterizedTypes#doStuff().
 //                                          kind Method
 //                                          display_name doStuff
@@ -113,9 +113,9 @@
 //  ⌄ enclosing_range_start scip-java maven . . minimized/ParameterizedTypes#createQuadruplet().
     public Quadruplet<String, ?, Object, ? super Integer> createQuadruplet() { return null; }
 //         ^^^^^^^^^^ reference scip-java maven . . minimized/ParameterizedTypes#Quadruplet#
-//                    ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
-//                               ^^^^^^ reference scip-java maven jdk 11 java/lang/Object#
-//                                               ^^^^^^^ reference scip-java maven jdk 11 java/lang/Integer#
+//                    ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
+//                               ^^^^^^ reference scip-java maven jdk 17 java/lang/Object#
+//                                               ^^^^^^^ reference scip-java maven jdk 17 java/lang/Integer#
 //                                                        ^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/ParameterizedTypes#createQuadruplet().
 //                                                                         kind Method
 //                                                                         display_name createQuadruplet

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Primitives.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/Primitives.java
@@ -3,7 +3,7 @@
   import java.util.Random;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^ reference scip-java maven jdk 11 java/util/Random#
+//                 ^^^^^^ reference scip-java maven jdk 17 java/util/Random#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/Primitives#
   public class Primitives {
@@ -19,7 +19,7 @@
 //                        > public Primitives()
 //  ⌄ enclosing_range_start scip-java maven . . minimized/Primitives#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/Primitives#app().
 //                           kind StaticMethod
 //                           display_name app
@@ -27,13 +27,13 @@
 //                           > public static String app()
 //    ⌄ enclosing_range_start local 0
       Random random = new Random();
-//    ^^^^^^ reference scip-java maven jdk 11 java/util/Random#
+//    ^^^^^^ reference scip-java maven jdk 17 java/util/Random#
 //           ^^^^^^ definition local 0
 //                  kind Variable
 //                  display_name random
 //                  signature_documentation
 //                  > Random random
-//                        ^^^^^^ reference scip-java maven jdk 11 java/util/Random#`<init>`().
+//                        ^^^^^^ reference scip-java maven jdk 17 java/util/Random#`<init>`().
 //                                ⌃ enclosing_range_end local 0
 //    ⌄ enclosing_range_start local 1
       byte a = (byte) random.nextInt();
@@ -43,7 +43,7 @@
 //           signature_documentation
 //           > byte a
 //                    ^^^^^^ reference local 0
-//                           ^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextInt().
+//                           ^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextInt().
 //                                    ⌃ enclosing_range_end local 1
 //    ⌄ enclosing_range_start local 2
       short b = (short) random.nextInt();
@@ -53,7 +53,7 @@
 //            signature_documentation
 //            > short b
 //                      ^^^^^^ reference local 0
-//                             ^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextInt().
+//                             ^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextInt().
 //                                      ⌃ enclosing_range_end local 2
 //    ⌄ enclosing_range_start local 3
       int c = random.nextInt();
@@ -63,7 +63,7 @@
 //          signature_documentation
 //          > int c
 //            ^^^^^^ reference local 0
-//                   ^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextInt().
+//                   ^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextInt().
 //                            ⌃ enclosing_range_end local 3
 //    ⌄ enclosing_range_start local 4
       long d = random.nextLong();
@@ -73,7 +73,7 @@
 //           signature_documentation
 //           > long d
 //             ^^^^^^ reference local 0
-//                    ^^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextLong().
+//                    ^^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextLong().
 //                              ⌃ enclosing_range_end local 4
 //    ⌄ enclosing_range_start local 5
       char e = (char) random.nextInt();
@@ -83,7 +83,7 @@
 //           signature_documentation
 //           > char e
 //                    ^^^^^^ reference local 0
-//                           ^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextInt().
+//                           ^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextInt().
 //                                    ⌃ enclosing_range_end local 5
 //    ⌄ enclosing_range_start local 6
       float f = (float) random.nextDouble();
@@ -93,7 +93,7 @@
 //            signature_documentation
 //            > float f
 //                      ^^^^^^ reference local 0
-//                             ^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextDouble().
+//                             ^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextDouble().
 //                                         ⌃ enclosing_range_end local 6
 //    ⌄ enclosing_range_start local 7
       double g = (double) random.nextDouble();
@@ -103,7 +103,7 @@
 //             signature_documentation
 //             > double g
 //                        ^^^^^^ reference local 0
-//                               ^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextDouble().
+//                               ^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextDouble().
 //                                           ⌃ enclosing_range_end local 7
 //    ⌄ enclosing_range_start local 8
       boolean h = random.nextBoolean();
@@ -113,7 +113,7 @@
 //              signature_documentation
 //              > boolean h
 //                ^^^^^^ reference local 0
-//                       ^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Random#nextBoolean().
+//                       ^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Random#nextBoolean().
 //                                    ⌃ enclosing_range_end local 8
       return "" + a + b + c + d + e + f + g + h;
 //                ^ reference local 1

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/RawTypes.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/RawTypes.java
@@ -3,15 +3,15 @@
   import java.util.Collections;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#
+//                 ^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#
   import java.util.List;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/util/
-//                 ^^^^ reference scip-java maven jdk 11 java/util/List#
+//                 ^^^^ reference scip-java maven jdk 17 java/util/List#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/RawTypes#
   @SuppressWarnings("ALL")
-// ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/SuppressWarnings#
+// ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/SuppressWarnings#
   public class RawTypes {
 //             ^^^^^^^^ definition scip-java maven . . minimized/RawTypes#
 //                      kind Class
@@ -26,14 +26,14 @@
 //                      > public RawTypes()
 //  ⌄ enclosing_range_start scip-java maven . . minimized/RawTypes#x.
     public static final List x = Collections.singletonList(42);
-//                      ^^^^ reference scip-java maven jdk 11 java/util/List#
+//                      ^^^^ reference scip-java maven jdk 17 java/util/List#
 //                           ^ definition scip-java maven . . minimized/RawTypes#x.
 //                             kind StaticField
 //                             display_name x
 //                             signature_documentation
 //                             > public static final List x
-//                               ^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#
-//                                           ^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/util/Collections#singletonList().
+//                               ^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#
+//                                           ^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/util/Collections#singletonList().
 //                                                            ⌃ enclosing_range_end scip-java maven . . minimized/RawTypes#x.
   }
 //⌃ enclosing_range_end scip-java maven . . minimized/RawTypes#

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/SubClasses.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/SubClasses.java
@@ -19,9 +19,9 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/SubClasses#abstractImplementation().
     @Override
-//   ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//   ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
     public String abstractImplementation() {
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/SubClasses#abstractImplementation().
 //                                       kind Method
 //                                       display_name abstractImplementation
@@ -35,9 +35,9 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/SubClasses#abstractInterfaceMethod().
     @Override
-//   ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//   ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
     public String abstractInterfaceMethod() {
-//         ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//         ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-java maven . . minimized/SubClasses#abstractInterfaceMethod().
 //                                        kind Method
 //                                        display_name abstractInterfaceMethod
@@ -51,7 +51,7 @@
   
 //  ⌄ enclosing_range_start scip-java maven . . minimized/SubClasses#app().
     public static String app() {
-//                ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                       ^^^ definition scip-java maven . . minimized/SubClasses#app().
 //                           kind StaticMethod
 //                           display_name app

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/TabIndented.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/TabIndented.java
@@ -21,16 +21,16 @@
 //                  > public void app()
 //    ⌄ enclosing_range_start local 0
       Object o = new Object() {
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/Object#
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/Object#
 //           ^ definition local 0
 //             kind Variable
 //             display_name o
 //             signature_documentation
 //             > Object o
-//                   ^^^^^^ reference scip-java maven jdk 11 java/lang/Object#
+//                   ^^^^^^ reference scip-java maven jdk 17 java/lang/Object#
 //      ⌄ enclosing_range_start local 2
         @Override
-//       ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//       ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
 //                            ⌄ enclosing_range_start local 3
         public boolean equals(Object other) {
 //                     ^^^^^^ definition local 2
@@ -39,8 +39,8 @@
 //                            signature_documentation
 //                            > @Override
 //                            > public boolean equals(Object other)
-//                            relationship scip-java maven jdk 11 java/lang/Object#equals(). implementation reference
-//                            ^^^^^^ reference scip-java maven jdk 11 java/lang/Object#
+//                            relationship scip-java maven jdk 17 java/lang/Object#equals(). implementation reference
+//                            ^^^^^^ reference scip-java maven jdk 17 java/lang/Object#
 //                                   ^^^^^ definition local 3
 //                                         display_name other
 //                                         signature_documentation
@@ -52,7 +52,7 @@
   
 //      ⌄ enclosing_range_start local 4
         @Override
-//       ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//       ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
         public int hashCode() {
 //                 ^^^^^^^^ definition local 4
 //                          kind Method
@@ -60,25 +60,25 @@
 //                          signature_documentation
 //                          > @Override
 //                          > public int hashCode()
-//                          relationship scip-java maven jdk 11 java/lang/Object#hashCode(). implementation reference
+//                          relationship scip-java maven jdk 17 java/lang/Object#hashCode(). implementation reference
           return System.identityHashCode(this);
-//               ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//                      ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/System#identityHashCode().
+//               ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//                      ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/System#identityHashCode().
         }
 //      ⌃ enclosing_range_end local 4
   
 //      ⌄ enclosing_range_start local 5
         @Override
-//       ^^^^^^^^ reference scip-java maven jdk 11 java/lang/Override#
+//       ^^^^^^^^ reference scip-java maven jdk 17 java/lang/Override#
         public String toString() {
-//             ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//             ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                    ^^^^^^^^ definition local 5
 //                             kind Method
 //                             display_name toString
 //                             signature_documentation
 //                             > @Override
 //                             > public String toString()
-//                             relationship scip-java maven jdk 11 java/lang/Object#toString(). implementation reference
+//                             relationship scip-java maven jdk 17 java/lang/Object#toString(). implementation reference
           return "";
         }
 //      ⌃ enclosing_range_end local 5

--- a/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/TypeAnnotations.java
+++ b/scip-snapshots/expected/java/common/scip-snapshots/cases/java/common/src/main/java/minimized/TypeAnnotations.java
@@ -4,18 +4,18 @@
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#
+//                            ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#
   import java.lang.annotation.Target;
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
 //                 ^^^^^^^^^^ reference scip-java maven . . java/lang/annotation/
-//                            ^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Target#
+//                            ^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Target#
   
 //⌄ enclosing_range_start scip-java maven . . minimized/TypeAnnotation#
   @Target({ ElementType.TYPE_USE })
-// ^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/Target#
-//          ^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#
-//                      ^^^^^^^^ reference scip-java maven jdk 11 java/lang/annotation/ElementType#TYPE_USE.
+// ^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/Target#
+//          ^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#
+//                      ^^^^^^^^ reference scip-java maven jdk 17 java/lang/annotation/ElementType#TYPE_USE.
   @interface TypeAnnotation {
 //           ^^^^^^^^^^^^^^ definition scip-java maven . . minimized/TypeAnnotation#
 //                          kind Interface
@@ -23,7 +23,7 @@
 //                          signature_documentation
 //                          > @Target({ElementType.TYPE_USE})
 //                          > @interface TypeAnnotation
-//                          relationship scip-java maven jdk 11 java/lang/annotation/Annotation# implementation
+//                          relationship scip-java maven jdk 17 java/lang/annotation/Annotation# implementation
 //    ⌄ enclosing_range_start scip-java maven . . minimized/TypeAnnotation#integer().
       int integer() default 1;
 //        ^^^^^^^ definition scip-java maven . . minimized/TypeAnnotation#integer().
@@ -50,7 +50,7 @@
 //                                                      signature_documentation
 //                                                      > T extends Number
 //                      ^^^^^^^^^^^^^^ reference scip-java maven . . minimized/TypeAnnotation#
-//                                               ^^^^^^ reference scip-java maven jdk 11 java/lang/Number#
+//                                               ^^^^^^ reference scip-java maven jdk 17 java/lang/Number#
   
 //    ⌄ enclosing_range_start scip-java maven . . minimized/ClassProcessed#`<init>`().
       public ClassProcessed() {
@@ -61,15 +61,15 @@
 //                          > public ClassProcessed()
 //        ⌄ enclosing_range_start local 0
           String s = new @TypeAnnotation String();
-//        ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//        ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //               ^ definition local 0
 //                 kind Variable
 //                 display_name s
 //                 signature_documentation
 //                 > String s
 //                        ^^^^^^^^^^^^^^ reference scip-java maven . . minimized/TypeAnnotation#
-//                                       ^^^^^^ reference scip-java maven jdk 11 java/lang/String#`<init>`().
-//                                       ^^^^^^ reference scip-java maven jdk 11 java/lang/String#
+//                                       ^^^^^^ reference scip-java maven jdk 17 java/lang/String#`<init>`().
+//                                       ^^^^^^ reference scip-java maven jdk 17 java/lang/String#
 //                                               ⌃ enclosing_range_end local 0
       }
 //    ⌃ enclosing_range_end scip-java maven . . minimized/ClassProcessed#`<init>`().

--- a/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/java/snapshots/ClassConsumer.java
+++ b/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/java/snapshots/ClassConsumer.java
@@ -20,9 +20,9 @@
 //                         signature_documentation
 //                         > public static void run()
       System.out.println(new Class().getAsdf());
-//    ^^^^^^ reference scip-java maven jdk 11 java/lang/System#
-//           ^^^ reference scip-java maven jdk 11 java/lang/System#out.
-//               ^^^^^^^ reference scip-java maven jdk 11 java/io/PrintStream#println(+9).
+//    ^^^^^^ reference scip-java maven jdk 17 java/lang/System#
+//           ^^^ reference scip-java maven jdk 17 java/lang/System#out.
+//               ^^^^^^^ reference scip-java maven jdk 17 java/io/PrintStream#println(+9).
 //                           ^^^^^ reference scip-java maven . . snapshots/Class#`<init>`(+1).
 //                                   ^^^^^^^ reference scip-java maven . . snapshots/Class#getAsdf().
     }

--- a/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/Docstrings.kt
+++ b/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/Docstrings.kt
@@ -4,7 +4,7 @@
   import java.io.Serializable
 //       ^^^^ reference scip-java maven . . java/
 //            ^^ reference scip-java maven . . java/io/
-//               ^^^^^^^^^^^^ reference scip-java maven jdk 11 java/io/Serializable#
+//               ^^^^^^^^^^^^ reference scip-java maven jdk 17 java/io/Serializable#
   
 //⌄ enclosing_range_start scip-java maven . . snapshots/DocstringSuperclass#
 //⌄ enclosing_range_start scip-java maven . . snapshots/DocstringSuperclass#`<init>`().
@@ -30,7 +30,7 @@
 //                 documentation
 //                 > Example class docstring.
 //                 relationship scip-java maven . . snapshots/DocstringSuperclass# implementation
-//                 relationship scip-java maven jdk 11 java/io/Serializable# implementation
+//                 relationship scip-java maven jdk 17 java/io/Serializable# implementation
 //      ^^^^^^^^^^ definition scip-java maven . . snapshots/Docstrings#`<init>`().
 //                 display_name Docstrings
 //                 signature_documentation
@@ -38,7 +38,7 @@
 //                 documentation
 //                 > Example class docstring.
 //                    ^^^^^^^^^^^^^^^^^^^ reference scip-java maven . . snapshots/DocstringSuperclass#
-//                                           ^^^^^^^^^^^^ reference scip-java maven jdk 11 java/io/Serializable#
+//                                           ^^^^^^^^^^^^ reference scip-java maven jdk 17 java/io/Serializable#
   }
 //⌃ enclosing_range_end scip-java maven . . snapshots/Docstrings#
 //⌃ enclosing_range_end scip-java maven . . snapshots/Docstrings#`<init>`().

--- a/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/Implementations.kt
+++ b/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/Implementations.kt
@@ -8,19 +8,19 @@
 //                display_name Overrides
 //                signature_documentation
 //                > public final class Overrides : {kotlin/AutoCloseable=} AutoCloseable
-//                relationship scip-java maven jdk 11 java/lang/AutoCloseable# implementation
+//                relationship scip-java maven jdk 17 java/lang/AutoCloseable# implementation
 //      ^^^^^^^^^ definition scip-java maven . . snapshots/Overrides#`<init>`().
 //                display_name Overrides
 //                signature_documentation
 //                > public constructor(): Overrides
-//                  ^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/AutoCloseable#
+//                  ^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/AutoCloseable#
 //    ⌄ enclosing_range_start scip-java maven . . snapshots/Overrides#close().
       override fun close() {
 //                 ^^^^^ definition scip-java maven . . snapshots/Overrides#close().
 //                       display_name close
 //                       signature_documentation
 //                       > public open override fun close(): Unit
-//                       relationship scip-java maven jdk 11 java/lang/AutoCloseable#close(). implementation
+//                       relationship scip-java maven jdk 17 java/lang/AutoCloseable#close(). implementation
           TODO("Not yet implemented")
 //        ^^^^ reference scip-java maven . . kotlin/TODO(+1).
       }

--- a/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/ObjectKt.kt
+++ b/scip-snapshots/expected/kotlin/common/scip-snapshots/cases/kotlin/common/src/main/kotlin/snapshots/ObjectKt.kt
@@ -4,7 +4,7 @@
   import java.lang.RuntimeException
 //       ^^^^ reference scip-java maven . . java/
 //            ^^^^ reference scip-java maven . . java/lang/
-//                 ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/RuntimeException#
+//                 ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/RuntimeException#
   
 //⌄ enclosing_range_start scip-java maven . . snapshots/ObjectKt#
 //⌄ enclosing_range_start scip-java maven . . snapshots/ObjectKt#`<init>`().
@@ -32,7 +32,7 @@
 //                              ^^^^^^^ reference scip-java maven . . kotlin/Nothing#
 //                          ⌃ enclosing_range_end scip-java maven . . snapshots/ObjectKt#fail().(message)
       throw RuntimeException(message)
-//          ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 11 java/lang/RuntimeException#`<init>`().
+//          ^^^^^^^^^^^^^^^^ reference scip-java maven jdk 17 java/lang/RuntimeException#`<init>`().
 //                           ^^^^^^^ reference scip-java maven . . snapshots/ObjectKt#fail().(message)
     }
 //  ⌃ enclosing_range_end scip-java maven . . snapshots/ObjectKt#fail().

--- a/scip-snapshots/src/main/java/tests/SaveSnapshots.java
+++ b/scip-snapshots/src/main/java/tests/SaveSnapshots.java
@@ -8,10 +8,9 @@ public final class SaveSnapshots {
   private SaveSnapshots() {}
 
   public static void main(String[] args) {
-    // Keep regenerated goldens stable across the supported JDK matrix by pinning the JDK version
-    // embedded in stdlib SCIP symbols. "11" is a historical, deterministic label (not a supported
-    // runtime); it only needs to match the `-Dscip.jdk.version` set on the test JVM in Gradle.
-    System.setProperty("scip.jdk.version", "11");
+    // The JDK version embedded in stdlib SCIP symbols is pinned via the
+    // `-Dscip.jdk.version` flag that the Gradle `saveSnapshots` task passes in,
+    // keeping regenerated goldens stable across the supported JDK matrix.
     MinimizedSnapshotScipGenerator generator = new MinimizedSnapshotScipGenerator();
     for (MinimizedSnapshotScipGenerator.SnapshotCase snapshotCase :
         MinimizedSnapshotScipGenerator.snapshotCases()) {

--- a/scip-snapshots/src/main/java/tests/SaveSnapshots.java
+++ b/scip-snapshots/src/main/java/tests/SaveSnapshots.java
@@ -8,8 +8,9 @@ public final class SaveSnapshots {
   private SaveSnapshots() {}
 
   public static void main(String[] args) {
-    // Keep regenerated goldens stable across JDK 11/17/21 by pinning the JDK version embedded in
-    // stdlib SCIP symbols. Matches the `-Dscip.jdk.version=11` set on the test JVM in Gradle.
+    // Keep regenerated goldens stable across the supported JDK matrix by pinning the JDK version
+    // embedded in stdlib SCIP symbols. "11" is a historical, deterministic label (not a supported
+    // runtime); it only needs to match the `-Dscip.jdk.version` set on the test JVM in Gradle.
     System.setProperty("scip.jdk.version", "11");
     MinimizedSnapshotScipGenerator generator = new MinimizedSnapshotScipGenerator();
     for (MinimizedSnapshotScipGenerator.SnapshotCase snapshotCase :


### PR DESCRIPTION
Drops Java 11 support (baseline now Java 17) and modernizes the codebase with pattern matching, switch expressions, and records.