### PR TITLE
Fix duplicate documents in Bazel index aggregation

### DIFF
--- a/scip-java/src/main/kotlin/org/scip_code/scip_java/buildtools/BazelBuildTool.kt
+++ b/scip-java/src/main/kotlin/org/scip_code/scip_java/buildtools/BazelBuildTool.kt
@@ -137,6 +137,21 @@ To narrow the set of targets to index or pass additional flags to Bazel, include
         Files.walkFileTree(
             bazelOutLink,
             object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(
+                    dir: Path,
+                    attrs: BasicFileAttributes,
+                ): FileVisitResult {
+                    // The aspect declares a `<target>.scip-targetroot` directory that
+                    // contains the intermediate per-source `*.scip` shards. Those shards
+                    // are already aggregated into the sibling `<target>.scip` file, so
+                    // including them here would duplicate every document in the index.
+                    return if (dir.fileName.toString().endsWith(".scip-targetroot")) {
+                        FileVisitResult.SKIP_SUBTREE
+                    } else {
+                        FileVisitResult.CONTINUE
+                    }
+                }
+
                 override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
                     if (scipPattern.matches(file)) {
                         val bytes = Files.readAllBytes(file)

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -13,9 +13,12 @@ many *.scip (https://github.com/scip-code/scip) files.
 These files encode information about which symbols are referenced from which
 locations in your source code.
 
-Use the command below to merge all of these SCIP files into a single index:
+Use the command below to merge all of these SCIP files into a single index.
+The `*.scip-targetroot` directories are excluded because they contain
+intermediate per-source shards that are already aggregated into the sibling
+`<target>.scip` files:
 
-    find bazel-bin/ -type f -name '*.scip' | xargs cat > index.scip
+    find bazel-bin/ -type f -name '*.scip' -not -path '*.scip-targetroot/*' | xargs cat > index.scip
 
 Use `src code-intel upload` to upload the unified SCIP file to Sourcegraph:
 


### PR DESCRIPTION
The final `bazel-out` walk matched both the per-target `<target>.scip` outputs and the per-source shards inside `<target>.scip-targetroot/`, so every document appeared twice in `index.scip`. Skip the targetroot subtrees during aggregation and fix the manual merge command in the aspect docstring accordingly.

Verified on `bazelbuild/examples` java-tutorial: documents dropped from 4 to 2 (one per source file), occurrences/definitions halved.