### PR TITLE
Support centrally declared repositories in Gradle plugin

### DIFF
--- a/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
+++ b/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
@@ -3,6 +3,7 @@ package org.scip_code.scip_java.gradle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -20,8 +21,19 @@ public class ScipGradlePlugin implements Plugin<Project> {
     // Inject Maven Central/local so the indexer (and plugins like protobuf that
     // resolve their own artifacts) can resolve dependencies even when the build
     // being indexed doesn't declare any repositories of its own.
-    project.getRepositories().add(project.getRepositories().mavenCentral());
-    project.getRepositories().add(project.getRepositories().mavenLocal());
+    try {
+      project.getRepositories().add(project.getRepositories().mavenCentral());
+      project.getRepositories().add(project.getRepositories().mavenLocal());
+    } catch (InvalidUserCodeException exc) {
+      // The build declares repositories centrally in settings.gradle with
+      // RepositoriesMode.FAIL_ON_PROJECT_REPOS, which makes any project-level
+      // repository an error (issue #847). Repositories are guaranteed to be
+      // declared in settings in that mode, so the injection is unnecessary.
+      project
+          .getLogger()
+          .info(
+              "scip-java: not injecting Maven Central/local repositories: " + exc.getMessage());
+    }
 
     Map<String, Object> extraProperties =
         project.getExtensions().getExtraProperties().getProperties();

--- a/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
+++ b/scip-gradle-plugin/src/main/java/org/scip_code/scip_java/gradle/ScipGradlePlugin.java
@@ -25,14 +25,11 @@ public class ScipGradlePlugin implements Plugin<Project> {
       project.getRepositories().add(project.getRepositories().mavenCentral());
       project.getRepositories().add(project.getRepositories().mavenLocal());
     } catch (InvalidUserCodeException exc) {
-      // The build declares repositories centrally in settings.gradle with
-      // RepositoriesMode.FAIL_ON_PROJECT_REPOS, which makes any project-level
-      // repository an error (issue #847). Repositories are guaranteed to be
-      // declared in settings in that mode, so the injection is unnecessary.
+      // FAIL_ON_PROJECT_REPOS forbids project repositories; they are declared
+      // in settings instead, so the injection isn't needed (issue #847).
       project
           .getLogger()
-          .info(
-              "scip-java: not injecting Maven Central/local repositories: " + exc.getMessage());
+          .info("scip-java: not injecting Maven Central/local repositories: " + exc.getMessage());
     }
 
     Map<String, Object> extraProperties =

--- a/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
+++ b/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
@@ -91,6 +91,18 @@ class GradleBuildToolTest : BuildToolHarness() {
             )
         )
         add(checkGradleBuild("basic", "gradle/basic", expectedScipFiles = 2))
+        // Regression test: builds that centralize repository declarations in
+        // settings.gradle with RepositoriesMode.FAIL_ON_PROJECT_REPOS reject any
+        // project-level repository, so the plugin must not inject Maven
+        // Central/local into the project.
+        // https://github.com/scip-code/scip-java/issues/847
+        add(
+            checkGradleBuild(
+                "centralized-repos",
+                "gradle/centralized-repos",
+                expectedScipFiles = 1,
+            )
+        )
         add(
             checkGradleBuild(
                 "toolchains",

--- a/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
+++ b/scip-java/src/test/kotlin/tests/GradleBuildToolTest.kt
@@ -91,17 +91,11 @@ class GradleBuildToolTest : BuildToolHarness() {
             )
         )
         add(checkGradleBuild("basic", "gradle/basic", expectedScipFiles = 2))
-        // Regression test: builds that centralize repository declarations in
-        // settings.gradle with RepositoriesMode.FAIL_ON_PROJECT_REPOS reject any
-        // project-level repository, so the plugin must not inject Maven
-        // Central/local into the project.
+        // Regression test: FAIL_ON_PROJECT_REPOS rejects project-level
+        // repositories, so the plugin must not inject Maven Central/local.
         // https://github.com/scip-code/scip-java/issues/847
         add(
-            checkGradleBuild(
-                "centralized-repos",
-                "gradle/centralized-repos",
-                expectedScipFiles = 1,
-            )
+            checkGradleBuild("centralized-repos", "gradle/centralized-repos", expectedScipFiles = 1)
         )
         add(
             checkGradleBuild(

--- a/scip-java/src/test/resources/fixtures/gradle/centralized-repos/build.gradle
+++ b/scip-java/src/test/resources/fixtures/gradle/centralized-repos/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java'
+}
+dependencies {
+    implementation 'com.google.guava:guava:31.1-jre'
+}

--- a/scip-java/src/test/resources/fixtures/gradle/centralized-repos/settings.gradle
+++ b/scip-java/src/test/resources/fixtures/gradle/centralized-repos/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+rootProject.name = 'centralized-repos'

--- a/scip-java/src/test/resources/fixtures/gradle/centralized-repos/src/main/java/Example.java
+++ b/scip-java/src/test/resources/fixtures/gradle/centralized-repos/src/main/java/Example.java
@@ -1,0 +1,7 @@
+import com.google.common.collect.ImmutableList;
+
+public class Example {
+    public static void main(String[] args) {
+        System.out.println(ImmutableList.of("a", "b"));
+    }
+}


### PR DESCRIPTION
The Gradle plugin unconditionally injected mavenCentral/mavenLocal into project repositories, which fails builds using `RepositoriesMode.FAIL_ON_PROJECT_REPOS`. Skip the injection when Gradle rejects it — repositories are declared in settings in that mode, so it isn't needed.

Adds a regression test fixture with centrally declared repositories.

Fixes #847