### PR TITLE
Disable Maven snapshots on main

### DIFF
--- a/.github/workflows/release-maven.yaml
+++ b/.github/workflows/release-maven.yaml
@@ -1,7 +1,6 @@
 name: Release Maven Central
 on:
   push:
-    branches: [main]
     tags: ["*"]
 
 jobs:
@@ -15,12 +14,6 @@ jobs:
         with:
           summarize: false
       - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - name: Publish snapshot ${{ github.ref }}
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: nix develop --command gradle --no-daemon publishToMavenCentral
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
       - name: Publish release ${{ github.ref }}
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |


### PR DESCRIPTION
Stops the Maven Central workflow from publishing snapshots on every main push. Release publishing remains tag-driven.