### PR TITLE
Fix Maven publish plugin classloading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
+    alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.spotless)
+    alias(libs.plugins.vanniktech.maven.publish) apply false
 }
 
 tasks.register("saveSnapshots") {


### PR DESCRIPTION
Declares the Kotlin JVM and Vanniktech Maven Publish plugins in the root build with apply false so publish tasks share plugin classloaders.