### PR TITLE
Add aggregator CI jobs for branch protection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,3 +66,14 @@ jobs:
           export -f check_repo
 
           parallel -j4 check_repo ::: circe/circe indeedeng/iwf-java-sdk
+
+  ci-pass:
+    if: always()
+    needs: [format, kotlin_plugin, docker_test]
+    runs-on: ubuntu-latest
+    name: CI pass
+    steps:
+      - if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -168,3 +168,15 @@ jobs:
 
       - run: du -h index.scip
         working-directory: examples/maven-example
+
+  nix-pass:
+    if: always()
+    needs: [flake-check, test, bazel, bazel_aspect, snapshots, maven]
+    runs-on: ubuntu-latest
+    name: Nix pass
+    steps:
+      - if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        shell: bash
+        run: exit 1

--- a/.github/workflows/repos.yaml
+++ b/.github/workflows/repos.yaml
@@ -271,3 +271,15 @@ jobs:
             fi
             exit 1
           fi
+
+  repos-pass:
+    if: always()
+    needs: [build-cli, index-repo]
+    runs-on: ubuntu-latest
+    name: Repository indexing pass
+    steps:
+      - if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        shell: bash
+        run: exit 1


### PR DESCRIPTION
Adds a `ci-pass`-style gate job to each PR-triggered workflow that depends on all other jobs and fails if any of them failed or was cancelled. This will be used to block PR merge on CI fail.