### PR TITLE
Add coursier to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           pkgs.mkShellNoCC {
             buildInputs = with pkgs; [
               bazelisk
+              coursier
               git
               (gradle_9.override ({ java = jdk; }))
               jdk


### PR DESCRIPTION
The `release-cli` workflow runs `cs resolve`/`cs bootstrap` inside `nix develop`, but the devshell never provided coursier. On pristine CI runners every `cs` invocation failed with `command not found` (previously swallowed by `>/dev/null 2>&1`), which is why the v0.13.0 launcher job failed four times with a misleading "artifact was not resolvable" error while the artifact was live on Maven Central. Locally the bug was masked because plain `nix develop` keeps the user profile on PATH.

Verified with `nix develop --ignore-environment --command bash -c 'command -v cs && cs version'` → coursier 2.1.24 from the devshell closure.