### PR TITLE
Add SCIP javac plugin to test annotation processor path

### DIFF
--- a/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
+++ b/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
@@ -37,16 +37,8 @@ public class ScipGradlePlugin implements Plugin<Project> {
       triggers.add("compileJava");
       triggers.add("compileTestJava");
 
-      boolean hasAnnotationPath;
-      try {
-        Configuration apConfig = project.getConfigurations().getByName("annotationProcessor");
-        hasAnnotationPath = apConfig.isCanBeResolved() && !apConfig.getDependencies().isEmpty();
-      } catch (Exception exc) {
-        hasAnnotationPath = false;
-      }
-
       Object javacPluginDep = project.files(requiredExtra(extraProperties, "javacPluginJar"));
-      boolean pluginAdded = tryAddJavacPlugin(project, javacPluginDep, hasAnnotationPath);
+      boolean pluginAdded = tryAddJavacPlugin(project, javacPluginDep);
 
       project
           .getTasks()
@@ -113,13 +105,32 @@ public class ScipGradlePlugin implements Plugin<Project> {
     project.getTasks().create("scipPrintDependencies", WriteDependencies.class);
   }
 
-  private static boolean tryAddJavacPlugin(
-      Project project, Object javacPluginDep, boolean hasAnnotationPath) {
+  /**
+   * javac discovers {@code -Xplugin:} plugins from the annotation processor path when {@code
+   * -processorpath} is set, and only falls back to the classpath when it isn't. Gradle populates
+   * {@code -processorpath} from the {@code annotationProcessor} (main) and {@code
+   * testAnnotationProcessor} (test) configurations, so whenever one of them declares a processor we
+   * must add the SCIP javac plugin to that same configuration or the corresponding compile task
+   * fails with "plug-in not found: scip". The two configurations are independent (test does not
+   * extend main), so each is checked separately.
+   */
+  private static boolean hasAnnotationProcessors(Project project, String configurationName) {
+    try {
+      Configuration config = project.getConfigurations().getByName(configurationName);
+      return config.isCanBeResolved() && !config.getDependencies().isEmpty();
+    } catch (Exception exc) {
+      return false;
+    }
+  }
+
+  private static boolean tryAddJavacPlugin(Project project, Object javacPluginDep) {
     try {
       project.getDependencies().add("compileOnly", javacPluginDep);
       project.getDependencies().add("testCompileOnly", javacPluginDep);
-      if (hasAnnotationPath) {
+      if (hasAnnotationProcessors(project, "annotationProcessor")) {
         project.getDependencies().add("annotationProcessor", javacPluginDep);
+      }
+      if (hasAnnotationProcessors(project, "testAnnotationProcessor")) {
         project.getDependencies().add("testAnnotationProcessor", javacPluginDep);
       }
       return true;

--- a/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
+++ b/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
@@ -117,10 +117,11 @@ public class ScipGradlePlugin implements Plugin<Project> {
       Project project, Object javacPluginDep, boolean hasAnnotationPath) {
     try {
       project.getDependencies().add("compileOnly", javacPluginDep);
+      project.getDependencies().add("testCompileOnly", javacPluginDep);
       if (hasAnnotationPath) {
         project.getDependencies().add("annotationProcessor", javacPluginDep);
+        project.getDependencies().add("testAnnotationProcessor", javacPluginDep);
       }
-      project.getDependencies().add("testCompileOnly", javacPluginDep);
       return true;
     } catch (Exception exc) {
       // The `compileOnly` configuration has likely already been resolved by

--- a/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
+++ b/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
@@ -55,6 +55,19 @@ class GradleBuildToolTest : BuildToolHarness() {
                 expectedScipFiles = 2,
             )
         )
+        // Regression test: annotation processors declared only for the test source
+        // set (testAnnotationProcessor) make Gradle pass -processorpath to
+        // compileTestJava, so the SCIP javac plugin must be added to that same
+        // configuration or plugin discovery fails with "plug-in not found: scip".
+        add(
+            checkGradleBuild(
+                "test-annotation-path",
+                "gradle/test-annotation-path",
+                // The generated immutable class is compiled alongside the original
+                // test source, so two SCIP shards are produced.
+                expectedScipFiles = 2,
+            )
+        )
         add(
             checkGradleBuild("build-with-Werror", "gradle/build-with-Werror", expectedScipFiles = 2)
         )

--- a/scip-java/src/test/resources/fixtures/gradle/test-annotation-path/build.gradle
+++ b/scip-java/src/test/resources/fixtures/gradle/test-annotation-path/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'java'
+}
+repositories {
+    mavenCentral()
+}
+dependencies {
+  testCompileOnly 'org.immutables:value:2.9.2'
+  testAnnotationProcessor 'org.immutables:value:2.9.2'
+}

--- a/scip-java/src/test/resources/fixtures/gradle/test-annotation-path/src/test/java/WorkflowOptions.java
+++ b/scip-java/src/test/resources/fixtures/gradle/test-annotation-path/src/test/java/WorkflowOptions.java
@@ -1,0 +1,7 @@
+package test;
+import org.immutables.value.Value;
+import java.util.Optional;
+@Value.Immutable
+public abstract class WorkflowOptions {
+    public abstract Optional<String> getWorkflowIdReusePolicy();
+}


### PR DESCRIPTION
javac loads `-Xplugin:` plugins from the processor path when `-processorpath` is set, so `compileTestJava` failed with `plug-in not found: scip` in projects declaring test-scoped annotation processors.

Rebased from #826: adds the plugin to `testAnnotationProcessor`, gating each configuration on its own declared processors (test does not extend main). Includes a regression test fixture.

Verified against a real repo (joutvhu/spring-dynamic-jpa): indexing fails on `origin/main`, succeeds with this change.